### PR TITLE
Improve MSVC compatibility

### DIFF
--- a/Makefile.nmake
+++ b/Makefile.nmake
@@ -239,17 +239,16 @@ perfs = \
 	gf_vect_dot_prod_1tbl.exe \
 	erasure_code_perf.exe \
 	erasure_code_base_perf.exe \
-	erasure_code_sse_perf.exe \
 	erasure_code_update_perf.exe \
 	xor_gen_perf.exe \
 	pq_gen_perf.exe \
 	crc16_t10dif_perf.exe \
 	crc32_ieee_perf.exe \
 	crc32_iscsi_perf.exe \
-	igzip_perf.exe \
-	igzip_sync_flush_perf.exe \
+	crc64_funcs_perf.exe \
 	crc32_gzip_refl_perf.exe \
 	mem_zero_detect_perf.exe
+	# igzip_perf.exe // has getopt.h dependency - more work required for MSVC
 
 perfs: lib $(perfs)
 $(perfs): $(@B).obj

--- a/crc/crc16_t10dif_copy_perf.c
+++ b/crc/crc16_t10dif_copy_perf.c
@@ -33,7 +33,7 @@
 #include <stdint.h>
 #include "crc.h"
 #include "test.h"
-#include "types.h"	// include posix_* definitions for MSVC
+#include "types.h"		// include posix_* definitions for MSVC
 
 //#define CACHED_TEST
 #ifdef CACHED_TEST

--- a/crc/crc16_t10dif_copy_perf.c
+++ b/crc/crc16_t10dif_copy_perf.c
@@ -34,6 +34,7 @@
 #include <sys/time.h>
 #include "crc.h"
 #include "test.h"
+#include "types.h"	// include posix_* definitions for MSVC
 
 //#define CACHED_TEST
 #ifdef CACHED_TEST

--- a/crc/crc16_t10dif_copy_perf.c
+++ b/crc/crc16_t10dif_copy_perf.c
@@ -31,7 +31,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
-#include <sys/time.h>
 #include "crc.h"
 #include "test.h"
 #include "types.h"	// include posix_* definitions for MSVC

--- a/crc/crc16_t10dif_op_perf.c
+++ b/crc/crc16_t10dif_op_perf.c
@@ -33,6 +33,7 @@
 #include <stdint.h>
 #include "crc.h"
 #include "test.h"
+#include "types.h"	// include posix_* definitions for MSVC
 
 #define BLKSIZE (512)
 

--- a/crc/crc16_t10dif_op_perf.c
+++ b/crc/crc16_t10dif_op_perf.c
@@ -33,7 +33,7 @@
 #include <stdint.h>
 #include "crc.h"
 #include "test.h"
-#include "types.h"	// include posix_* definitions for MSVC
+#include "types.h"		// include posix_* definitions for MSVC
 
 #define BLKSIZE (512)
 

--- a/crc/crc16_t10dif_perf.c
+++ b/crc/crc16_t10dif_perf.c
@@ -33,7 +33,7 @@
 #include <stdint.h>
 #include "crc.h"
 #include "test.h"
-#include "types.h"	// include posix_* definitions for MSVC
+#include "types.h"		// include posix_* definitions for MSVC
 
 //#define CACHED_TEST
 #ifdef CACHED_TEST

--- a/crc/crc16_t10dif_perf.c
+++ b/crc/crc16_t10dif_perf.c
@@ -34,6 +34,7 @@
 #include <sys/time.h>
 #include "crc.h"
 #include "test.h"
+#include "types.h"	// include posix_* definitions for MSVC
 
 //#define CACHED_TEST
 #ifdef CACHED_TEST

--- a/crc/crc16_t10dif_perf.c
+++ b/crc/crc16_t10dif_perf.c
@@ -31,7 +31,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
-#include <sys/time.h>
 #include "crc.h"
 #include "test.h"
 #include "types.h"	// include posix_* definitions for MSVC

--- a/crc/crc16_t10dif_test.c
+++ b/crc/crc16_t10dif_test.c
@@ -32,7 +32,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include "crc.h"
-#include "types.h"	// include posix_* definitions for MSVC
+#include "types.h"		// include posix_* definitions for MSVC
 #include "crc_ref.h"
 
 #ifndef TEST_SEED

--- a/crc/crc16_t10dif_test.c
+++ b/crc/crc16_t10dif_test.c
@@ -32,7 +32,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include "crc.h"
-#include "types.h"
+#include "types.h"	// include posix_* definitions for MSVC
 #include "crc_ref.h"
 
 #ifndef TEST_SEED

--- a/crc/crc32_funcs_test.c
+++ b/crc/crc32_funcs_test.c
@@ -32,7 +32,7 @@
 #include <string.h>
 #include <stdint.h>
 #include "crc.h"
-#include "types.h"	// include posix_* definitions for MSVC
+#include "types.h"		// include posix_* definitions for MSVC
 #include "crc_ref.h"
 
 #ifndef TEST_SEED

