### PR TITLE
crc: arm64 implementation tweaks

### DIFF
--- a/crc/aarch64/crc32_gzip_refl_pmull.h
+++ b/crc/aarch64/crc32_gzip_refl_pmull.h
@@ -49,7 +49,7 @@
 	.text
 	.section	.rodata
 	.align	4
-	.set	.LANCHOR0,. + 0
+	.set	.lanchor_crc_tab,. + 0
 	.type	crc32_table_gzip_refl, %object
 	.size	crc32_table_gzip_refl, 1024
 crc32_table_gzip_refl:

--- a/crc/aarch64/crc32_ieee_norm_pmull.h
+++ b/crc/aarch64/crc32_ieee_norm_pmull.h
@@ -49,7 +49,7 @@
 	.text
 	.section	.rodata
 	.align	4
-	.set	.LANCHOR0,. + 0
+	.set	.lanchor_crc_tab,. + 0
 	.type	crc32_table_ieee_norm, %object
 	.size	crc32_table_ieee_norm, 1024
 crc32_table_ieee_norm:

--- a/crc/aarch64/crc32_iscsi_refl_pmull.h
+++ b/crc/aarch64/crc32_iscsi_refl_pmull.h
@@ -49,7 +49,7 @@
 	.text
 	.section	.rodata
 	.align	4
-	.set	.LANCHOR0,. + 0
+	.set	.lanchor_crc_tab,. + 0
 	.type	crc32_table_iscsi_refl, %object
 	.size	crc32_table_iscsi_refl, 1024
 crc32_table_iscsi_refl:

--- a/crc/aarch64/crc64_ecma_norm_pmull.h
+++ b/crc/aarch64/crc64_ecma_norm_pmull.h
@@ -66,7 +66,7 @@
 	.text
 	.section	.rodata
 	.align	4
-	.set	lanchor_crc64_tab,. + 0
+	.set	.lanchor_crc_tab,. + 0
 	.type	crc64_tab, %object
 	.size	crc64_tab, 2048
 crc64_tab:

--- a/crc/aarch64/crc64_ecma_refl_pmull.h
+++ b/crc/aarch64/crc64_ecma_refl_pmull.h
@@ -62,7 +62,7 @@
 	.text
 	.section	.rodata
 	.align	4
-	.set	.lanchor_crc64_tab,. + 0
+	.set	.lanchor_crc_tab,. + 0
 	.type	crc64_tab, %object
 	.size	crc64_tab, 2048
 crc64_tab:

--- a/crc/aarch64/crc64_iso_norm_pmull.h
+++ b/crc/aarch64/crc64_iso_norm_pmull.h
@@ -66,7 +66,7 @@
 	.text
 	.section	.rodata
 	.align	4
-	.set	lanchor_crc64_tab,. + 0
+	.set	.lanchor_crc_tab,. + 0
 	.type	crc64_tab, %object
 	.size	crc64_tab, 2048
 

--- a/crc/aarch64/crc64_iso_refl_pmull.h
+++ b/crc/aarch64/crc64_iso_refl_pmull.h
@@ -62,7 +62,7 @@
 	.text
 	.section	.rodata
 	.align	4
-	.set	.lanchor_crc64_tab,. + 0
+	.set	.lanchor_crc_tab,. + 0
 	.type	crc64_tab, %object
 	.size	crc64_tab, 2048
 

--- a/crc/aarch64/crc64_jones_norm_pmull.h
+++ b/crc/aarch64/crc64_jones_norm_pmull.h
@@ -66,7 +66,7 @@
 	.text
 	.section	.rodata
 	.align	4
-	.set	lanchor_crc64_tab,. + 0
+	.set	.lanchor_crc_tab,. + 0
 	.type	crc64_tab, %object
 	.size	crc64_tab, 2048
 crc64_tab:

--- a/crc/aarch64/crc64_jones_refl_pmull.h
+++ b/crc/aarch64/crc64_jones_refl_pmull.h
@@ -62,7 +62,7 @@
 	.text
 	.section	.rodata
 	.align	4
-	.set	.lanchor_crc64_tab,. + 0
+	.set	.lanchor_crc_tab,. + 0
 	.type	crc64_tab, %object
 	.size	crc64_tab, 2048
 crc64_tab:

--- a/crc/aarch64/crc64_norm_common_pmull.h
+++ b/crc/aarch64/crc64_norm_common_pmull.h
@@ -27,8 +27,10 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #########################################################################
 
+#include "crc_common_pmull.h"
+
 .macro crc64_norm_func name:req
-	.arch armv8-a+crc+crypto
+	.arch armv8-a+crypto
 	.text
 	.align	3
 	.global	\name
@@ -36,269 +38,86 @@
 
 /* uint64_t crc64_norm_func(uint64_t seed, const uint8_t * buf, uint64_t len) */
 
-// parameter
-x_seed		.req	x0
-x_buf		.req	x1
-x_len		.req	x2
-
-// return
-x_crc_ret	.req	x0
-
-// constant
-.equ    FOLD_SIZE, 1024
-
-// global variables
-x_buf_end		.req	x3 // buffer address with truncated
-x_counter		.req	x4
-x_buf_iter		.req	x5
-x_crc64_tab_addr	.req	x9
-
-w_tmp			.req	w6
-x_tmp			.req	x6
-w_tmp1			.req	w7
-x_tmp1			.req	x7
 \name\():
 	mvn	x_seed, x_seed
 	mov	x_counter, 0
 	cmp	x_len, (FOLD_SIZE-1)
-	bhi	.crc64_clmul_pre
+	bhi	.crc_clmul_pre
 
