### PR TITLE
build: fix compile break for unsupported CPUs

### DIFF
--- a/make.inc
+++ b/make.inc
@@ -103,6 +103,11 @@ ARFLAGS  = $(ARFLAGS_$(arch))
 DEFINES += $(addprefix -D , $D)
 CLEANFILES += $(O) *.o *.a $(all_tests) $(bin_PROGRAMS) $(lib_name) $(so_lib_name) $(all_llvm_fuzz_tests)
 
+# set host_cpu=base_aliases for unsupported CPUs
+ifeq ($(filter aarch64 x86_%,$(host_cpu)),)
+  host_cpu=base_aliases
+endif
+
 other_tests += $(other_tests_$(host_cpu))
 
 lsrc += $(lsrc_$(host_cpu))


### PR DESCRIPTION
Build with `make -f Makefile.unx ` on ppc64le platform  FAIL .  
It report below error 
```
  ---> Building Programs programs/igzip DEBUG ppc64le
/tmp/ccfsafxG.o: In function `compress_file':
/home/haoyu01/work/isa-l/programs/igzip_cli.c:680: undefined reference to `crc32_gzip_refl'
bin/isa-l.a(igzip.o): In function `isal_adler32_bam1':
(.text+0xeec): undefined reference to `isal_adler32'
```