--- a/crc/crc32_funcs_test.c
+++ b/crc/crc32_funcs_test.c
@@ -32,7 +32,7 @@
 #include <string.h>
 #include <stdint.h>
 #include "crc.h"
-#include "types.h"
+#include "types.h"	// include posix_* definitions for MSVC
 #include "crc_ref.h"
 
 #ifndef TEST_SEED

--- a/crc/crc32_gzip_refl_perf.c
+++ b/crc/crc32_gzip_refl_perf.c
@@ -33,7 +33,7 @@
 #include <stdint.h>
 #include "crc.h"
 #include "test.h"
-#include "types.h"	// include posix_* definitions for MSVC
+#include "types.h"		// include posix_* definitions for MSVC
 
 //#define CACHED_TEST
 #ifdef CACHED_TEST

--- a/crc/crc32_gzip_refl_perf.c
+++ b/crc/crc32_gzip_refl_perf.c
@@ -34,6 +34,7 @@
 #include <sys/time.h>
 #include "crc.h"
 #include "test.h"
+#include "types.h"	// include posix_* definitions for MSVC
 
 //#define CACHED_TEST
 #ifdef CACHED_TEST

--- a/crc/crc32_gzip_refl_perf.c
+++ b/crc/crc32_gzip_refl_perf.c
@@ -31,7 +31,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
-#include <sys/time.h>
 #include "crc.h"
 #include "test.h"
 #include "types.h"	// include posix_* definitions for MSVC

--- a/crc/crc32_ieee_perf.c
+++ b/crc/crc32_ieee_perf.c
@@ -33,7 +33,7 @@
 #include <stdint.h>
 #include "crc.h"
 #include "test.h"
-#include "types.h"	// include posix_* definitions for MSVC
+#include "types.h"		// include posix_* definitions for MSVC
 
 //#define CACHED_TEST
 #ifdef CACHED_TEST

--- a/crc/crc32_ieee_perf.c
+++ b/crc/crc32_ieee_perf.c
@@ -34,6 +34,7 @@
 #include <sys/time.h>
 #include "crc.h"
 #include "test.h"
+#include "types.h"	// include posix_* definitions for MSVC
 
 //#define CACHED_TEST
 #ifdef CACHED_TEST

--- a/crc/crc32_ieee_perf.c
+++ b/crc/crc32_ieee_perf.c
@@ -31,7 +31,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
-#include <sys/time.h>
 #include "crc.h"
 #include "test.h"
 #include "types.h"	// include posix_* definitions for MSVC

--- a/crc/crc32_iscsi_perf.c
+++ b/crc/crc32_iscsi_perf.c
@@ -33,7 +33,7 @@
 #include <stdint.h>
 #include "crc.h"
 #include "test.h"
-#include "types.h"	// include posix_* definitions for MSVC
+#include "types.h"		// include posix_* definitions for MSVC
 
 //#define CACHED_TEST
 #ifdef CACHED_TEST

--- a/crc/crc32_iscsi_perf.c
+++ b/crc/crc32_iscsi_perf.c
@@ -34,6 +34,7 @@
 #include <sys/time.h>
 #include "crc.h"
 #include "test.h"
+#include "types.h"	// include posix_* definitions for MSVC
 
 //#define CACHED_TEST
 #ifdef CACHED_TEST

--- a/crc/crc32_iscsi_perf.c
+++ b/crc/crc32_iscsi_perf.c
@@ -31,7 +31,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
-#include <sys/time.h>
 #include "crc.h"
 #include "test.h"
 #include "types.h"	// include posix_* definitions for MSVC

--- a/crc/crc64_funcs_perf.c
+++ b/crc/crc64_funcs_perf.c
@@ -34,6 +34,7 @@
 #include <sys/time.h>
 #include "crc64.h"
 #include "test.h"
+#include "types.h"	// include posix_* definitions for MSVC
 
 //#define CACHED_TEST
 #ifdef CACHED_TEST

--- a/crc/crc64_funcs_perf.c
+++ b/crc/crc64_funcs_perf.c
@@ -33,7 +33,7 @@
 #include <stdint.h>
 #include "crc64.h"
 #include "test.h"
-#include "types.h"	// include posix_* definitions for MSVC
+#include "types.h"		// include posix_* definitions for MSVC
 
 //#define CACHED_TEST
 #ifdef CACHED_TEST

--- a/crc/crc64_funcs_perf.c
+++ b/crc/crc64_funcs_perf.c
@@ -31,7 +31,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>
-#include <sys/time.h>
 #include "crc64.h"
 #include "test.h"
 #include "types.h"	// include posix_* definitions for MSVC

--- a/crc/crc64_funcs_test.c
+++ b/crc/crc64_funcs_test.c
@@ -32,7 +32,7 @@
 #include <string.h>
 #include <stdint.h>
 #include "crc64.h"
