### PR TITLE
Add arm64 to Travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,24 @@ matrix:
             - g++-6
       env: C_COMPILER=gcc-6
 
+    ### arm64: clang-3.8
+    - os: linux
+      dist: xenial
+      arch: arm64
+      env: C_COMPILER=clang
+
+    ### arm64: gcc-5.4
+    - os: linux
+      dist: xenial
+      arch: arm64
+      env: C_COMPILER=gcc
+
+    ### arm64: gcc-5.4
+    - os: linux
+      dist: xenial
+      arch: arm64
+      env: TEST_TYPE=ext
+
     ### linux extended tests
     - dist: xenial
       addons:


### PR DESCRIPTION
Enable new arm64 architecture in TravisCI, add tests for
following compilers:
gcc: v4.8, v5.4.0, v6.5.0, v7.4.0, v8.3.0
clang: v3.8.0, v4.0, v6.0.0, v8.0.0

Change-Id: Id0b2f2231fabcbeff7061f85050db99df12c9a67
Signed-off-by: Jun He <jun.he@arm.com>