### PR TITLE
igzip: cleanup perf test related code

### DIFF
--- a/igzip/igzip_build_hash_table_perf.c
+++ b/igzip/igzip_build_hash_table_perf.c
@@ -31,8 +31,7 @@ int main(int argc, char *argv[])
 	struct perf start;
 	BENCHMARK(&start, time, isal_deflate_hash(&stream, dict, dict_len));
 
-	printf("igzip_build_hash_table_perf:\n");
-	printf("  in_size=%u ", dict_len);
+	printf("igzip_build_hash_table_perf: in_size=%u ", dict_len);
 	perf_print(start, (long long)dict_len);
 
 	return 0;

--- a/igzip/igzip_hist_perf.c
+++ b/igzip/igzip_hist_perf.c
@@ -110,12 +110,15 @@ int main(int argc, char *argv[])
 	}
 
 	if (outbuf == NULL) {
+		free(inbuf);
 		fprintf(stderr, "Can't allocate output buffer memory\n");
 		exit(0);
 	}
 
 	avail_in = fread(inbuf, 1, infile_size, in);
 	if (avail_in != infile_size) {
+		free(inbuf);
+		free(outbuf);
 		fprintf(stderr, "Couldn't fit all of input file into buffer\n");
 		exit(0);
 	}
@@ -124,10 +127,13 @@ int main(int argc, char *argv[])
 	BENCHMARK(&start, BENCHMARK_TIME,
 		  isal_update_histogram(inbuf, infile_size, &histogram1));
 	printf("  file %s - in_size=%lu\n", argv[1], infile_size);
-	printf("igzip_file: ");
+	printf("igzip_hist_file: ");
 	perf_print(start, (long long)infile_size);
 
 	fclose(in);
 	fflush(0);
+	free(inbuf);
+	free(outbuf);
+
 	return 0;
 }

--- a/igzip/igzip_perf.c
+++ b/igzip/igzip_perf.c
@@ -51,7 +51,7 @@
 /* Limit output buffer size to 2 Gigabytes. Since stream->avail_out is a
  * uint32_t and there is no logic for handling an overflowed output buffer in
  * the perf test, this define must be less then 4 Gigabytes */
-#define MAX_COMPRESS_BUF_SIZE (1 << 31)
+#define MAX_COMPRESS_BUF_SIZE (1U << 31)
 
 int level_size_buf[10] = {
 #ifdef ISAL_DEF_LVL0_DEFAULT

--- a/igzip/igzip_semi_dyn_file_perf.c
+++ b/igzip/igzip_semi_dyn_file_perf.c
@@ -288,7 +288,7 @@ int main(int argc, char *argv[])
 	printf("  file %s - in_size=%lu out_size=%d iter=%d ratio=%3.1f%%\n", argv[optind],
 	       infile_size, stream.total_out, i, 100.0 * stream.total_out / infile_size);
 
-	printf("igzip_file: ");
+	printf("igzip_semi_dyn_file: ");
 	perf_print(start, (long long)infile_size);
 
 	if (out != NULL) {


### PR DESCRIPTION
This patch addresses some cppcheck issues.
And some minor changes to maintain code consistency.

- Cleanup cppcheck issues.
  [log][igzip/igzip_perf.c] (error) Shifting signed 32-bit value by 31 bits is undefined behaviour
  [log][igzip/igzip_hist_perf.c:132]: (error) Memory leak: outbuf

- Some minor changes to maintain code consistency.
  igzip/igzip_build_hash_table_perf.c
  igzip/igzip_hist_perf.c
  igzip/igzip_semi_dyn_file_perf.c

Change-Id: Icbbd8f70de689931c8a844d89e457af8d97c6793
Signed-off-by: Zhiyuan Zhu <zhiyuan.zhu@arm.com>