-#include "types.h"	// include posix_* definitions for MSVC
+#include "types.h"		// include posix_* definitions for MSVC
 #include "crc64_ref.h"
 
 #ifndef TEST_SEED

--- a/crc/crc64_funcs_test.c
+++ b/crc/crc64_funcs_test.c
@@ -32,7 +32,7 @@
 #include <string.h>
 #include <stdint.h>
 #include "crc64.h"
-#include "types.h"
+#include "types.h"	// include posix_* definitions for MSVC
 #include "crc64_ref.h"
 
 #ifndef TEST_SEED

--- a/erasure_code/erasure_code_base_perf.c
+++ b/erasure_code/erasure_code_base_perf.c
@@ -32,7 +32,7 @@
 #include <string.h>		// for memset, memcmp
 #include "erasure_code.h"
 #include "test.h"
-#include "types.h"	// include posix_* definitions for MSVC
+#include "types.h"		// include posix_* definitions for MSVC
 
 //#define CACHED_TEST
 #ifdef CACHED_TEST

--- a/erasure_code/erasure_code_base_perf.c
+++ b/erasure_code/erasure_code_base_perf.c
@@ -32,6 +32,7 @@
 #include <string.h>		// for memset, memcmp
 #include "erasure_code.h"
 #include "test.h"
+#include "types.h"	// include posix_* definitions for MSVC
 
 //#define CACHED_TEST
 #ifdef CACHED_TEST

--- a/erasure_code/erasure_code_base_test.c
+++ b/erasure_code/erasure_code_base_test.c
@@ -31,7 +31,7 @@
 #include <stdlib.h>
 #include <string.h>		// for memset, memcmp
 #include "erasure_code.h"
-#include "types.h"
+#include "types.h"	// include posix_* definitions for MSVC
 
 #define TEST_LEN 8192
 #define TEST_SIZE (TEST_LEN/2)

--- a/erasure_code/erasure_code_base_test.c
+++ b/erasure_code/erasure_code_base_test.c
@@ -31,7 +31,7 @@
 #include <stdlib.h>
 #include <string.h>		// for memset, memcmp
 #include "erasure_code.h"
-#include "types.h"	// include posix_* definitions for MSVC
+#include "types.h"		// include posix_* definitions for MSVC
 
 #define TEST_LEN 8192
 #define TEST_SIZE (TEST_LEN/2)

--- a/erasure_code/erasure_code_perf.c
+++ b/erasure_code/erasure_code_perf.c
@@ -32,7 +32,7 @@
 #include <string.h>		// for memset, memcmp
 #include "erasure_code.h"
 #include "test.h"
-#include "types.h"	// include posix_* definitions for MSVC
+#include "types.h"		// include posix_* definitions for MSVC
 
 //#define CACHED_TEST
 #ifdef CACHED_TEST

--- a/erasure_code/erasure_code_perf.c
+++ b/erasure_code/erasure_code_perf.c
@@ -32,6 +32,7 @@
 #include <string.h>		// for memset, memcmp
 #include "erasure_code.h"
 #include "test.h"
+#include "types.h"	// include posix_* definitions for MSVC
 
 //#define CACHED_TEST
 #ifdef CACHED_TEST

--- a/erasure_code/erasure_code_test.c
+++ b/erasure_code/erasure_code_test.c
@@ -31,7 +31,7 @@
 #include <stdlib.h>
 #include <string.h>		// for memset, memcmp
 #include "erasure_code.h"
-#include "types.h"
+#include "types.h"	// include posix_* definitions for MSVC
 
 #define TEST_LEN 8192
 #define TEST_SIZE (TEST_LEN/2)

--- a/erasure_code/erasure_code_test.c
+++ b/erasure_code/erasure_code_test.c
@@ -31,7 +31,7 @@
 #include <stdlib.h>
 #include <string.h>		// for memset, memcmp
 #include "erasure_code.h"
-#include "types.h"	// include posix_* definitions for MSVC
+#include "types.h"		// include posix_* definitions for MSVC
 
 #define TEST_LEN 8192
 #define TEST_SIZE (TEST_LEN/2)

--- a/erasure_code/erasure_code_update_perf.c
+++ b/erasure_code/erasure_code_update_perf.c
@@ -31,7 +31,7 @@
 #include <stdlib.h>
 #include <string.h>		// for memset, memcmp
 #include "erasure_code.h"
-#include "types.h"	// include posix_* definitions for MSVC
+#include "types.h"		// include posix_* definitions for MSVC
 #include "test.h"
 
 //By default, test multibinary version

--- a/erasure_code/erasure_code_update_perf.c
+++ b/erasure_code/erasure_code_update_perf.c
@@ -31,7 +31,7 @@
 #include <stdlib.h>
 #include <string.h>		// for memset, memcmp
 #include "erasure_code.h"
-#include "types.h"
+#include "types.h"	// include posix_* definitions for MSVC
 #include "test.h"
 
 //By default, test multibinary version