-.crc64_tab_pre:
+.crc_tab_pre:
 	cmp	x_len, x_counter
 	bls	.done
 
-	adrp	x_tmp, lanchor_crc64_tab
+	adrp	x_tmp, .lanchor_crc_tab
 	add	x_buf_iter, x_buf, x_counter
 	add	x_buf, x_buf, x_len
-	add	x_crc64_tab_addr, x_tmp, :lo12:lanchor_crc64_tab
+	add	x_crc_tab_addr, x_tmp, :lo12:.lanchor_crc_tab
 
 	.align 3
-.loop_crc64_tab:
+.loop_crc_tab:
 	ldrb	w_tmp, [x_buf_iter], 1
 	cmp	x_buf, x_buf_iter
 	eor	x_tmp, x_tmp, x_seed, lsr 56
-	ldr	x_tmp, [x_crc64_tab_addr, x_tmp, lsl 3]
+	ldr	x_tmp, [x_crc_tab_addr, x_tmp, lsl 3]
 	eor	x_seed, x_tmp, x_seed, lsl 8
-	bne	.loop_crc64_tab
+	bne	.loop_crc_tab
 
 .done:
 	mvn	x_crc_ret, x_seed
 	ret
 
-d_tmp		.req	d3
-q_tmp		.req	q3
-v_tmp		.req	v3
-
-q_x0		.req	q2
-q_x1		.req	q16
-q_x2		.req	q6
-q_x3		.req	q4
-
-v_x0		.req	v2
-v_x1		.req	v16
-v_x2		.req	v6
-v_x3		.req	v4
-
-d_p4_low	.req	d3
-d_p4_high	.req	d5
-v_p4_low	.req	v3
-v_p4_high	.req	v5
-
-q_shuffle	.req	q1
-v_shuffle	.req	v1
 	.align 2
