### PR TITLE
igzip: optimize convert_dist_to_dist_sym to branchless

### DIFF
--- a/igzip/huff_codes.c
+++ b/igzip/huff_codes.c
@@ -728,39 +728,12 @@ void isal_update_histogram_base(uint8_t * start_stream, int length,
 static uint32_t convert_dist_to_dist_sym(uint32_t dist)
 {
 	assert(dist <= 32768 && dist > 0);
-	if (dist <= 2)
-		return dist - 1;
-	else if (dist <= 4)
-		return 0 + (dist - 1) / 1;
-	else if (dist <= 8)
-		return 2 + (dist - 1) / 2;
-	else if (dist <= 16)
-		return 4 + (dist - 1) / 4;
-	else if (dist <= 32)
-		return 6 + (dist - 1) / 8;
-	else if (dist <= 64)
-		return 8 + (dist - 1) / 16;
-	else if (dist <= 128)
-		return 10 + (dist - 1) / 32;
-	else if (dist <= 256)
-		return 12 + (dist - 1) / 64;
-	else if (dist <= 512)
-		return 14 + (dist - 1) / 128;
-	else if (dist <= 1024)
-		return 16 + (dist - 1) / 256;
-	else if (dist <= 2048)
-		return 18 + (dist - 1) / 512;
-	else if (dist <= 4096)
-		return 20 + (dist - 1) / 1024;
-	else if (dist <= 8192)
-		return 22 + (dist - 1) / 2048;
-	else if (dist <= 16384)
-		return 24 + (dist - 1) / 4096;
-	else if (dist <= 32768)
-		return 26 + (dist - 1) / 8192;
-	else
-		return ~0;	/* ~0 is an invalid distance code */
-
+	if (dist <= 32768) {
+		uint32_t msb = dist > 4 ? bsr(dist - 1) - 2 : 0;
+		return (msb * 2) + ((dist - 1) >> msb);
+	} else {
+		return ~0;
+	}
 }
 
 /**

--- a/igzip/huffman.h
+++ b/igzip/huffman.h
@@ -44,11 +44,27 @@
 # define inline __inline
 #endif //__x86_64__  || __i386__ || _M_X64 || _M_IX86
 
+/**
+ * @brief Calculate the bit offset of the msb.
+ * @param val 32-bit unsigned integer input
+ *
+ * @returns bit offset of msb starting at 1 for first bit
+ */
 static inline uint32_t bsr(uint32_t val)
 {
 	uint32_t msb;
-#ifdef __LZCNT__
+#if defined(_MSC_VER)
+	unsigned long ret = 0;
+	if (val != 0) {
+		_BitScanReverse(&ret, val);
+		msb = ret + 1;
+	}
+	else
+		msb = 0;
+#elif defined( __LZCNT__)
 	msb = 32 - __lzcnt32(val);
+#elif defined(__x86_64__) || defined(__aarch64__)
+	msb = (val == 0)? 0 : 32 - __builtin_clz(val);
 #else
 	for(msb = 0; val > 0; val >>= 1)
 		msb++;
@@ -63,7 +79,7 @@ static inline uint32_t tzbytecnt(uint64_t val)
 #ifdef __BMI__
 	cnt = __tzcnt_u64(val);
 	cnt = cnt / 8;
-#elif defined(__x86_64__)
+#elif defined(__x86_64__) || defined(__aarch64__)
 
 	cnt = (val == 0)? 64 : __builtin_ctzll(val);
 	cnt = cnt / 8;


### PR DESCRIPTION
convert_dist_to_dist_sym uses long if/else branch to get look back distance.
The distance calculation is well formed with each distance range, so it could
be optimized to a branchless version.

Change-Id: I4e1e5170f8b3238631f3048087f95acc53e4498e
Signed-off-by: Jun He <jun.he@arm.com>