--- a/erasure_code/erasure_code_update_test.c
+++ b/erasure_code/erasure_code_update_test.c
@@ -31,7 +31,7 @@
 #include <stdlib.h>
 #include <string.h>		// for memset, memcmp
 #include "erasure_code.h"
-#include "types.h"
+#include "types.h"	// include posix_* definitions for MSVC
 
 #ifndef ALIGN_SIZE
 # define ALIGN_SIZE 16

--- a/erasure_code/erasure_code_update_test.c
+++ b/erasure_code/erasure_code_update_test.c
@@ -31,7 +31,7 @@
 #include <stdlib.h>
 #include <string.h>		// for memset, memcmp
 #include "erasure_code.h"
-#include "types.h"	// include posix_* definitions for MSVC
+#include "types.h"		// include posix_* definitions for MSVC
 
 #ifndef ALIGN_SIZE
 # define ALIGN_SIZE 16

--- a/erasure_code/gf_2vect_dot_prod_sse_test.c
+++ b/erasure_code/gf_2vect_dot_prod_sse_test.c
@@ -31,7 +31,7 @@
 #include <stdlib.h>
 #include <string.h>		// for memset, memcmp
 #include "erasure_code.h"
-#include "types.h"	// include posix_* definitions for MSVC
+#include "types.h"		// include posix_* definitions for MSVC
 
 #ifndef FUNCTION_UNDER_TEST
 # define FUNCTION_UNDER_TEST gf_2vect_dot_prod_sse

--- a/erasure_code/gf_2vect_dot_prod_sse_test.c
+++ b/erasure_code/gf_2vect_dot_prod_sse_test.c
@@ -31,7 +31,7 @@
 #include <stdlib.h>
 #include <string.h>		// for memset, memcmp
 #include "erasure_code.h"
-#include "types.h"
+#include "types.h"	// include posix_* definitions for MSVC
 
 #ifndef FUNCTION_UNDER_TEST
 # define FUNCTION_UNDER_TEST gf_2vect_dot_prod_sse

--- a/erasure_code/gf_3vect_dot_prod_sse_test.c
+++ b/erasure_code/gf_3vect_dot_prod_sse_test.c
@@ -31,7 +31,7 @@
 #include <stdlib.h>
 #include <string.h>		// for memset, memcmp
 #include "erasure_code.h"
-#include "types.h"	// include posix_* definitions for MSVC
+#include "types.h"		// include posix_* definitions for MSVC
 
 #ifndef FUNCTION_UNDER_TEST
 # define FUNCTION_UNDER_TEST gf_3vect_dot_prod_sse

--- a/erasure_code/gf_3vect_dot_prod_sse_test.c
+++ b/erasure_code/gf_3vect_dot_prod_sse_test.c
@@ -31,7 +31,7 @@
 #include <stdlib.h>
 #include <string.h>		// for memset, memcmp
 #include "erasure_code.h"
-#include "types.h"
+#include "types.h"	// include posix_* definitions for MSVC
 
 #ifndef FUNCTION_UNDER_TEST
 # define FUNCTION_UNDER_TEST gf_3vect_dot_prod_sse

--- a/erasure_code/gf_4vect_dot_prod_sse_test.c
+++ b/erasure_code/gf_4vect_dot_prod_sse_test.c
@@ -31,7 +31,7 @@
 #include <stdlib.h>
 #include <string.h>		// for memset, memcmp
 #include "erasure_code.h"
-#include "types.h"
+#include "types.h"	// include posix_* definitions for MSVC
 
 #ifndef FUNCTION_UNDER_TEST
 # define FUNCTION_UNDER_TEST gf_4vect_dot_prod_sse

--- a/erasure_code/gf_4vect_dot_prod_sse_test.c
+++ b/erasure_code/gf_4vect_dot_prod_sse_test.c
@@ -31,7 +31,7 @@
 #include <stdlib.h>
 #include <string.h>		// for memset, memcmp
 #include "erasure_code.h"
-#include "types.h"	// include posix_* definitions for MSVC
+#include "types.h"		// include posix_* definitions for MSVC
 
 #ifndef FUNCTION_UNDER_TEST
 # define FUNCTION_UNDER_TEST gf_4vect_dot_prod_sse

--- a/erasure_code/gf_5vect_dot_prod_sse_test.c
+++ b/erasure_code/gf_5vect_dot_prod_sse_test.c
@@ -31,7 +31,7 @@
 #include <stdlib.h>
 #include <string.h>		// for memset, memcmp
 #include "erasure_code.h"
-#include "types.h"
+#include "types.h"	// include posix_* definitions for MSVC
 
 #ifndef FUNCTION_UNDER_TEST
 # define FUNCTION_UNDER_TEST gf_5vect_dot_prod_sse