-.crc64_clmul_pre:
-	adrp	x_tmp, .shuffle_data
-	ldr	q_shuffle, [x_tmp, #:lo12:.shuffle_data]
+.crc_clmul_pre:
+	movi	v_x0.2s, 0
+	fmov	v_x0.d[1], x_seed // save crc to v_x0
 
-	and	x_counter, x_len, -64
-	sub	x_tmp1, x_counter, #64
-	cmp	x_tmp1, 63 // align and the truncated buffer size
+	crc_norm_load_first_block
 
-	movi	v_x0.4s, 0
-	ins	v_x0.d[1], x_seed
-
-	add	x_buf_iter, x_buf, 64
-
-	ldr	q_tmp, [x_buf]
-	ldr	q_x1, [x_buf, 16]
-	ldr	q_x2, [x_buf, 32]
-	ldr	q_x3, [x_buf, 48]
-
-	tbl	v_tmp.16b, {v_tmp.16b}, v_shuffle.16b
-	tbl	v_x1.16b, {v_x1.16b}, v_shuffle.16b
-	tbl	v_x2.16b, {v_x2.16b}, v_shuffle.16b
-	tbl	v_x3.16b, {v_x3.16b}, v_shuffle.16b
-
-	eor	v_x0.16b, v_x0.16b, v_tmp.16b
 	bls	.clmul_loop_end
 
-	mov	x_tmp, p4_high_b0
-	movk	x_tmp, p4_high_b1, lsl 16
-	movk	x_tmp, p4_high_b2, lsl 32
-	movk	x_tmp, p4_high_b3, lsl 48
-	fmov	d_p4_high, x_tmp
-
-	mov	x_tmp, p4_low_b0
-	movk	x_tmp, p4_low_b1, lsl 16
-	movk	x_tmp, p4_low_b2, lsl 32
-	movk	x_tmp, p4_low_b3, lsl 48
-	fmov	d_p4_low, x_tmp
-
-	add	x_buf_end, x_buf_iter, x_tmp1
+	crc64_load_p4
 
 // 1024bit --> 512bit loop
 // merge x0, x1, x2, x3, y0, y1, y2, y3 => x0, x1, x2, x3 (uint64x2_t)
-d_x0_high	.req	d24
-d_x1_high	.req	d22
-d_x2_high	.req	d20
-d_x3_high	.req	d18
+	crc_norm_loop
 
-v_x0_high	.req	v24
-v_x1_high	.req	v22
-v_x2_high	.req	v20
-v_x3_high	.req	v18
-
-q_y0		.req	q17
-q_y1		.req	q19
-q_y2		.req	q7
-q_y3		.req	q0
-
-v_y0		.req	v17
-v_y1		.req	v19
-v_y2		.req	v7
-v_y3		.req	v0
-	.align 3
-.clmul_loop:
-	dup	d_x0_high, v_x0.d[1]
-	dup	d_x1_high, v_x1.d[1]
-	dup	d_x2_high, v_x2.d[1]
-	dup	d_x3_high, v_x3.d[1]
-
-	add	x_buf_iter, x_buf_iter, 64
-	cmp	x_buf_iter, x_buf_end
-
-	ldr	q_y0, [x_buf_iter, -64]
-	ldr	q_y1, [x_buf_iter, -48]
-	ldr	q_y2, [x_buf_iter, -32]
-	ldr	q_y3, [x_buf_iter, -16]
-
-	pmull	v_x0.1q, v_x0.1d, v_p4_low.1d
-	pmull	v_x1.1q, v_x1.1d, v_p4_low.1d
-	pmull	v_x2.1q, v_x2.1d, v_p4_low.1d
-	pmull	v_x3.1q, v_x3.1d, v_p4_low.1d
-
-	pmull	v_x0_high.1q, v_x0_high.1d, v_p4_high.1d
-	pmull	v_x1_high.1q, v_x1_high.1d, v_p4_high.1d
-	pmull	v_x2_high.1q, v_x2_high.1d, v_p4_high.1d
-	pmull	v_x3_high.1q, v_x3_high.1d, v_p4_high.1d
-
-	tbl	v_y0.16b, {v_y0.16b}, v_shuffle.16b
-	tbl	v_y1.16b, {v_y1.16b}, v_shuffle.16b
-	tbl	v_y2.16b, {v_y2.16b}, v_shuffle.16b
-	tbl	v_y3.16b, {v_y3.16b}, v_shuffle.16b
-
-	eor	v_x0_high.16b, v_x0_high.16b, v_x0.16b
-	eor	v_x1_high.16b, v_x1_high.16b, v_x1.16b
-	eor	v_x2_high.16b, v_x2_high.16b, v_x2.16b
-	eor	v_x3_high.16b, v_x3_high.16b, v_x3.16b
-
-	eor	v_x0.16b, v_x0_high.16b, v_y0.16b
-	eor	v_x1.16b, v_x1_high.16b, v_y1.16b
-	eor	v_x2.16b, v_x2_high.16b, v_y2.16b
-	eor	v_x3.16b, v_x3_high.16b, v_y3.16b
-	bne	.clmul_loop
-
-// folding 512bit --> 128bit
-// merge x0, x1, x2, x3 => x0 (uint64x2_t)
-d_tmp1		.req	d18
-v_tmp1		.req	v18
-
-d_p1_high	.req	d5
-v_p1_high	.req	v5
-
-d_p1_low	.req	d3
-v_p1_low	.req	v3
 .clmul_loop_end:
-	mov	x_tmp, p1_high_b0
-	movk	x_tmp, p1_high_b1, lsl 16
-	movk	x_tmp, p1_high_b2, lsl 32
-	movk	x_tmp, p1_high_b3, lsl 48
+// folding 512bit --> 128bit
+	crc64_fold_512b_to_128b
 
-	fmov	d_p1_high, x_tmp
-
-	mov	x_tmp, p1_low_b0
-	movk	x_tmp, p1_low_b1, lsl 16
-	movk	x_tmp, p1_low_b2, lsl 32
-	movk	x_tmp, p1_low_b3, lsl 48
-
-	fmov	d_p1_low, x_tmp
-
-	dup	d_tmp1, v_x0.d[1]
-	pmull	v_x0.1q, v_x0.1d, v_p1_low.1d
-	pmull	v_tmp1.1q, v_tmp1.1d, v_p1_high.1d
-	eor	v_x0.16b, v_tmp1.16b, v_x0.16b
-	eor	v_x1.16b, v_x0.16b, v_x1.16b
-
-	dup	d_tmp1, v_x1.d[1]
-	pmull	v_x1.1q, v_x1.1d, v_p1_low.1d
-	pmull	v_tmp1.1q, v_tmp1.1d, v_p1_high.1d
-	eor	v_tmp1.16b, v_tmp1.16b, v_x1.16b
-	eor	v_x2.16b, v_tmp1.16b, v_x2.16b
-
-	dup	d_tmp1, v_x2.d[1]
-	pmull	v_x2.1q, v_x2.1d, v_p1_low.1d
-	pmull	v_tmp1.1q, v_tmp1.1d, v_p1_high.1d
-	eor	v_x2.16b, v_tmp1.16b, v_x2.16b
-	eor	v_x3.16b, v_x2.16b, v_x3.16b
-
-// fold 64b
-d_p0_low	.req	d3
-v_p0_low	.req	v3
-
-d_x3_high1	.req	d2
-v_x3_high1	.req	v2
+// folding 128bit --> 64bit
 	mov	x_tmp, p0_low_b0
 	movk	x_tmp, p0_low_b1, lsl 16
 	movk	x_tmp, p0_low_b2, lsl 32
 	movk	x_tmp, p0_low_b3, lsl 48
-	fmov	d_p0_low, x_tmp
+	fmov	d_p0_high, x_tmp
 
-	dup	d_x3_high1, v_x3.d[1]
-	movi	v0.4s, 0
-	ext	v0.16b, v0.16b, v_x3.16b, #8
-	pmull	v_x3_high1.1q, v_x3_high1.1d, v_p0_low.1d
-	eor	v0.16b, v0.16b, v_x3_high1.16b
+	pmull2	v_tmp_high.1q, v_x3.2d, v_p0.2d
+	movi	v_tmp_low.2s, 0
+	ext	v_tmp_low.16b, v_tmp_low.16b, v_x3.16b, #8
+
+	eor	v_x3.16b, v_tmp_high.16b, v_tmp_low.16b
 
 // barrett reduction
 	mov	x_tmp, br_low_b0
 	movk	x_tmp, br_low_b1, lsl 16
 	movk	x_tmp, br_low_b2, lsl 32
 	movk	x_tmp, br_low_b3, lsl 48
+	fmov	d_br_low2, x_tmp
 
-	movi	v1.4s, 0x0
-	mov	x_tmp1, -1
-	ins	v1.d[1], x_tmp1
-	and	v2.16b, v1.16b, v0.16b
+	mov	x_tmp2, br_high_b0
+	movk	x_tmp2, br_high_b1, lsl 16
+	movk	x_tmp2, br_high_b2, lsl 32
+	movk	x_tmp2, br_high_b3, lsl 48
+	fmov	d_br_high2, x_tmp2
 
-	fmov	d1, x_tmp
+	pmull2	v_tmp_low.1q, v_x3.2d, v_br_low.2d
+	eor	v_tmp_low.16b, v_x3.16b, v_tmp_low.16b
+	pmull2	v_tmp_low.1q, v_tmp_low.2d, v_br_high.2d
+	eor	v_x3.8b, v_x3.8b, v_tmp_low.8b
+	umov	x_seed, v_x3.d[0]
 
-	dup	d4, v0.d[1]
-	pmull	v4.1q, v4.1d, v1.1d
-
-	mov	x_tmp, br_high_b0
-	movk	x_tmp, br_high_b1, lsl 16
-	movk	x_tmp, br_high_b2, lsl 32
-	movk	x_tmp, br_high_b3, lsl 48
-	fmov	d1, x_tmp
-
-	eor	v2.16b, v2.16b, v4.16b
-	dup	d2, v2.d[1]
-	pmull	v2.1q, v2.1d, v1.1d
-	eor	v0.16b, v0.16b, v2.16b
-	umov	x_seed, v0.d[0]
-
-	b	.crc64_tab_pre
+	b	.crc_tab_pre
 
 	.size	\name, .-\name
 

--- a/crc/aarch64/crc64_refl_common_pmull.h
+++ b/crc/aarch64/crc64_refl_common_pmull.h
@@ -27,276 +27,100 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #########################################################################
 
+#include "crc_common_pmull.h"
+
 .macro crc64_refl_func name:req
-	.arch armv8-a+crc+crypto
+	.arch armv8-a+crypto
 	.text
 	.align	3
 	.global	\name
 	.type	\name, %function
 
-// parameter
-x_seed		.req	x0
-x_buf		.req	x1
-x_len		.req	x2
+/* uint64_t crc64_refl_func(uint64_t seed, const uint8_t * buf, uint64_t len) */
 
-// return
-x_crc_ret	.req	x0
-
-// constant
-.equ	FOLD_SIZE, 1024
-
-// global variable
-x_buf_end		.req	x3
-x_counter		.req	x4
-x_buf_iter		.req	x5
-x_crc64_tab_addr	.req	x6
-w_tmp			.req	w7
-x_tmp			.req	x7
-
-// crc64 refl function entry
 \name\():
-// crc64 for table
 	mvn	x_seed, x_seed
 	mov	x_counter, 0
 	cmp	x_len, (FOLD_SIZE-1)
-	bhi	.crc64_clmul_pre
-.crc64_tab_pre:
+	bhi	.crc_clmul_pre
+
+.crc_tab_pre:
 	cmp	x_len, x_counter
 	bls	.done
 
-	adrp	x_tmp, .lanchor_crc64_tab
+	adrp	x_tmp, .lanchor_crc_tab
 	add	x_buf_iter, x_buf, x_counter
 	add	x_buf, x_buf, x_len
-	add	x_crc64_tab_addr, x_tmp, :lo12:.lanchor_crc64_tab
+	add	x_crc_tab_addr, x_tmp, :lo12:.lanchor_crc_tab
 
 	.align 3
-.loop_crc64_tab:
+.loop_crc_tab:
 	ldrb	w_tmp, [x_buf_iter], 1
 	eor	w_tmp, w_tmp, w0
 	cmp	x_buf, x_buf_iter
 	and	x_tmp, x_tmp, 255
-	ldr	x_tmp, [x_crc64_tab_addr, x_tmp, lsl 3]
+	ldr	x_tmp, [x_crc_tab_addr, x_tmp, lsl 3]
 	eor	x_seed, x_tmp, x_seed, lsr 8
-	bne	.loop_crc64_tab
+	bne	.loop_crc_tab
+
 .done:
-	mvn	x_crc_ret, x_crc_ret
+	mvn	x_crc_ret, x_seed
 	ret
 
-// clmul prepare
-q_x0		.req	q0
-q_x1		.req	q4
-q_x2		.req	q6
-q_x3		.req	q1
-
-v_x0		.req	v0
-v_x1		.req	v4
-v_x2		.req	v6
-v_x3		.req	v1
-
-d_p4_high	.req	d17
-d_p4_low	.req	d7
-v_p4_high	.req	v17
-v_p4_low	.req	v7
-
-d_y0_tmp	.req	d0
-v_y0_tmp	.req	v0
-
-q_tmp		.req	q2
-v_tmp		.req	v2
-
 	.align 2
-.crc64_clmul_pre:
-	ldr	q_tmp, [x_buf]
-	ldr	q_x1, [x_buf, 16]
-	ldr	q_x2, [x_buf, 32]
-	ldr	q_x3, [x_buf, 48]
+.crc_clmul_pre:
+	fmov	d_x0, x_seed // save crc to d_x0
 
-	and	x_counter, x_len, -64
-	sub	x_tmp, x_counter, #64
-	cmp	x_tmp, 63
+	crc_refl_load_first_block
 
-	fmov	d_y0_tmp, x_seed // save crc to d0
-	eor	v_x0.16b, v_y0_tmp.16b, v_tmp.16b
-
-	add	x_buf_iter, x_buf, 64
 	bls	.clmul_loop_end
 
-	add	x_buf_end, x_buf_iter, x_tmp
-
-	mov	x_tmp, p4_high_b0
-	movk	x_tmp, p4_high_b1, lsl 16
-	movk	x_tmp, p4_high_b2, lsl 32
-	movk	x_tmp, p4_high_b3, lsl 48
-	fmov	d_p4_high, x_tmp
-
-	mov	x_tmp, p4_low_b0
-	movk	x_tmp, p4_low_b1, lsl 16
-	movk	x_tmp, p4_low_b2, lsl 32
-	movk	x_tmp, p4_low_b3, lsl 48
-	fmov	d_p4_low, x_tmp
+	crc64_load_p4
 
 // 1024bit --> 512bit loop
 // merge x0, x1, x2, x3, y0, y1, y2, y3 => x0, x1, x2, x3 (uint64x2_t)
-d_x0_high	.req	d24
-d_x1_high	.req	d22
-d_x2_high	.req	d20
-d_x3_high	.req	d16
-
-v_x0_high	.req	v24
-v_x1_high	.req	v22
-v_x2_high	.req	v20
-v_x3_high	.req	v16
-
-q_x0_tmp	.req	q2
-q_x1_tmp	.req	q5
-q_x2_tmp	.req	q3
-q_x3_tmp	.req	q18
-
-v_x0_tmp	.req	v2
-v_x1_tmp	.req	v5
-v_x2_tmp	.req	v3
-v_x3_tmp	.req	v18
-
-q_x0_tmp	.req	q2
-q_x1_tmp	.req	q5
-q_x2_tmp	.req	q3
-q_x3_tmp	.req	q18
-
-	.align 3
-.clmul_loop:
-	add	x_buf_iter, x_buf_iter, 64
-	cmp	x_buf_iter, x_buf_end
-
-	dup	d_x0_high, v_x0.d[1]
-	dup	d_x1_high, v_x1.d[1]
-	dup	d_x2_high, v_x2.d[1]
-	dup	d_x3_high, v_x3.d[1]
-
-	pmull	v_x0_high.1q, v_x0_high.1d, v_p4_high.1d
-	pmull	v_x1_high.1q, v_x1_high.1d, v_p4_high.1d
-	pmull	v_x2_high.1q, v_x2_high.1d, v_p4_high.1d
-	pmull	v_x3_high.1q, v_x3_high.1d, v_p4_high.1d
-
-	pmull	v_x0.1q, v_x0.1d, v_p4_low.1d
-	pmull	v_x1.1q, v_x1.1d, v_p4_low.1d
-	pmull	v_x2.1q, v_x2.1d, v_p4_low.1d
-	pmull	v_x3.1q, v_x3.1d, v_p4_low.1d
-
-	ldr	q_x0_tmp, [x_buf_iter, -64]
-	ldr	q_x1_tmp, [x_buf_iter, -48]
-	ldr	q_x2_tmp, [x_buf_iter, -32]
-	ldr	q_x3_tmp, [x_buf_iter, -16]
-
-	eor	v_x0_tmp.16b, v_x0_tmp.16b, v_x0_high.16b
-	eor	v_x1_tmp.16b, v_x1_tmp.16b, v_x1_high.16b
-	eor	v_x2_tmp.16b, v_x2_tmp.16b, v_x2_high.16b
-	eor	v_x3_tmp.16b, v_x3_tmp.16b, v_x3_high.16b
-
-	eor	v_x0.16b, v_x0_tmp.16b, v_x0.16b
-	eor	v_x1.16b, v_x1_tmp.16b, v_x1.16b
-	eor	v_x2.16b, v_x2_tmp.16b, v_x2.16b
-	eor	v_x3.16b, v_x3_tmp.16b, v_x3.16b
-	bne	.clmul_loop
-
-// folding 512bit --> 128bit
-// merge x0, x1, x2, x3 => x3 (uint64x2_t)
-// input: x0 -> v_x0, x1 -> v_x1, x2 -> v_x2, x3 -> v_x3
-// output: v_x3
-d_p1_high	.req	d5
-d_p1_low	.req	d3
-v_p1_high	.req	v5
-v_p1_low	.req	v3
-
-d_tmp_high	.req	d16
-d_tmp_low	.req	d2
-v_tmp_high	.req	v16
-v_tmp_low	.req	v2
+	crc_refl_loop
 
 .clmul_loop_end:
-	mov	x_tmp, p1_high_b0
-	movk	x_tmp, p1_high_b1, lsl 16
-	movk	x_tmp, p1_high_b2, lsl 32
-	movk	x_tmp, p1_high_b3, lsl 48
-	fmov	d_p1_high, x_tmp
+// folding 512bit --> 128bit
+	crc64_fold_512b_to_128b
 
-	mov	x_tmp, p1_low_b0
-	movk	x_tmp, p1_low_b1, lsl 16
-	movk	x_tmp, p1_low_b2, lsl 32
-	movk	x_tmp, p1_low_b3, lsl 48
-	fmov	d_p1_low, x_tmp
-
-	dup	d_tmp_high, v_x0.d[1]
-	dup	d_tmp_low, v_x0.d[0]
-
-	pmull	v_tmp_high.1q, v_tmp_high.1d, v_p1_high.1d
-	pmull	v_tmp_low.1q, v_tmp_low.1d, v_p1_low.1d
-	eor	v_tmp_high.16b, v_tmp_high.16b, v_tmp_low.16b
-	eor	v_x1.16b, v_tmp_high.16b, v_x1.16b
-
-	dup	d_tmp_high, v_x1.d[1]
-	pmull	v_x1.1q, v_x1.1d, v_p1_low.1d
-	pmull	v_tmp_high.1q, v_tmp_high.1d, v_p1_high.1d
-	eor	v_tmp_high.16b, v_tmp_high.16b, v_x1.16b
-	eor	v_x2.16b, v_tmp_high.16b, v_x2.16b
-
-	dup	d_tmp_high, v_x2.d[1]
-	pmull	v_x2.1q, v_x2.1d, v_p1_low.1d
-	pmull	v_tmp_high.1q, v_tmp_high.1d, v_p1_high.1d
-	eor	v_tmp_high.16b, v_tmp_high.16b, v_x2.16b
-	eor	v_x3.16b, v_tmp_high.16b, v_x3.16b
-
-// fold 64b
-// input: v_x3
-// output: v_x3
-d_p0_low		.req	d3
-v_p0_low		.req	v3
-d_x3_low_fold_64b	.req	d2
-v_x3_low_fold_64b	.req	v2
-v_zero_fold_64b		.req	v0
+// folding 128bit --> 64bit
 	mov	x_tmp, p0_low_b0
 	movk	x_tmp, p0_low_b1, lsl 16
 	movk	x_tmp, p0_low_b2, lsl 32
 	movk	x_tmp, p0_low_b3, lsl 48
 	fmov	d_p0_low, x_tmp
 
-	dup	d_x3_low_fold_64b, v_x3.d[0]
-	movi	v_zero_fold_64b.4s, 0
-	ext	v_x3.16b, v_x3.16b, v0.16b, #8
+	pmull	v_tmp_low.1q, v_x3.1d, v_p0.1d
 
-	pmull	v_x3_low_fold_64b.1q, v_x3_low_fold_64b.1d, v_p0_low.1d
-	eor	v_x3.16b, v_x3.16b, v_x3_low_fold_64b.16b
+	mov	d_tmp_high, v_x3.d[1]
+
+	eor	v_x3.16b, v_tmp_high.16b, v_tmp_low.16b
 
 // barrett reduction
-// input: v_x3
-// output: x0
-d_br_low	.req	d3
-d_br_high	.req	d5
-v_br_low	.req	v3
-v_br_high	.req	v5
-	mov	x0, br_low_b0
-	movk	x0, br_low_b1, lsl 16
-	movk	x0, br_low_b2, lsl 32
-	movk	x0, br_low_b3, lsl 48
-	fmov	d_br_low, x0
+	mov	x_tmp, br_low_b0
+	movk	x_tmp, br_low_b1, lsl 16
+	movk	x_tmp, br_low_b2, lsl 32
+	movk	x_tmp, br_low_b3, lsl 48
+	fmov	d_br_low, x_tmp
 
-	mov	x0, br_high_b0
-	movk	x0, br_high_b1, lsl 16
-	movk	x0, br_high_b2, lsl 32
-	movk	x0, br_high_b3, lsl 48
-	fmov	d_br_high, x0
+	mov	x_tmp2, br_high_b0
+	movk	x_tmp2, br_high_b1, lsl 16
+	movk	x_tmp2, br_high_b2, lsl 32
+	movk	x_tmp2, br_high_b3, lsl 48
+	fmov	d_br_high, x_tmp2
 
-	dup	d2, v_x3.d[0]
+	pmull	v_tmp_low.1q, v_x3.1d, v_br_low.1d
+	pmull	v_tmp_high.1q, v_tmp_low.1d, v_br_high.1d
 
-	pmull	v2.1q, v2.1d, v_br_low.1d
-	pmull	v4.1q, v2.1d, v_br_high.1d
+	ext	v_tmp_low.16b, v_br_low.16b, v_tmp_low.16b, #8
 
-	ext	v0.16b, v0.16b, v2.16b, #8
+	eor	v_tmp_low.16b, v_tmp_low.16b, v_tmp_high.16b
+	eor	v_tmp_low.16b, v_tmp_low.16b, v_x3.16b
+	umov	x_crc_ret, v_tmp_low.d[1]
 
-	eor	v0.16b, v0.16b, v4.16b
-	eor	v0.16b, v0.16b, v_x3.16b
-	umov	x0, v0.d[1]
-
-	b	.crc64_tab_pre
+	b	.crc_tab_pre
 
 	.size	\name, .-\name
 .endm

--- a/crc/aarch64/crc_common_pmull.h
+++ b/crc/aarch64/crc_common_pmull.h
@@ -1,0 +1,302 @@
+########################################################################
+#  Copyright (c) 2019 Microsoft Corporation.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions
+#  are met:
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in
+#      the documentation and/or other materials provided with the
+#      distribution.
+#    * Neither the name of Microsoft Corporation nor the names of its
+#      contributors may be used to endorse or promote products derived
+#      from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+#  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#########################################################################
+
+// parameters
+#define w_seed          w0
+#define x_seed          x0
+#define x_buf           x1
+#define w_len           w2
+#define x_len           x2
+
+// return
+#define w_crc_ret       w0
+#define x_crc_ret       x0
+
+// constant
+#define FOLD_SIZE       64
+
+// global variables
+#define x_buf_end       x3
+#define w_counter       w4
+#define x_counter       x4
+#define x_buf_iter      x5
+#define x_crc_tab_addr  x6
+#define x_tmp2          x6
+#define w_tmp           w7
+#define x_tmp           x7
+
+#define v_x0            v0
+#define d_x0            d0
+#define s_x0            s0
+
+#define q_x1            q1
+#define v_x1            v1
+
+#define q_x2            q2
+#define v_x2            v2
+
+#define q_x3            q3
+#define v_x3            v3
+#define d_x3            d3
+#define s_x3            s3
+
+#define q_y0            q4
+#define v_y0            v4
+#define v_tmp_high      v4
+#define d_tmp_high      d4
+
+#define q_y1            q5
+#define v_y1            v5
+#define v_tmp_low       v5
+
+#define q_y2            q6
+#define v_y2            v6
+
+#define q_y3            q7
+#define v_y3            v7
+
+#define q_x0_tmp        q30
+#define v_x0_tmp        v30
+#define d_p4_high       v30.d[1]
+#define d_p4_low        d30
+#define v_p4            v30
+#define d_p1_high       v30.d[1]
+#define d_p1_low        d30
+#define v_p1            v30
+#define d_p0_high       v30.d[1]
+#define d_p0_low        d30
+#define v_p0            v30
+#define d_br_low        d30
+#define d_br_low2       v30.d[1]
+#define v_br_low        v30
+
+#define q_shuffle       q31
+#define v_shuffle       v31
+#define d_br_high       d31
+#define d_br_high2      v31.d[1]
+#define v_br_high       v31
+#define d_p0_low2       d31
+#define d_p0_high2      v31.d[1]
+#define v_p02           v31
+
+#define v_x0_high       v16
+#define v_x1_high       v17
+#define v_x2_high       v18
+#define v_x3_high       v19
+
+.macro crc_refl_load_first_block
+	ldr	q_x0_tmp, [x_buf]
+	ldr	q_x1, [x_buf, 16]
+	ldr	q_x2, [x_buf, 32]
+	ldr	q_x3, [x_buf, 48]
+
+	and	x_counter, x_len, -64
+	sub	x_tmp, x_counter, #64
+	cmp	x_tmp, 63
+
+	add	x_buf_iter, x_buf, 64
+
+	eor	v_x0.16b, v_x0.16b, v_x0_tmp.16b
+.endm
+
+.macro crc_norm_load_first_block
+	adrp	x_tmp, .shuffle_data
+	ldr	q_shuffle, [x_tmp, #:lo12:.shuffle_data]
+
+	ldr	q_x0_tmp, [x_buf]
+	ldr	q_x1, [x_buf, 16]
+	ldr	q_x2, [x_buf, 32]
+	ldr	q_x3, [x_buf, 48]
+
+	and	x_counter, x_len, -64
+	sub	x_tmp, x_counter, #64
+	cmp	x_tmp, 63
+
+	add	x_buf_iter, x_buf, 64
+
+	tbl	v_x0_tmp.16b, {v_x0_tmp.16b}, v_shuffle.16b
+	tbl	v_x1.16b, {v_x1.16b}, v_shuffle.16b
+	tbl	v_x2.16b, {v_x2.16b}, v_shuffle.16b
+	tbl	v_x3.16b, {v_x3.16b}, v_shuffle.16b
+
+	eor	v_x0.16b, v_x0.16b, v_x0_tmp.16b
+.endm
+
+.macro crc32_load_p4
+	add	x_buf_end, x_buf_iter, x_tmp
+
+	mov	x_tmp, p4_low_b0
+	movk	x_tmp, p4_low_b1, lsl 16
+	fmov	d_p4_low, x_tmp
+
+	mov	x_tmp2, p4_high_b0
+	movk	x_tmp2, p4_high_b1, lsl 16
+	fmov	d_p4_high, x_tmp2
+.endm
+
+.macro crc64_load_p4
+	add	x_buf_end, x_buf_iter, x_tmp
+
+	mov	x_tmp, p4_low_b0
+	movk	x_tmp, p4_low_b1, lsl 16
+	movk	x_tmp, p4_low_b2, lsl 32
+	movk	x_tmp, p4_low_b3, lsl 48
+	fmov	d_p4_low, x_tmp
+
+	mov	x_tmp2, p4_high_b0
+	movk	x_tmp2, p4_high_b1, lsl 16
+	movk	x_tmp2, p4_high_b2, lsl 32
+	movk	x_tmp2, p4_high_b3, lsl 48
+	fmov	d_p4_high, x_tmp2
+.endm
+
+.macro crc_refl_loop
+	.align 3
+.clmul_loop:
+	// interleave ldr and pmull(2) for arch which can only issue quadword load every
+	// other cycle (i.e. A55)
+	ldr	q_y0, [x_buf_iter]
+	pmull2	v_x0_high.1q, v_x0.2d, v_p4.2d
+	ldr	q_y1, [x_buf_iter, 16]
+	pmull2	v_x1_high.1q, v_x1.2d, v_p4.2d
+	ldr	q_y2, [x_buf_iter, 32]
+	pmull2	v_x2_high.1q, v_x2.2d, v_p4.2d
+	ldr	q_y3, [x_buf_iter, 48]
+	pmull2	v_x3_high.1q, v_x3.2d, v_p4.2d
+
+	pmull	v_x0.1q, v_x0.1d, v_p4.1d
+	add	x_buf_iter, x_buf_iter, 64
+	pmull	v_x1.1q, v_x1.1d, v_p4.1d
+	cmp	x_buf_iter, x_buf_end
+	pmull	v_x2.1q, v_x2.1d, v_p4.1d
+	pmull	v_x3.1q, v_x3.1d, v_p4.1d
+
+	eor	v_x0.16b, v_x0.16b, v_x0_high.16b
+	eor	v_x1.16b, v_x1.16b, v_x1_high.16b
+	eor	v_x2.16b, v_x2.16b, v_x2_high.16b
+	eor	v_x3.16b, v_x3.16b, v_x3_high.16b
+
+	eor	v_x0.16b, v_x0.16b, v_y0.16b
+	eor	v_x1.16b, v_x1.16b, v_y1.16b
+	eor	v_x2.16b, v_x2.16b, v_y2.16b
+	eor	v_x3.16b, v_x3.16b, v_y3.16b
+	bne	.clmul_loop
+.endm
+
+.macro crc_norm_loop
+	.align 3
+.clmul_loop:
+	// interleave ldr and pmull(2) for arch which can only issue quadword load every
+	// other cycle (i.e. A55)
+	ldr	q_y0, [x_buf_iter]
+	pmull2	v_x0_high.1q, v_x0.2d, v_p4.2d
+	ldr	q_y1, [x_buf_iter, 16]
+	pmull2	v_x1_high.1q, v_x1.2d, v_p4.2d
+	ldr	q_y2, [x_buf_iter, 32]
+	pmull2	v_x2_high.1q, v_x2.2d, v_p4.2d
+	ldr	q_y3, [x_buf_iter, 48]
+	pmull2	v_x3_high.1q, v_x3.2d, v_p4.2d
+
+	pmull	v_x0.1q, v_x0.1d, v_p4.1d
+	add	x_buf_iter, x_buf_iter, 64
+	pmull	v_x1.1q, v_x1.1d, v_p4.1d
+	cmp	x_buf_iter, x_buf_end
+	pmull	v_x2.1q, v_x2.1d, v_p4.1d
+	pmull	v_x3.1q, v_x3.1d, v_p4.1d
+
+	tbl	v_y0.16b, {v_y0.16b}, v_shuffle.16b
+	tbl	v_y1.16b, {v_y1.16b}, v_shuffle.16b
+	tbl	v_y2.16b, {v_y2.16b}, v_shuffle.16b
+	tbl	v_y3.16b, {v_y3.16b}, v_shuffle.16b
+
+	eor	v_x0.16b, v_x0.16b, v_x0_high.16b
+	eor	v_x1.16b, v_x1.16b, v_x1_high.16b
+	eor	v_x2.16b, v_x2.16b, v_x2_high.16b
+	eor	v_x3.16b, v_x3.16b, v_x3_high.16b
+
+	eor	v_x0.16b, v_x0.16b, v_y0.16b
+	eor	v_x1.16b, v_x1.16b, v_y1.16b
+	eor	v_x2.16b, v_x2.16b, v_y2.16b
+	eor	v_x3.16b, v_x3.16b, v_y3.16b
+	bne	.clmul_loop
+.endm
+
+.macro crc32_fold_512b_to_128b
+	mov	x_tmp, p1_low_b0
+	movk	x_tmp, p1_low_b1, lsl 16
+	fmov	d_p1_low, x_tmp
+
+	mov	x_tmp2, p1_high_b0
+	movk	x_tmp2, p1_high_b1, lsl 16
+	fmov	d_p1_high, x_tmp2
+
+	pmull2	v_tmp_high.1q, v_x0.2d, v_p1.2d
+	pmull	v_tmp_low.1q, v_x0.1d, v_p1.1d
+	eor	v_x1.16b, v_x1.16b, v_tmp_high.16b
+	eor	v_x1.16b, v_x1.16b, v_tmp_low.16b
+
+	pmull2	v_tmp_high.1q, v_x1.2d, v_p1.2d
+	pmull	v_tmp_low.1q, v_x1.1d, v_p1.1d
+	eor	v_x2.16b, v_x2.16b, v_tmp_high.16b
+	eor	v_x2.16b, v_x2.16b, v_tmp_low.16b
+
+	pmull2	v_tmp_high.1q, v_x2.2d, v_p1.2d
+	pmull	v_tmp_low.1q, v_x2.1d, v_p1.1d
+	eor	v_x3.16b, v_x3.16b, v_tmp_high.16b
+	eor	v_x3.16b, v_x3.16b, v_tmp_low.16b
+.endm
+
+.macro crc64_fold_512b_to_128b
+	mov	x_tmp, p1_low_b0
+	movk	x_tmp, p1_low_b1, lsl 16
+	movk	x_tmp, p1_low_b2, lsl 32
+	movk	x_tmp, p1_low_b3, lsl 48
+	fmov	d_p1_low, x_tmp
+
+	mov	x_tmp2, p1_high_b0
+	movk	x_tmp2, p1_high_b1, lsl 16
+	movk	x_tmp2, p1_high_b2, lsl 32
+	movk	x_tmp2, p1_high_b3, lsl 48
+	fmov	d_p1_high, x_tmp2
+
+	pmull2	v_tmp_high.1q, v_x0.2d, v_p1.2d
+	pmull	v_tmp_low.1q, v_x0.1d, v_p1.1d
+	eor	v_x1.16b, v_x1.16b, v_tmp_high.16b
+	eor	v_x1.16b, v_x1.16b, v_tmp_low.16b
+
+	pmull2	v_tmp_high.1q, v_x1.2d, v_p1.2d
+	pmull	v_tmp_low.1q, v_x1.1d, v_p1.1d
+	eor	v_x2.16b, v_x2.16b, v_tmp_high.16b
+	eor	v_x2.16b, v_x2.16b, v_tmp_low.16b
+
+	pmull2	v_tmp_high.1q, v_x2.2d, v_p1.2d
+	pmull	v_tmp_low.1q, v_x2.1d, v_p1.1d
+	eor	v_x3.16b, v_x3.16b, v_tmp_high.16b
+	eor	v_x3.16b, v_x3.16b, v_tmp_low.16b
+.endm


### PR DESCRIPTION
These changes are mostly focused on improving the throughput of CRC for
large inputs on arm64 - similar changes could be made to improve small
cases by applying the same ideas to the final folding / barrett
reduction.

+ Utilise `pmull2` instruction in main loops of arm64 crc functions and
avoid the need for `dup` to align multiplicands.
  + Use just 1 ASIMD register to hold both 64b p4 constants,
appropriately aligned.
+ Interleave quadword `ldr` with `pmull{2}` to avoid unnecessary stalls
on existing LITTLE uarch (which can only issue these instructions every
other cycle).
+ Similarly interleave scalar instructions with ASIMD instructions to
increase likelihood of instruction level parallelism on a variety of
uarch.

Mostly cosmetic changes:

+ Made some attempt to be more consistent in the phrasing of the
algorithm in all 4 source files.
+ Phrased the `eor` instructions in the main loop to more clearly show
that we can rewrite pairs of `eor` instructions with a single `eor3`
instruction in the presence of Armv8.2-SHA (should probably be an option
in multibinary in future).

Signed-off-by: Samuel Lee <samuel.lee@microsoft.com>