--- a/erasure_code/gf_5vect_dot_prod_sse_test.c
+++ b/erasure_code/gf_5vect_dot_prod_sse_test.c
@@ -31,7 +31,7 @@
 #include <stdlib.h>
 #include <string.h>		// for memset, memcmp
 #include "erasure_code.h"
-#include "types.h"	// include posix_* definitions for MSVC
+#include "types.h"		// include posix_* definitions for MSVC
 
 #ifndef FUNCTION_UNDER_TEST
 # define FUNCTION_UNDER_TEST gf_5vect_dot_prod_sse

--- a/erasure_code/gf_6vect_dot_prod_sse_test.c
+++ b/erasure_code/gf_6vect_dot_prod_sse_test.c
@@ -31,7 +31,7 @@
 #include <stdlib.h>
 #include <string.h>		// for memset, memcmp
 #include "erasure_code.h"
-#include "types.h"
+#include "types.h"	// include posix_* definitions for MSVC
 
 #ifndef FUNCTION_UNDER_TEST
 # define FUNCTION_UNDER_TEST gf_6vect_dot_prod_sse

--- a/erasure_code/gf_6vect_dot_prod_sse_test.c
+++ b/erasure_code/gf_6vect_dot_prod_sse_test.c
@@ -31,7 +31,7 @@
 #include <stdlib.h>
 #include <string.h>		// for memset, memcmp
 #include "erasure_code.h"
-#include "types.h"	// include posix_* definitions for MSVC
+#include "types.h"		// include posix_* definitions for MSVC
 
 #ifndef FUNCTION_UNDER_TEST
 # define FUNCTION_UNDER_TEST gf_6vect_dot_prod_sse

--- a/erasure_code/gf_vect_dot_prod_base_test.c
+++ b/erasure_code/gf_vect_dot_prod_base_test.c
@@ -31,7 +31,7 @@
 #include <stdlib.h>
 #include <string.h>		// for memset, memcmp
 #include "erasure_code.h"
-#include "types.h"
+#include "types.h"	// include posix_* definitions for MSVC
 
 #define TEST_LEN 8192
 #define TEST_SIZE (TEST_LEN/2)

--- a/erasure_code/gf_vect_dot_prod_base_test.c
+++ b/erasure_code/gf_vect_dot_prod_base_test.c
@@ -31,7 +31,7 @@
 #include <stdlib.h>
 #include <string.h>		// for memset, memcmp
 #include "erasure_code.h"
-#include "types.h"	// include posix_* definitions for MSVC
+#include "types.h"		// include posix_* definitions for MSVC
 
 #define TEST_LEN 8192
 #define TEST_SIZE (TEST_LEN/2)

--- a/erasure_code/gf_vect_dot_prod_perf.c
+++ b/erasure_code/gf_vect_dot_prod_perf.c
@@ -32,7 +32,7 @@
 #include <string.h>		// for memset, memcmp
 #include "erasure_code.h"
 #include "test.h"
-#include "types.h"	// include posix_* definitions for MSVC
+#include "types.h"		// include posix_* definitions for MSVC
 
 #ifndef FUNCTION_UNDER_TEST
 # define FUNCTION_UNDER_TEST gf_vect_dot_prod

--- a/erasure_code/gf_vect_dot_prod_perf.c
+++ b/erasure_code/gf_vect_dot_prod_perf.c
@@ -32,6 +32,7 @@
 #include <string.h>		// for memset, memcmp
 #include "erasure_code.h"
 #include "test.h"
+#include "types.h"	// include posix_* definitions for MSVC
 
 #ifndef FUNCTION_UNDER_TEST
 # define FUNCTION_UNDER_TEST gf_vect_dot_prod

--- a/erasure_code/gf_vect_dot_prod_test.c
+++ b/erasure_code/gf_vect_dot_prod_test.c
@@ -31,7 +31,7 @@
 #include <stdlib.h>
 #include <string.h>		// for memset, memcmp
 #include "erasure_code.h"
-#include "types.h"	// include posix_* definitions for MSVC
+#include "types.h"		// include posix_* definitions for MSVC
 
 #ifndef FUNCTION_UNDER_TEST
 # define FUNCTION_UNDER_TEST gf_vect_dot_prod

--- a/erasure_code/gf_vect_dot_prod_test.c
+++ b/erasure_code/gf_vect_dot_prod_test.c
@@ -31,7 +31,7 @@
 #include <stdlib.h>
 #include <string.h>		// for memset, memcmp
 #include "erasure_code.h"
-#include "types.h"
+#include "types.h"	// include posix_* definitions for MSVC
 
 #ifndef FUNCTION_UNDER_TEST
 # define FUNCTION_UNDER_TEST gf_vect_dot_prod

--- a/erasure_code/gf_vect_mad_test.c
+++ b/erasure_code/gf_vect_mad_test.c
@@ -31,7 +31,7 @@
 #include <stdlib.h>
 #include <string.h>		// for memset, memcmp
 #include "erasure_code.h"
-#include "types.h"
+#include "types.h"	// include posix_* definitions for MSVC
 
 #ifndef ALIGN_SIZE
 # define ALIGN_SIZE 32

--- a/erasure_code/gf_vect_mad_test.c
+++ b/erasure_code/gf_vect_mad_test.c
@@ -31,7 +31,7 @@
 #include <stdlib.h>
 #include <string.h>		// for memset, memcmp
 #include "erasure_code.h"
-#include "types.h"	// include posix_* definitions for MSVC
+#include "types.h"		// include posix_* definitions for MSVC
 
 #ifndef ALIGN_SIZE
 # define ALIGN_SIZE 32

--- a/igzip/adler32_perf.c
+++ b/igzip/adler32_perf.c
@@ -33,7 +33,7 @@
 #include <stdint.h>
 #include "igzip_lib.h"
 #include "test.h"
-#include "types.h"	// include posix_* definitions for MSVC
+#include "types.h"		// include posix_* definitions for MSVC
 
 //#define CACHED_TEST
 #ifdef CACHED_TEST

--- a/igzip/adler32_perf.c
+++ b/igzip/adler32_perf.c
@@ -33,6 +33,7 @@
 #include <stdint.h>
 #include "igzip_lib.h"
 #include "test.h"
+#include "types.h"	// include posix_* definitions for MSVC
 
 //#define CACHED_TEST
 #ifdef CACHED_TEST

--- a/igzip/checksum32_funcs_test.c
+++ b/igzip/checksum32_funcs_test.c
@@ -33,7 +33,7 @@
 #include <stdint.h>
 #include "igzip_checksums.h"
 #include "checksum_test_ref.h"
-#include "types.h"	// include posix_* definitions for MSVC
+#include "types.h"		// include posix_* definitions for MSVC
 
 #ifndef TEST_SEED
 # define TEST_SEED 0x1234

--- a/igzip/checksum32_funcs_test.c
+++ b/igzip/checksum32_funcs_test.c
@@ -33,7 +33,7 @@
 #include <stdint.h>
 #include "igzip_checksums.h"
 #include "checksum_test_ref.h"
-#include "types.h"
+#include "types.h"	// include posix_* definitions for MSVC
 
 #ifndef TEST_SEED
 # define TEST_SEED 0x1234

--- a/igzip/igzip.c
+++ b/igzip/igzip.c
@@ -918,7 +918,7 @@ static inline void reset_match_history(struct isal_zstream *stream)
 		uint16_t hash_init_val;
 
 		hash_init_val = stream->total_in & 0xffff;
-		wmemset((wchar_t *) hash_table, hash_init_val,
+		wmemset((wchar_t *)hash_table, hash_init_val,
 			hash_table_size / sizeof(wchar_t));
 
 	} else if (sizeof(wchar_t) == 4) {
@@ -930,7 +930,7 @@ static inline void reset_match_history(struct isal_zstream *stream)
 		     rep_bits *= 2)
 			hash_init_val |= hash_init_val << rep_bits;
 
-		wmemset((wchar_t *) hash_table, hash_init_val,
+		wmemset((wchar_t *)hash_table, hash_init_val,
 			hash_table_size / sizeof(wchar_t));
 	} else {
 		if ((stream->total_in & 0xFFFF) == 0)
@@ -1136,7 +1136,7 @@ uint32_t isal_write_gzip_header(struct isal_zstream *stream, struct isal_gzip_he
 	return ISAL_DECOMP_OK;
 }
 
-uint32_t isal_write_zlib_header(struct isal_zstream * stream, struct isal_zlib_header * z_hdr)
+uint32_t isal_write_zlib_header(struct isal_zstream *stream, struct isal_zlib_header *z_hdr)
 {
 	uint32_t cmf, flg, dict_flag = 0, hdr_size = ZLIB_HDR_BASE;
 	uint8_t *out_buf = stream->next_out;

--- a/igzip/igzip.c
+++ b/igzip/igzip.c
@@ -918,7 +918,7 @@ static inline void reset_match_history(struct isal_zstream *stream)
 		uint16_t hash_init_val;
 
 		hash_init_val = stream->total_in & 0xffff;
-		wmemset((wchar_t *)hash_table, hash_init_val,
+		wmemset((wchar_t *) hash_table, hash_init_val,
 			hash_table_size / sizeof(wchar_t));
 
 	} else if (sizeof(wchar_t) == 4) {
@@ -930,7 +930,7 @@ static inline void reset_match_history(struct isal_zstream *stream)
 		     rep_bits *= 2)
 			hash_init_val |= hash_init_val << rep_bits;
 
-		wmemset((wchar_t *)hash_table, hash_init_val,
+		wmemset((wchar_t *) hash_table, hash_init_val,
 			hash_table_size / sizeof(wchar_t));
 	} else {
 		if ((stream->total_in & 0xFFFF) == 0)
@@ -1136,7 +1136,7 @@ uint32_t isal_write_gzip_header(struct isal_zstream *stream, struct isal_gzip_he
 	return ISAL_DECOMP_OK;
 }
 
-uint32_t isal_write_zlib_header(struct isal_zstream *stream, struct isal_zlib_header *z_hdr)
+uint32_t isal_write_zlib_header(struct isal_zstream * stream, struct isal_zlib_header * z_hdr)
 {
 	uint32_t cmf, flg, dict_flag = 0, hdr_size = ZLIB_HDR_BASE;
 	uint8_t *out_buf = stream->next_out;

--- a/mem/mem_zero_detect_perf.c
+++ b/mem/mem_zero_detect_perf.c
@@ -32,7 +32,7 @@
 #include <string.h>
 #include "mem_routines.h"
 #include "test.h"
-#include "types.h"
+#include "types.h"	// include posix_* definitions for MSVC
 
 #define TEST_LEN     8*1024
 #define TEST_TYPE_STR "_warm"

--- a/mem/mem_zero_detect_perf.c
+++ b/mem/mem_zero_detect_perf.c
@@ -32,7 +32,7 @@
 #include <string.h>
 #include "mem_routines.h"
 #include "test.h"
-#include "types.h"	// include posix_* definitions for MSVC
+#include "types.h"		// include posix_* definitions for MSVC
 
 #define TEST_LEN     8*1024
 #define TEST_TYPE_STR "_warm"

--- a/mem/mem_zero_detect_test.c
+++ b/mem/mem_zero_detect_test.c
@@ -32,7 +32,7 @@
 #include <stdlib.h>
 #include <limits.h>
 #include "mem_routines.h"
-#include "types.h"
+#include "types.h"	// include posix_* definitions for MSVC
 
 #define TEST_MEM  10*1024*1024
 #define TEST_LEN  8*1024

--- a/mem/mem_zero_detect_test.c
+++ b/mem/mem_zero_detect_test.c
@@ -32,7 +32,7 @@
 #include <stdlib.h>
 #include <limits.h>
 #include "mem_routines.h"
-#include "types.h"	// include posix_* definitions for MSVC
+#include "types.h"		// include posix_* definitions for MSVC
 
 #define TEST_MEM  10*1024*1024
 #define TEST_LEN  8*1024

--- a/programs/igzip_cli.c
+++ b/programs/igzip_cli.c
@@ -224,7 +224,7 @@ size_t get_filesize(FILE * fp)
 	fseeko(fp, 0, SEEK_END);
 #endif
 	fgetpos(fp, &pos);
-	file_size = *(size_t *)&pos;
+	file_size = *(size_t *) & pos;
 	fsetpos(fp, &pos_curr);	/* Restore position */
 
 	return file_size;

--- a/programs/igzip_cli.c
+++ b/programs/igzip_cli.c
@@ -224,7 +224,7 @@ size_t get_filesize(FILE * fp)
 	fseeko(fp, 0, SEEK_END);
 #endif
 	fgetpos(fp, &pos);
-	file_size = *(size_t *) & pos;
+	file_size = *(size_t *)&pos;
 	fsetpos(fp, &pos_curr);	/* Restore position */
 
 	return file_size;

--- a/raid/pq_check_test.c
+++ b/raid/pq_check_test.c
@@ -32,7 +32,7 @@
 #include<string.h>
 #include<stdlib.h>
 #include "raid.h"
-#include "types.h"
+#include "types.h"	// include posix_* definitions for MSVC
 
 #define TEST_SOURCES 16
 #define TEST_LEN     1024

--- a/raid/pq_check_test.c
+++ b/raid/pq_check_test.c
@@ -32,7 +32,7 @@
 #include<string.h>
 #include<stdlib.h>
 #include "raid.h"
-#include "types.h"	// include posix_* definitions for MSVC
+#include "types.h"		// include posix_* definitions for MSVC
 
 #define TEST_SOURCES 16
 #define TEST_LEN     1024

--- a/raid/pq_gen_perf.c
+++ b/raid/pq_gen_perf.c
@@ -33,7 +33,7 @@
 #include<stdlib.h>
 #include<sys/time.h>
 #include "raid.h"
-#include "test.h"
+#include "types.h"	// include posix_* definitions for MSVC
 
 //#define CACHED_TEST
 #ifdef CACHED_TEST

--- a/raid/pq_gen_perf.c
+++ b/raid/pq_gen_perf.c
@@ -31,8 +31,8 @@
 #include<stdint.h>
 #include<string.h>
 #include<stdlib.h>
-#include<sys/time.h>
 #include "raid.h"
+#include "test.h"
 #include "types.h"	// include posix_* definitions for MSVC
 
 //#define CACHED_TEST

--- a/raid/pq_gen_perf.c
+++ b/raid/pq_gen_perf.c
@@ -33,7 +33,7 @@
 #include<stdlib.h>
 #include "raid.h"
 #include "test.h"
-#include "types.h"	// include posix_* definitions for MSVC
+#include "types.h"		// include posix_* definitions for MSVC
 
 //#define CACHED_TEST
 #ifdef CACHED_TEST

--- a/raid/pq_gen_test.c
+++ b/raid/pq_gen_test.c
@@ -33,7 +33,7 @@
 #include<stdlib.h>
 #include<limits.h>
 #include "raid.h"
-#include "types.h"	// include posix_* definitions for MSVC
+#include "types.h"		// include posix_* definitions for MSVC
 
 #define TEST_SOURCES 16
 #define TEST_LEN     1024

--- a/raid/pq_gen_test.c
+++ b/raid/pq_gen_test.c
@@ -33,7 +33,7 @@
 #include<stdlib.h>
 #include<limits.h>
 #include "raid.h"
-#include "types.h"
+#include "types.h"	// include posix_* definitions for MSVC
 
 #define TEST_SOURCES 16
 #define TEST_LEN     1024

--- a/raid/xor_check_test.c
+++ b/raid/xor_check_test.c
@@ -32,7 +32,7 @@
 #include<string.h>
 #include<stdlib.h>
 #include "raid.h"
-#include "types.h"
+#include "types.h"	// include posix_* definitions for MSVC
 
 #define TEST_SOURCES 16
 #define TEST_LEN     1024

--- a/raid/xor_check_test.c
+++ b/raid/xor_check_test.c
@@ -32,7 +32,7 @@
 #include<string.h>
 #include<stdlib.h>
 #include "raid.h"
-#include "types.h"	// include posix_* definitions for MSVC
+#include "types.h"		// include posix_* definitions for MSVC
 
 #define TEST_SOURCES 16
 #define TEST_LEN     1024

--- a/raid/xor_example.c
+++ b/raid/xor_example.c
@@ -29,7 +29,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include "raid.h"
-#include "types.h"
+#include "types.h"	// include posix_* definitions for MSVC
 
 #define TEST_SOURCES 16
 #define TEST_LEN     16*1024

--- a/raid/xor_example.c
+++ b/raid/xor_example.c
@@ -29,7 +29,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include "raid.h"
-#include "types.h"	// include posix_* definitions for MSVC
+#include "types.h"		// include posix_* definitions for MSVC
 
 #define TEST_SOURCES 16
 #define TEST_LEN     16*1024

--- a/raid/xor_gen_perf.c
+++ b/raid/xor_gen_perf.c
@@ -31,7 +31,6 @@
 #include<stdint.h>
 #include<string.h>
 #include<stdlib.h>
-#include<sys/time.h>
 #include "raid.h"
 #include "test.h"
 #include "types.h"	// include posix_* definitions for MSVC

--- a/raid/xor_gen_perf.c
+++ b/raid/xor_gen_perf.c
@@ -33,7 +33,7 @@
 #include<stdlib.h>
 #include "raid.h"
 #include "test.h"
-#include "types.h"	// include posix_* definitions for MSVC
+#include "types.h"		// include posix_* definitions for MSVC
 
 //#define CACHED_TEST
 #ifdef CACHED_TEST

--- a/raid/xor_gen_perf.c
+++ b/raid/xor_gen_perf.c
@@ -34,6 +34,7 @@
 #include<sys/time.h>
 #include "raid.h"
 #include "test.h"
+#include "types.h"	// include posix_* definitions for MSVC
 
 //#define CACHED_TEST
 #ifdef CACHED_TEST

--- a/raid/xor_gen_test.c
+++ b/raid/xor_gen_test.c
@@ -32,7 +32,7 @@
 #include<string.h>
 #include<stdlib.h>
 #include "raid.h"
-#include "types.h"
+#include "types.h"	// include posix_* definitions for MSVC
 
 #define TEST_SOURCES 16
 #define TEST_LEN     1024

--- a/raid/xor_gen_test.c
+++ b/raid/xor_gen_test.c
@@ -32,7 +32,7 @@
 #include<string.h>
 #include<stdlib.h>
 #include "raid.h"
-#include "types.h"	// include posix_* definitions for MSVC
+#include "types.h"		// include posix_* definitions for MSVC
 
 #define TEST_SOURCES 16
 #define TEST_LEN     1024


### PR DESCRIPTION
I found that using nmake in an MSVC command prompt to build isa-l was running into several issues.

One is that `Makefile.nmake` is not up to date - I have removed some targets which no longer exist, and included crc64_funcs_perf. I have not tried to get it fully up to date, just get it to a state where with appropriately set CC / AS, all of the targets can build successfully. I want to do some looking into whether there's a better solution for integrating with the other makefiles.

There were also issues with posix C functions being used in various tests without including the appropriate definitions for MSVC, this is fixed by ensuring inclusion of `types.h`. I also remove `<sys/time.h>` from various tests, none of which actually needed this to be included.

`igzip_perf.exe` is a bit of a pain due to its inclusion of `getopt.h` - I have not tried to fix this yet.