### PR TITLE
erasure_code: constify a bunch of "src" args

### DIFF
--- a/erasure_code/ec_base.c
+++ b/erasure_code/ec_base.c
@@ -299,7 +299,7 @@ void gf_vect_mad_base(int len, int vec, int vec_i,
 }
 
 void ec_encode_data_base(int len, int srcs, int dests, unsigned char *v,
-			 unsigned char **src, unsigned char **dest)
+			 const unsigned char **src, unsigned char **dest)
 {
 	int i, j, l;
 	unsigned char s;
@@ -316,7 +316,7 @@ void ec_encode_data_base(int len, int srcs, int dests, unsigned char *v,
 }
 
 void ec_encode_data_update_base(int len, int k, int rows, int vec_i, unsigned char *v,
-				unsigned char *data, unsigned char **dest)
+				const unsigned char *data, unsigned char **dest)
 {
 	int i, l;
 	unsigned char s;

--- a/erasure_code/ec_base_aliases.c
+++ b/erasure_code/ec_base_aliases.c
@@ -43,7 +43,7 @@ void gf_vect_mad(int len, int vec, int vec_i,
 }
 
 void ec_encode_data(int len, int srcs, int dests, unsigned char *v,
-		    unsigned char **src, unsigned char **dest)
+		    const unsigned char **src, unsigned char **dest)
 {
 	ec_encode_data_base(len, srcs, dests, v, src, dest);
 }

--- a/erasure_code/ec_highlevel_func.c
+++ b/erasure_code/ec_highlevel_func.c
@@ -30,8 +30,8 @@
 #include "erasure_code.h"
 
 #if __x86_64__  || __i386__ || _M_X64 || _M_IX86
-void ec_encode_data_sse(int len, int k, int rows, unsigned char *g_tbls, unsigned char **data,
-			unsigned char **coding)
+void ec_encode_data_sse(int len, int k, int rows, unsigned char *g_tbls,
+			const unsigned char **data, unsigned char **coding)
 {
 
 	if (len < 16) {
@@ -67,8 +67,8 @@ void ec_encode_data_sse(int len, int k, int rows, unsigned char *g_tbls, unsigne
 
 }
 
-void ec_encode_data_avx(int len, int k, int rows, unsigned char *g_tbls, unsigned char **data,
-			unsigned char **coding)
+void ec_encode_data_avx(int len, int k, int rows, unsigned char *g_tbls,
+			const unsigned char **data, unsigned char **coding)
 {
 	if (len < 16) {
 		ec_encode_data_base(len, k, rows, g_tbls, data, coding);
@@ -103,8 +103,8 @@ void ec_encode_data_avx(int len, int k, int rows, unsigned char *g_tbls, unsigne
 
 }
 
-void ec_encode_data_avx2(int len, int k, int rows, unsigned char *g_tbls, unsigned char **data,
-			 unsigned char **coding)
+void ec_encode_data_avx2(int len, int k, int rows, unsigned char *g_tbls,
+			 const unsigned char **data, unsigned char **coding)
 {
 
 	if (len < 32) {
@@ -142,33 +142,33 @@ void ec_encode_data_avx2(int len, int k, int rows, unsigned char *g_tbls, unsign
 
 #ifdef HAVE_AS_KNOWS_AVX512
 
-extern int gf_vect_dot_prod_avx512(int len, int k, unsigned char *g_tbls, unsigned char **data,
-				   unsigned char *dest);
+extern int gf_vect_dot_prod_avx512(int len, int k, unsigned char *g_tbls,
+				   const unsigned char **data, unsigned char *dest);
 extern int gf_2vect_dot_prod_avx512(int len, int k, unsigned char *g_tbls,
-				    unsigned char **data, unsigned char **coding);
+				    const unsigned char **data, unsigned char **coding);
 extern int gf_3vect_dot_prod_avx512(int len, int k, unsigned char *g_tbls,
-				    unsigned char **data, unsigned char **coding);
+				    const unsigned char **data, unsigned char **coding);
 extern int gf_4vect_dot_prod_avx512(int len, int k, unsigned char *g_tbls,
-				    unsigned char **data, unsigned char **coding);
+				    const unsigned char **data, unsigned char **coding);
 extern int gf_5vect_dot_prod_avx512(int len, int k, unsigned char *g_tbls,
-				    unsigned char **data, unsigned char **coding);
+				    const unsigned char **data, unsigned char **coding);
 extern int gf_6vect_dot_prod_avx512(int len, int k, unsigned char *g_tbls,
-				    unsigned char **data, unsigned char **coding);
+				    const unsigned char **data, unsigned char **coding);
 extern void gf_vect_mad_avx512(int len, int vec, int vec_i, unsigned char *gftbls,
-			       unsigned char *src, unsigned char *dest);
+			       const unsigned char *src, unsigned char *dest);
 extern void gf_2vect_mad_avx512(int len, int vec, int vec_i, unsigned char *gftbls,
-				unsigned char *src, unsigned char **dest);
+				const unsigned char *src, unsigned char **dest);
 extern void gf_3vect_mad_avx512(int len, int vec, int vec_i, unsigned char *gftbls,
-				unsigned char *src, unsigned char **dest);
+				const unsigned char *src, unsigned char **dest);
 extern void gf_4vect_mad_avx512(int len, int vec, int vec_i, unsigned char *gftbls,
-				unsigned char *src, unsigned char **dest);
+				const unsigned char *src, unsigned char **dest);
 extern void gf_5vect_mad_avx512(int len, int vec, int vec_i, unsigned char *gftbls,
-				unsigned char *src, unsigned char **dest);
+				const unsigned char *src, unsigned char **dest);
 extern void gf_6vect_mad_avx512(int len, int vec, int vec_i, unsigned char *gftbls,
-				unsigned char *src, unsigned char **dest);
+				const unsigned char *src, unsigned char **dest);
 
 void ec_encode_data_avx512(int len, int k, int rows, unsigned char *g_tbls,
-			   unsigned char **data, unsigned char **coding)
+			   const unsigned char **data, unsigned char **coding)
 {
 
 	if (len < 64) {
@@ -243,7 +243,7 @@ void ec_encode_data_update_avx512(int len, int k, int rows, int vec_i, unsigned 
 #if __WORDSIZE == 64 || _WIN64 || __x86_64__
 
 void ec_encode_data_update_sse(int len, int k, int rows, int vec_i, unsigned char *g_tbls,
-			       unsigned char *data, unsigned char **coding)
+			       const unsigned char *data, unsigned char **coding)
 {
 	if (len < 16) {
 		ec_encode_data_update_base(len, k, rows, vec_i, g_tbls, data, coding);
@@ -282,7 +282,7 @@ void ec_encode_data_update_sse(int len, int k, int rows, int vec_i, unsigned cha
 }
 
 void ec_encode_data_update_avx(int len, int k, int rows, int vec_i, unsigned char *g_tbls,
-			       unsigned char *data, unsigned char **coding)
+			       const unsigned char *data, unsigned char **coding)
 {
 	if (len < 16) {
 		ec_encode_data_update_base(len, k, rows, vec_i, g_tbls, data, coding);
@@ -320,7 +320,7 @@ void ec_encode_data_update_avx(int len, int k, int rows, int vec_i, unsigned cha
 }
 
 void ec_encode_data_update_avx2(int len, int k, int rows, int vec_i, unsigned char *g_tbls,
-				unsigned char *data, unsigned char **coding)
+				const unsigned char *data, unsigned char **coding)
 {
 	if (len < 32) {
 		ec_encode_data_update_base(len, k, rows, vec_i, g_tbls, data, coding);

--- a/erasure_code/erasure_code_base_test.c
+++ b/erasure_code/erasure_code_base_test.c
@@ -282,7 +282,7 @@ int main(int argc, char *argv[])
 
 	// Perform matrix dot_prod for EC encoding
 	// using g_tbls from encode matrix encode_matrix
-	ec_encode_data_base(TEST_LEN, k, m - k, g_tbls, buffs, &buffs[k]);
+	ec_encode_data_base(TEST_LEN, k, m - k, g_tbls, (const u8 **)buffs, &buffs[k]);
 
 	// Choose random buffers to be in erasure
 	memset(src_in_err, 0, TEST_SOURCES);
@@ -305,7 +305,7 @@ int main(int argc, char *argv[])
 
 	// Recover data
 	ec_init_tables(k, nerrs, decode_matrix, g_tbls);
-	ec_encode_data_base(TEST_LEN, k, nerrs, g_tbls, recov, &temp_buffs[k]);
+	ec_encode_data_base(TEST_LEN, k, nerrs, g_tbls, (const u8 **)recov, &temp_buffs[k]);
 	for (i = 0; i < nerrs; i++) {
 
 		if (0 != memcmp(temp_buffs[k + i], buffs[src_err_list[i]], TEST_LEN)) {
@@ -350,7 +350,7 @@ int main(int argc, char *argv[])
 
 	// Perform matrix dot_prod for EC encoding
 	// using g_tbls from encode matrix encode_matrix
-	ec_encode_data_base(TEST_LEN, k, m - k, g_tbls, buffs, &buffs[k]);
+	ec_encode_data_base(TEST_LEN, k, m - k, g_tbls, (const u8 **)buffs, &buffs[k]);
 
 	// Choose random buffers to be in erasure
 	memset(src_in_err, 0, TEST_SOURCES);
@@ -373,7 +373,7 @@ int main(int argc, char *argv[])
 
 	// Recover data
 	ec_init_tables(k, nerrs, decode_matrix, g_tbls);
-	ec_encode_data_base(TEST_LEN, k, nerrs, g_tbls, recov, &temp_buffs[k]);
+	ec_encode_data_base(TEST_LEN, k, nerrs, g_tbls, (const u8 **)recov, &temp_buffs[k]);
 	for (i = 0; i < nerrs; i++) {
 
 		if (0 != memcmp(temp_buffs[k + i], buffs[src_err_list[i]], TEST_LEN)) {
@@ -420,7 +420,7 @@ int main(int argc, char *argv[])
 		ec_init_tables(k, m - k, &encode_matrix[k * k], g_tbls);
 		// Perform matrix dot_prod for EC encoding
 		// using g_tbls from encode matrix a
-		ec_encode_data_base(TEST_LEN, k, m - k, g_tbls, buffs, &buffs[k]);
+		ec_encode_data_base(TEST_LEN, k, m - k, g_tbls, (const u8 **)buffs, &buffs[k]);
 
 		// Random errors
 		memset(src_in_err, 0, TEST_SOURCES);
@@ -443,7 +443,8 @@ int main(int argc, char *argv[])
 
 		// Recover data
 		ec_init_tables(k, nerrs, decode_matrix, g_tbls);
-		ec_encode_data_base(TEST_LEN, k, nerrs, g_tbls, recov, &temp_buffs[k]);
+		ec_encode_data_base(TEST_LEN, k, nerrs, g_tbls, (const u8 **)recov,
+				    &temp_buffs[k]);
 
 		for (i = 0; i < nerrs; i++) {
 
@@ -503,7 +504,7 @@ int main(int argc, char *argv[])
 			ec_init_tables(k, m - k, &encode_matrix[k * k], g_tbls);
 			// Perform matrix dot_prod for EC encoding
 			// using g_tbls from encode matrix a
-			ec_encode_data_base(size, k, m - k, g_tbls, efence_buffs,
+			ec_encode_data_base(size, k, m - k, g_tbls, (const u8 **)efence_buffs,
 					    &efence_buffs[k]);
 
 			// Random errors
@@ -527,7 +528,8 @@ int main(int argc, char *argv[])
 
 			// Recover data
 			ec_init_tables(k, nerrs, decode_matrix, g_tbls);
-			ec_encode_data_base(size, k, nerrs, g_tbls, recov, &temp_buffs[k]);
+			ec_encode_data_base(size, k, nerrs, g_tbls, (const u8 **)recov,
+					    &temp_buffs[k]);
 
 			for (i = 0; i < nerrs; i++) {
 
@@ -596,7 +598,7 @@ int main(int argc, char *argv[])
 		ec_init_tables(k, m - k, &encode_matrix[k * k], g_tbls);
 		// Perform matrix dot_prod for EC encoding
 		// using g_tbls from encode matrix a
-		ec_encode_data_base(size, k, m - k, g_tbls, ubuffs, &ubuffs[k]);
+		ec_encode_data_base(size, k, m - k, g_tbls, (const u8 **)ubuffs, &ubuffs[k]);
 
 		// Random errors
 		memset(src_in_err, 0, TEST_SOURCES);
@@ -619,7 +621,8 @@ int main(int argc, char *argv[])
 
 		// Recover data
 		ec_init_tables(k, nerrs, decode_matrix, g_tbls);
-		ec_encode_data_base(size, k, nerrs, g_tbls, recov, &temp_ubuffs[k]);
+		ec_encode_data_base(size, k, nerrs, g_tbls, (const u8 **)recov,
+				    &temp_ubuffs[k]);
 
 		for (i = 0; i < nerrs; i++) {
 
@@ -708,7 +711,7 @@ int main(int argc, char *argv[])
 		ec_init_tables(k, m - k, &encode_matrix[k * k], g_tbls);
 		// Perform matrix dot_prod for EC encoding
 		// using g_tbls from encode matrix a
-		ec_encode_data_base(size, k, m - k, g_tbls, buffs, &buffs[k]);
+		ec_encode_data_base(size, k, m - k, g_tbls, (const u8 **)buffs, &buffs[k]);
 
 		// Random errors
 		memset(src_in_err, 0, TEST_SOURCES);
@@ -730,7 +733,8 @@ int main(int argc, char *argv[])
 
 		// Recover data
 		ec_init_tables(k, nerrs, decode_matrix, g_tbls);
-		ec_encode_data_base(size, k, nerrs, g_tbls, recov, &temp_buffs[k]);
+		ec_encode_data_base(size, k, nerrs, g_tbls, (const u8 **)recov,
+				    &temp_buffs[k]);
 
 		for (i = 0; i < nerrs; i++) {
 

--- a/erasure_code/erasure_code_test.c
+++ b/erasure_code/erasure_code_test.c
@@ -283,7 +283,7 @@ int main(int argc, char *argv[])
 
 	// Perform matrix dot_prod for EC encoding
 	// using g_tbls from encode matrix encode_matrix
-	ec_encode_data(TEST_LEN, k, m - k, g_tbls, buffs, &buffs[k]);
+	ec_encode_data(TEST_LEN, k, m - k, g_tbls, (const u8 **)buffs, &buffs[k]);
 
 	// Choose random buffers to be in erasure
 	memset(src_in_err, 0, TEST_SOURCES);
@@ -306,7 +306,7 @@ int main(int argc, char *argv[])
 
 	// Recover data
 	ec_init_tables(k, nerrs, decode_matrix, g_tbls);
-	ec_encode_data(TEST_LEN, k, nerrs, g_tbls, recov, &temp_buffs[k]);
+	ec_encode_data(TEST_LEN, k, nerrs, g_tbls, (const u8 **)recov, &temp_buffs[k]);
 	for (i = 0; i < nerrs; i++) {
 
 		if (0 != memcmp(temp_buffs[k + i], buffs[src_err_list[i]], TEST_LEN)) {
@@ -351,7 +351,7 @@ int main(int argc, char *argv[])
 
 	// Perform matrix dot_prod for EC encoding
 	// using g_tbls from encode matrix encode_matrix
-	ec_encode_data(TEST_LEN, k, m - k, g_tbls, buffs, &buffs[k]);
+	ec_encode_data(TEST_LEN, k, m - k, g_tbls, (const u8 **)buffs, &buffs[k]);
 
 	// Choose random buffers to be in erasure
 	memset(src_in_err, 0, TEST_SOURCES);
@@ -374,7 +374,7 @@ int main(int argc, char *argv[])
 
 	// Recover data
 	ec_init_tables(k, nerrs, decode_matrix, g_tbls);
-	ec_encode_data(TEST_LEN, k, nerrs, g_tbls, recov, &temp_buffs[k]);
+	ec_encode_data(TEST_LEN, k, nerrs, g_tbls, (const u8 **)recov, &temp_buffs[k]);
 	for (i = 0; i < nerrs; i++) {
 
 		if (0 != memcmp(temp_buffs[k + i], buffs[src_err_list[i]], TEST_LEN)) {
@@ -421,7 +421,7 @@ int main(int argc, char *argv[])
 		ec_init_tables(k, m - k, &encode_matrix[k * k], g_tbls);
 		// Perform matrix dot_prod for EC encoding
 		// using g_tbls from encode matrix a
-		ec_encode_data(TEST_LEN, k, m - k, g_tbls, buffs, &buffs[k]);
+		ec_encode_data(TEST_LEN, k, m - k, g_tbls, (const u8 **)buffs, &buffs[k]);
 
 		// Random errors
 		memset(src_in_err, 0, TEST_SOURCES);
@@ -444,7 +444,7 @@ int main(int argc, char *argv[])
 
 		// Recover data
 		ec_init_tables(k, nerrs, decode_matrix, g_tbls);
-		ec_encode_data(TEST_LEN, k, nerrs, g_tbls, recov, &temp_buffs[k]);
+		ec_encode_data(TEST_LEN, k, nerrs, g_tbls, (const u8 **)recov, &temp_buffs[k]);
 
 		for (i = 0; i < nerrs; i++) {
 
@@ -504,7 +504,8 @@ int main(int argc, char *argv[])
 			ec_init_tables(k, m - k, &encode_matrix[k * k], g_tbls);
 			// Perform matrix dot_prod for EC encoding
 			// using g_tbls from encode matrix a
-			ec_encode_data(size, k, m - k, g_tbls, efence_buffs, &efence_buffs[k]);
+			ec_encode_data(size, k, m - k, g_tbls, (const u8 **)efence_buffs,
+				       &efence_buffs[k]);
 
 			// Random errors
 			memset(src_in_err, 0, TEST_SOURCES);
@@ -527,7 +528,8 @@ int main(int argc, char *argv[])
 
 			// Recover data
 			ec_init_tables(k, nerrs, decode_matrix, g_tbls);
-			ec_encode_data(size, k, nerrs, g_tbls, recov, &temp_buffs[k]);
+			ec_encode_data(size, k, nerrs, g_tbls, (const u8 **)recov,
+				       &temp_buffs[k]);
 
 			for (i = 0; i < nerrs; i++) {
 
@@ -596,7 +598,7 @@ int main(int argc, char *argv[])
 		ec_init_tables(k, m - k, &encode_matrix[k * k], g_tbls);
 		// Perform matrix dot_prod for EC encoding
 		// using g_tbls from encode matrix a
-		ec_encode_data(size, k, m - k, g_tbls, ubuffs, &ubuffs[k]);
+		ec_encode_data(size, k, m - k, g_tbls, (const u8 **)ubuffs, &ubuffs[k]);
 
 		// Random errors
 		memset(src_in_err, 0, TEST_SOURCES);
@@ -619,7 +621,7 @@ int main(int argc, char *argv[])
 
 		// Recover data
 		ec_init_tables(k, nerrs, decode_matrix, g_tbls);
-		ec_encode_data(size, k, nerrs, g_tbls, recov, &temp_ubuffs[k]);
+		ec_encode_data(size, k, nerrs, g_tbls, (const u8 **)recov, &temp_ubuffs[k]);
 
 		for (i = 0; i < nerrs; i++) {
 
@@ -708,7 +710,7 @@ int main(int argc, char *argv[])
 		ec_init_tables(k, m - k, &encode_matrix[k * k], g_tbls);
 		// Perform matrix dot_prod for EC encoding
 		// using g_tbls from encode matrix a
-		ec_encode_data(size, k, m - k, g_tbls, buffs, &buffs[k]);
+		ec_encode_data(size, k, m - k, g_tbls, (const u8 **)buffs, &buffs[k]);
 
 		// Random errors
 		memset(src_in_err, 0, TEST_SOURCES);
@@ -730,7 +732,7 @@ int main(int argc, char *argv[])
 
 		// Recover data
 		ec_init_tables(k, nerrs, decode_matrix, g_tbls);
-		ec_encode_data(size, k, nerrs, g_tbls, recov, &temp_buffs[k]);
+		ec_encode_data(size, k, nerrs, g_tbls, (const u8 **)recov, &temp_buffs[k]);
 
 		for (i = 0; i < nerrs; i++) {
 

--- a/erasure_code/erasure_code_update_test.c
+++ b/erasure_code/erasure_code_update_test.c
@@ -310,7 +310,7 @@ int main(int argc, char *argv[])
 
 	// Perform matrix dot_prod for EC encoding
 	// using g_tbls from encode matrix encode_matrix
-	REF_FUNCTION(TEST_LEN, k, m - k, g_tbls, buffs, &buffs[k]);
+	REF_FUNCTION(TEST_LEN, k, m - k, g_tbls, (const unsigned char **)buffs, &buffs[k]);
 	for (i = 0; i < k; i++) {
 		FUNCTION_UNDER_TEST(TEST_LEN, k, m - k, i, g_tbls, update_buffs[i],
 				    &update_buffs[k]);
@@ -346,7 +346,8 @@ int main(int argc, char *argv[])
 
 	// Recover data
 	ec_init_tables(k, nerrs, decode_matrix, g_tbls);
-	REF_FUNCTION(TEST_LEN, k, nerrs, g_tbls, recov, &temp_buffs[k]);
+	REF_FUNCTION(TEST_LEN, k, nerrs, g_tbls, (const unsigned char **)recov,
+		     &temp_buffs[k]);
 	for (i = 0; i < nerrs; i++) {
 
 		if (0 != memcmp(temp_buffs[k + i], update_buffs[src_err_list[i]], TEST_LEN)) {
@@ -400,7 +401,7 @@ int main(int argc, char *argv[])
 
 	// Perform matrix dot_prod for EC encoding
 	// using g_tbls from encode matrix encode_matrix
-	REF_FUNCTION(TEST_LEN, k, m - k, g_tbls, buffs, &buffs[k]);
+	REF_FUNCTION(TEST_LEN, k, m - k, g_tbls, (const unsigned char **)buffs, &buffs[k]);
 	for (i = 0; i < k; i++) {
 		FUNCTION_UNDER_TEST(TEST_LEN, k, m - k, i, g_tbls, update_buffs[i],
 				    &update_buffs[k]);
@@ -497,7 +498,8 @@ int main(int argc, char *argv[])
 		ec_init_tables(k, m - k, &encode_matrix[k * k], g_tbls);
 		// Perform matrix dot_prod for EC encoding
 		// using g_tbls from encode matrix a
-		REF_FUNCTION(TEST_LEN, k, m - k, g_tbls, buffs, &buffs[k]);
+		REF_FUNCTION(TEST_LEN, k, m - k, g_tbls, (const unsigned char **)buffs,
+			     &buffs[k]);
 		for (i = 0; i < k; i++) {
 			FUNCTION_UNDER_TEST(TEST_LEN, k, m - k, i, g_tbls, update_buffs[i],
 					    &update_buffs[k]);
@@ -614,7 +616,8 @@ int main(int argc, char *argv[])
 			ec_init_tables(k, m - k, &encode_matrix[k * k], g_tbls);
 			// Perform matrix dot_prod for EC encoding
 			// using g_tbls from encode matrix a
-			REF_FUNCTION(size, k, m - k, g_tbls, efence_buffs, &efence_buffs[k]);
+			REF_FUNCTION(size, k, m - k, g_tbls,
+				     (const unsigned char **)efence_buffs, &efence_buffs[k]);
 			for (i = 0; i < k; i++) {
 				FUNCTION_UNDER_TEST(size, k, m - k, i, g_tbls,
 						    efence_update_buffs[i],
@@ -741,7 +744,8 @@ int main(int argc, char *argv[])
 		ec_init_tables(k, m - k, &encode_matrix[k * k], g_tbls);
 		// Perform matrix dot_prod for EC encoding
 		// using g_tbls from encode matrix a
-		REF_FUNCTION(size, k, m - k, g_tbls, ubuffs, &ubuffs[k]);
+		REF_FUNCTION(size, k, m - k, g_tbls, (const unsigned char **)ubuffs,
+			     &ubuffs[k]);
 		for (i = 0; i < k; i++) {
 			FUNCTION_UNDER_TEST(size, k, m - k, i, g_tbls, update_ubuffs[i],
 					    &update_ubuffs[k]);
@@ -882,7 +886,7 @@ int main(int argc, char *argv[])
 		ec_init_tables(k, m - k, &encode_matrix[k * k], g_tbls);
 		// Perform matrix dot_prod for EC encoding
 		// using g_tbls from encode matrix a
-		REF_FUNCTION(size, k, m - k, g_tbls, buffs, &buffs[k]);
+		REF_FUNCTION(size, k, m - k, g_tbls, (const unsigned char **)buffs, &buffs[k]);
 		for (i = 0; i < k; i++) {
 			FUNCTION_UNDER_TEST(size, k, m - k, i, g_tbls, update_buffs[i],
 					    &update_buffs[k]);

--- a/erasure_code/gf_2vect_dot_prod_sse_test.c
+++ b/erasure_code/gf_2vect_dot_prod_sse_test.c
@@ -69,7 +69,7 @@
 typedef unsigned char u8;
 
 extern void FUNCTION_UNDER_TEST(int len, int vlen, unsigned char *gftbls,
-				unsigned char **src, unsigned char **dest);
+				const unsigned char **src, unsigned char **dest);
 
 void dump(unsigned char *buf, int len)
 {
@@ -178,7 +178,7 @@ int main(int argc, char *argv[])
 	gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[32 * TEST_SOURCES], buffs,
 			      dest_ref2);
 
-	FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, g_tbls, buffs, dest_ptrs);
+	FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, g_tbls, (const u8 **)buffs, dest_ptrs);
 
 	if (0 != memcmp(dest_ref1, dest1, TEST_LEN)) {
 		printf("Fail zero " xstr(FUNCTION_UNDER_TEST) " test1\n");
@@ -222,7 +222,8 @@ int main(int argc, char *argv[])
 		gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[32 * TEST_SOURCES],
 				      buffs, dest_ref2);
 
-		FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, g_tbls, buffs, dest_ptrs);
+		FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, g_tbls, (const u8 **)buffs,
+				    dest_ptrs);
 
 		if (0 != memcmp(dest_ref1, dest1, TEST_LEN)) {
 			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test1 %d\n", rtest);
@@ -267,7 +268,8 @@ int main(int argc, char *argv[])
 			gf_vect_dot_prod_base(TEST_LEN, srcs, &g_tbls[32 * srcs], buffs,
 					      dest_ref2);
 
-			FUNCTION_UNDER_TEST(TEST_LEN, srcs, g_tbls, buffs, dest_ptrs);
+			FUNCTION_UNDER_TEST(TEST_LEN, srcs, g_tbls, (const u8 **)buffs,
+					    dest_ptrs);
 
 			if (0 != memcmp(dest_ref1, dest1, TEST_LEN)) {
 				printf("Fail rand " xstr(FUNCTION_UNDER_TEST)
@@ -318,7 +320,8 @@ int main(int argc, char *argv[])
 		gf_vect_dot_prod_base(size, TEST_SOURCES, &g_tbls[32 * TEST_SOURCES],
 				      efence_buffs, dest_ref2);
 
-		FUNCTION_UNDER_TEST(size, TEST_SOURCES, g_tbls, efence_buffs, dest_ptrs);
+		FUNCTION_UNDER_TEST(size, TEST_SOURCES, g_tbls, (const u8 **)efence_buffs,
+				    dest_ptrs);
 
 		if (0 != memcmp(dest_ref1, dest1, size)) {
 			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test1 %d\n", rtest);
@@ -379,7 +382,7 @@ int main(int argc, char *argv[])
 		gf_vect_dot_prod_base(size, srcs, &g_tbls[0], ubuffs, dest_ref1);
 		gf_vect_dot_prod_base(size, srcs, &g_tbls[32 * srcs], ubuffs, dest_ref2);
 
-		FUNCTION_UNDER_TEST(size, srcs, g_tbls, ubuffs, udest_ptrs);
+		FUNCTION_UNDER_TEST(size, srcs, g_tbls, (const u8 **)ubuffs, udest_ptrs);
 
 		if (memcmp(dest_ref1, udest_ptrs[0], size)) {
 			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test ualign srcs=%d\n",
@@ -450,7 +453,7 @@ int main(int argc, char *argv[])
 		gf_vect_dot_prod_base(size, srcs, &g_tbls[0], buffs, dest_ref1);
 		gf_vect_dot_prod_base(size, srcs, &g_tbls[32 * srcs], buffs, dest_ref2);
 
-		FUNCTION_UNDER_TEST(size, srcs, g_tbls, buffs, dest_ptrs);
+		FUNCTION_UNDER_TEST(size, srcs, g_tbls, (const u8 **)buffs, dest_ptrs);
 
 		if (memcmp(dest_ref1, dest_ptrs[0], size)) {
 			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test ualign len=%d\n",

--- a/erasure_code/gf_3vect_dot_prod_sse_test.c
+++ b/erasure_code/gf_3vect_dot_prod_sse_test.c
@@ -69,7 +69,7 @@
 typedef unsigned char u8;
 
 extern void FUNCTION_UNDER_TEST(int len, int vlen, unsigned char *gftbls,
-				unsigned char **src, unsigned char **dest);
+				const unsigned char **src, unsigned char **dest);
 
 void dump(unsigned char *buf, int len)
 {
@@ -196,7 +196,7 @@ int main(int argc, char *argv[])
 	gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[64 * TEST_SOURCES], buffs,
 			      dest_ref3);
 
-	FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, g_tbls, buffs, dest_ptrs);
+	FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, g_tbls, (const u8 **)buffs, dest_ptrs);
 
 	if (0 != memcmp(dest_ref1, dest1, TEST_LEN)) {
 		printf("Fail zero" xstr(FUNCTION_UNDER_TEST) " test1\n");
@@ -253,7 +253,8 @@ int main(int argc, char *argv[])
 		gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[64 * TEST_SOURCES],
 				      buffs, dest_ref3);
 
-		FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, g_tbls, buffs, dest_ptrs);
+		FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, g_tbls, (const u8 **)buffs,
+				    dest_ptrs);
 
 		if (0 != memcmp(dest_ref1, dest1, TEST_LEN)) {
 			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test1 %d\n", rtest);
@@ -311,7 +312,8 @@ int main(int argc, char *argv[])
 			gf_vect_dot_prod_base(TEST_LEN, srcs, &g_tbls[64 * srcs], buffs,
 					      dest_ref3);
 
-			FUNCTION_UNDER_TEST(TEST_LEN, srcs, g_tbls, buffs, dest_ptrs);
+			FUNCTION_UNDER_TEST(TEST_LEN, srcs, g_tbls, (const u8 **)buffs,
+					    dest_ptrs);
 
 			if (0 != memcmp(dest_ref1, dest1, TEST_LEN)) {
 				printf("Fail rand " xstr(FUNCTION_UNDER_TEST)
@@ -376,7 +378,8 @@ int main(int argc, char *argv[])
 		gf_vect_dot_prod_base(size, TEST_SOURCES, &g_tbls[64 * TEST_SOURCES],
 				      efence_buffs, dest_ref3);
 
-		FUNCTION_UNDER_TEST(size, TEST_SOURCES, g_tbls, efence_buffs, dest_ptrs);
+		FUNCTION_UNDER_TEST(size, TEST_SOURCES, g_tbls, (const u8 **)efence_buffs,
+				    dest_ptrs);
 
 		if (0 != memcmp(dest_ref1, dest1, size)) {
 			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test1 %d\n", rtest);
@@ -452,7 +455,7 @@ int main(int argc, char *argv[])
 		gf_vect_dot_prod_base(size, srcs, &g_tbls[32 * srcs], ubuffs, dest_ref2);
 		gf_vect_dot_prod_base(size, srcs, &g_tbls[64 * srcs], ubuffs, dest_ref3);
 
-		FUNCTION_UNDER_TEST(size, srcs, g_tbls, ubuffs, udest_ptrs);
+		FUNCTION_UNDER_TEST(size, srcs, g_tbls, (const u8 **)ubuffs, udest_ptrs);
 
 		if (memcmp(dest_ref1, udest_ptrs[0], size)) {
 			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test ualign srcs=%d\n",
@@ -546,7 +549,7 @@ int main(int argc, char *argv[])
 		gf_vect_dot_prod_base(size, srcs, &g_tbls[32 * srcs], buffs, dest_ref2);
 		gf_vect_dot_prod_base(size, srcs, &g_tbls[64 * srcs], buffs, dest_ref3);
 
-		FUNCTION_UNDER_TEST(size, srcs, g_tbls, buffs, dest_ptrs);
+		FUNCTION_UNDER_TEST(size, srcs, g_tbls, (const u8 **)buffs, dest_ptrs);
 
 		if (memcmp(dest_ref1, dest_ptrs[0], size)) {
 			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test ualign len=%d\n",

--- a/erasure_code/gf_4vect_dot_prod_sse_test.c
+++ b/erasure_code/gf_4vect_dot_prod_sse_test.c
@@ -69,7 +69,7 @@
 typedef unsigned char u8;
 
 extern void FUNCTION_UNDER_TEST(int len, int vlen, unsigned char *gftbls,
-				unsigned char **src, unsigned char **dest);
+				const unsigned char **src, unsigned char **dest);
 
 void dump(unsigned char *buf, int len)
 {
@@ -216,7 +216,7 @@ int main(int argc, char *argv[])
 	gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[96 * TEST_SOURCES], buffs,
 			      dest_ref4);
 
-	FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, g_tbls, buffs, dest_ptrs);
+	FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, g_tbls, (const u8 **)buffs, dest_ptrs);
 
 	if (0 != memcmp(dest_ref1, dest1, TEST_LEN)) {
 		printf("Fail zero " xstr(FUNCTION_UNDER_TEST) " test1\n");
@@ -286,7 +286,8 @@ int main(int argc, char *argv[])
 		gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[96 * TEST_SOURCES],
 				      buffs, dest_ref4);
 
-		FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, g_tbls, buffs, dest_ptrs);
+		FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, g_tbls, (const u8 **)buffs,
+				    dest_ptrs);
 
 		if (0 != memcmp(dest_ref1, dest1, TEST_LEN)) {
 			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test1 %d\n", rtest);
@@ -357,7 +358,8 @@ int main(int argc, char *argv[])
 			gf_vect_dot_prod_base(TEST_LEN, srcs, &g_tbls[96 * srcs], buffs,
 					      dest_ref4);
 
-			FUNCTION_UNDER_TEST(TEST_LEN, srcs, g_tbls, buffs, dest_ptrs);
+			FUNCTION_UNDER_TEST(TEST_LEN, srcs, g_tbls, (const u8 **)buffs,
+					    dest_ptrs);
 
 			if (0 != memcmp(dest_ref1, dest1, TEST_LEN)) {
 				printf("Fail rand " xstr(FUNCTION_UNDER_TEST)
@@ -436,7 +438,8 @@ int main(int argc, char *argv[])
 		gf_vect_dot_prod_base(size, TEST_SOURCES, &g_tbls[96 * TEST_SOURCES],
 				      efence_buffs, dest_ref4);
 
-		FUNCTION_UNDER_TEST(size, TEST_SOURCES, g_tbls, efence_buffs, dest_ptrs);
+		FUNCTION_UNDER_TEST(size, TEST_SOURCES, g_tbls, (const u8 **)efence_buffs,
+				    dest_ptrs);
 
 		if (0 != memcmp(dest_ref1, dest1, size)) {
 			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test1 %d\n", rtest);
@@ -527,7 +530,7 @@ int main(int argc, char *argv[])
 		gf_vect_dot_prod_base(size, srcs, &g_tbls[64 * srcs], ubuffs, dest_ref3);
 		gf_vect_dot_prod_base(size, srcs, &g_tbls[96 * srcs], ubuffs, dest_ref4);
 
-		FUNCTION_UNDER_TEST(size, srcs, g_tbls, ubuffs, udest_ptrs);
+		FUNCTION_UNDER_TEST(size, srcs, g_tbls, (const u8 **)ubuffs, udest_ptrs);
 
 		if (memcmp(dest_ref1, udest_ptrs[0], size)) {
 			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test ualign srcs=%d\n",
@@ -645,7 +648,7 @@ int main(int argc, char *argv[])
 		gf_vect_dot_prod_base(size, srcs, &g_tbls[64 * srcs], buffs, dest_ref3);
 		gf_vect_dot_prod_base(size, srcs, &g_tbls[96 * srcs], buffs, dest_ref4);
 
-		FUNCTION_UNDER_TEST(size, srcs, g_tbls, buffs, dest_ptrs);
+		FUNCTION_UNDER_TEST(size, srcs, g_tbls, (const u8 **)buffs, dest_ptrs);
 
 		if (memcmp(dest_ref1, dest_ptrs[0], size)) {
 			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test ualign len=%d\n",

--- a/erasure_code/gf_5vect_dot_prod_sse_test.c
+++ b/erasure_code/gf_5vect_dot_prod_sse_test.c
@@ -239,7 +239,7 @@ int main(int argc, char *argv[])
 	gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[128 * TEST_SOURCES], buffs,
 			      dest_ref5);
 
-	FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, g_tbls, buffs, dest_ptrs);
+	FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, g_tbls, (const u8 **)buffs, dest_ptrs);
 
 	if (0 != memcmp(dest_ref1, dest1, TEST_LEN)) {
 		printf("Fail zero " xstr(FUNCTION_UNDER_TEST) " test1\n");
@@ -321,7 +321,8 @@ int main(int argc, char *argv[])
 		gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[128 * TEST_SOURCES],
 				      buffs, dest_ref5);
 
-		FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, g_tbls, buffs, dest_ptrs);
+		FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, g_tbls, (const u8 **)buffs,
+				    dest_ptrs);
 
 		if (0 != memcmp(dest_ref1, dest1, TEST_LEN)) {
 			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test1 %d\n", rtest);
@@ -405,7 +406,8 @@ int main(int argc, char *argv[])
 			gf_vect_dot_prod_base(TEST_LEN, srcs, &g_tbls[128 * srcs], buffs,
 					      dest_ref5);
 
-			FUNCTION_UNDER_TEST(TEST_LEN, srcs, g_tbls, buffs, dest_ptrs);
+			FUNCTION_UNDER_TEST(TEST_LEN, srcs, g_tbls, (const u8 **)buffs,
+					    dest_ptrs);
 
 			if (0 != memcmp(dest_ref1, dest1, TEST_LEN)) {
 				printf("Fail rand " xstr(FUNCTION_UNDER_TEST)
@@ -498,7 +500,8 @@ int main(int argc, char *argv[])
 		gf_vect_dot_prod_base(size, TEST_SOURCES, &g_tbls[128 * TEST_SOURCES],
 				      efence_buffs, dest_ref5);
 
-		FUNCTION_UNDER_TEST(size, TEST_SOURCES, g_tbls, efence_buffs, dest_ptrs);
+		FUNCTION_UNDER_TEST(size, TEST_SOURCES, g_tbls, (const u8 **)efence_buffs,
+				    dest_ptrs);
 
 		if (0 != memcmp(dest_ref1, dest1, size)) {
 			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test1 %d\n", rtest);
@@ -604,7 +607,7 @@ int main(int argc, char *argv[])
 		gf_vect_dot_prod_base(size, srcs, &g_tbls[96 * srcs], ubuffs, dest_ref4);
 		gf_vect_dot_prod_base(size, srcs, &g_tbls[128 * srcs], ubuffs, dest_ref5);
 
-		FUNCTION_UNDER_TEST(size, srcs, g_tbls, ubuffs, udest_ptrs);
+		FUNCTION_UNDER_TEST(size, srcs, g_tbls, (const u8 **)ubuffs, udest_ptrs);
 
 		if (memcmp(dest_ref1, udest_ptrs[0], size)) {
 			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test ualign srcs=%d\n",
@@ -744,7 +747,7 @@ int main(int argc, char *argv[])
 		gf_vect_dot_prod_base(size, srcs, &g_tbls[96 * srcs], buffs, dest_ref4);
 		gf_vect_dot_prod_base(size, srcs, &g_tbls[128 * srcs], buffs, dest_ref5);
 
-		FUNCTION_UNDER_TEST(size, srcs, g_tbls, buffs, dest_ptrs);
+		FUNCTION_UNDER_TEST(size, srcs, g_tbls, (const u8 **)buffs, dest_ptrs);
 
 		if (memcmp(dest_ref1, dest_ptrs[0], size)) {
 			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test ualign len=%d\n",

--- a/erasure_code/gf_6vect_dot_prod_sse_test.c
+++ b/erasure_code/gf_6vect_dot_prod_sse_test.c
@@ -258,7 +258,7 @@ int main(int argc, char *argv[])
 	gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[160 * TEST_SOURCES], buffs,
 			      dest_ref6);
 
-	FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, g_tbls, buffs, dest_ptrs);
+	FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, g_tbls, (const u8 **)buffs, dest_ptrs);
 
 	if (0 != memcmp(dest_ref1, dest1, TEST_LEN)) {
 		printf("Fail zero " xstr(FUNCTION_UNDER_TEST) " test1\n");
@@ -353,7 +353,8 @@ int main(int argc, char *argv[])
 		gf_vect_dot_prod_base(TEST_LEN, TEST_SOURCES, &g_tbls[160 * TEST_SOURCES],
 				      buffs, dest_ref6);
 
-		FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, g_tbls, buffs, dest_ptrs);
+		FUNCTION_UNDER_TEST(TEST_LEN, TEST_SOURCES, g_tbls, (const u8 **)buffs,
+				    dest_ptrs);
 
 		if (0 != memcmp(dest_ref1, dest1, TEST_LEN)) {
 			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test1 %d\n", rtest);
@@ -450,7 +451,8 @@ int main(int argc, char *argv[])
 			gf_vect_dot_prod_base(TEST_LEN, srcs, &g_tbls[160 * srcs], buffs,
 					      dest_ref6);
 
-			FUNCTION_UNDER_TEST(TEST_LEN, srcs, g_tbls, buffs, dest_ptrs);
+			FUNCTION_UNDER_TEST(TEST_LEN, srcs, g_tbls, (const u8 **)buffs,
+					    dest_ptrs);
 
 			if (0 != memcmp(dest_ref1, dest1, TEST_LEN)) {
 				printf("Fail rand " xstr(FUNCTION_UNDER_TEST)
@@ -557,7 +559,8 @@ int main(int argc, char *argv[])
 		gf_vect_dot_prod_base(size, TEST_SOURCES, &g_tbls[160 * TEST_SOURCES],
 				      efence_buffs, dest_ref6);
 
-		FUNCTION_UNDER_TEST(size, TEST_SOURCES, g_tbls, efence_buffs, dest_ptrs);
+		FUNCTION_UNDER_TEST(size, TEST_SOURCES, g_tbls, (const u8 **)efence_buffs,
+				    dest_ptrs);
 
 		if (0 != memcmp(dest_ref1, dest1, size)) {
 			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test1 %d\n", rtest);
@@ -678,7 +681,7 @@ int main(int argc, char *argv[])
 		gf_vect_dot_prod_base(size, srcs, &g_tbls[128 * srcs], ubuffs, dest_ref5);
 		gf_vect_dot_prod_base(size, srcs, &g_tbls[160 * srcs], ubuffs, dest_ref6);
 
-		FUNCTION_UNDER_TEST(size, srcs, g_tbls, ubuffs, udest_ptrs);
+		FUNCTION_UNDER_TEST(size, srcs, g_tbls, (const u8 **)ubuffs, udest_ptrs);
 
 		if (memcmp(dest_ref1, udest_ptrs[0], size)) {
 			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test ualign srcs=%d\n",
@@ -841,7 +844,7 @@ int main(int argc, char *argv[])
 		gf_vect_dot_prod_base(size, srcs, &g_tbls[128 * srcs], buffs, dest_ref5);
 		gf_vect_dot_prod_base(size, srcs, &g_tbls[160 * srcs], buffs, dest_ref6);
 
-		FUNCTION_UNDER_TEST(size, srcs, g_tbls, buffs, dest_ptrs);
+		FUNCTION_UNDER_TEST(size, srcs, g_tbls, (const u8 **)buffs, dest_ptrs);
 
 		if (memcmp(dest_ref1, dest_ptrs[0], size)) {
 			printf("Fail rand " xstr(FUNCTION_UNDER_TEST) " test ualign len=%d\n",

--- a/examples/ec/ec_piggyback_example.c
+++ b/examples/ec/ec_piggyback_example.c
@@ -331,13 +331,13 @@ int main(int argc, char *argv[])
 		// Standard encode using no assumptions on the encode matrix
 
 		// Generate EC parity blocks from sources
-		ec_encode_data(len / 2, k2, p2, g_tbls, frag_ptrs, parity_ptrs);
+		ec_encode_data(len / 2, k2, p2, g_tbls, (const u8 **)frag_ptrs, parity_ptrs);
 
 		if (benchmark) {
 			struct perf start;
 			BENCHMARK(&start, BENCHMARK_TIME,
-				  ec_encode_data(len / 2, k2, p2, g_tbls, frag_ptrs,
-						 parity_ptrs));
+				  ec_encode_data(len / 2, k2, p2, g_tbls,
+						 (const u8 **)frag_ptrs, parity_ptrs));
 			printf("ec_piggyback_encode_std: ");
 			perf_print(start, m2 * len / 2);
 		}
@@ -371,15 +371,16 @@ int main(int argc, char *argv[])
 		ec_init_tables(k, p, &encode_matrix_faster[k * k], g_tbls_faster);
 
 		// Generate EC parity blocks from sources
-		ec_encode_data(len / 2, k, p, g_tbls_faster, frag_ptrs, parity_ptrs);
-		ec_encode_data(len / 2, k2, p, &g_tbls[k2 * p * 32], frag_ptrs,
+		ec_encode_data(len / 2, k, p, g_tbls_faster, (const u8 **)frag_ptrs,
+			       parity_ptrs);
+		ec_encode_data(len / 2, k2, p, &g_tbls[k2 * p * 32], (const u8 **)frag_ptrs,
 			       &parity_ptrs[p]);
 
 		if (benchmark) {
 			struct perf start;
 			BENCHMARK(&start, BENCHMARK_TIME,
-				  ec_encode_data(len / 2, k, p, g_tbls_faster, frag_ptrs,
-						 parity_ptrs);
+				  ec_encode_data(len / 2, k, p, g_tbls_faster,
+						 (const u8 **)frag_ptrs, parity_ptrs);
 				  ec_encode_data(len / 2, k2, p, &g_tbls[k2 * p * 32],
 						 frag_ptrs, &parity_ptrs[p]));
 			printf("ec_piggyback_encode_sparse: ");
@@ -418,13 +419,13 @@ int main(int argc, char *argv[])
 
 	// Recover data
 	ec_init_tables(k2, nerrs2, decode_matrix, g_tbls);
-	ec_encode_data(len / 2, k2, nerrs2, g_tbls, recover_srcs, recover_outp);
+	ec_encode_data(len / 2, k2, nerrs2, g_tbls, (const u8 **)recover_srcs, recover_outp);
 
 	if (benchmark) {
 		struct perf start;
 		BENCHMARK(&start, BENCHMARK_TIME,
-			  ec_encode_data(len / 2, k2, nerrs2, g_tbls, recover_srcs,
-					 recover_outp));
+			  ec_encode_data(len / 2, k2, nerrs2, g_tbls,
+					 (const u8 **)recover_srcs, recover_outp));
 		printf("ec_piggyback_decode: ");
 		perf_print(start, (k2 + nerrs2) * len / 2);
 	}

--- a/examples/ec/ec_simple_example.c
+++ b/examples/ec/ec_simple_example.c
@@ -177,7 +177,7 @@ int main(int argc, char *argv[])
 	ec_init_tables(k, p, &encode_matrix[k * k], g_tbls);
 
 	// Generate EC parity blocks from sources
-	ec_encode_data(len, k, p, g_tbls, frag_ptrs, &frag_ptrs[k]);
+	ec_encode_data(len, k, p, g_tbls, (const u8 **)frag_ptrs, &frag_ptrs[k]);
 
 	if (nerrs <= 0)
 		return 0;
@@ -198,7 +198,7 @@ int main(int argc, char *argv[])
 
 	// Recover data
 	ec_init_tables(k, nerrs, decode_matrix, g_tbls);
-	ec_encode_data(len, k, nerrs, g_tbls, recover_srcs, recover_outp);
+	ec_encode_data(len, k, nerrs, g_tbls, (const u8 **)recover_srcs, recover_outp);
 
 	// Check that recovered buffers are the same as original
 	printf(" check recovery of block {");

--- a/include/erasure_code.h
+++ b/include/erasure_code.h
@@ -95,16 +95,16 @@ void ec_init_tables(int k, int rows, unsigned char* a, unsigned char* gftbls);
  * @returns none
  */
 
-void ec_encode_data(int len, int k, int rows, unsigned char *gftbls, unsigned char **data,
-		    unsigned char **coding);
+void ec_encode_data(int len, int k, int rows, unsigned char *gftbls,
+		    const unsigned char **data, unsigned char **coding);
 
 /**
  * @brief Generate or decode erasure codes on blocks of data, runs baseline version.
  *
  * Baseline version of ec_encode_data() with same parameters.
  */
-void ec_encode_data_base(int len, int srcs, int dests, unsigned char *v, unsigned char **src,
-			 unsigned char **dest);
+void ec_encode_data_base(int len, int srcs, int dests, unsigned char *v,
+			  const unsigned char **src, unsigned char **dest);
 
 /**
  * @brief Generate update for encode or decode of erasure codes from single source, runs appropriate version.
@@ -138,7 +138,7 @@ void ec_encode_data_update(int len, int k, int rows, int vec_i, unsigned char *g
  */
 
 void ec_encode_data_update_base(int len, int k, int rows, int vec_i, unsigned char *v,
-				unsigned char *data, unsigned char **dest);
+				const unsigned char *data, unsigned char **dest);
 
 /**
  * @brief GF(2^8) vector dot product, runs baseline version.
@@ -231,8 +231,8 @@ void gf_vect_mad_base(int len, int vec, int vec_i, unsigned char *v, unsigned ch
  * Arch specific version of ec_encode_data() with same parameters.
  * @requires SSE4.1
  */
-void ec_encode_data_sse(int len, int k, int rows, unsigned char *gftbls, unsigned char **data,
-			unsigned char **coding);
+void ec_encode_data_sse(int len, int k, int rows, unsigned char *gftbls,
+			const unsigned char **data, unsigned char **coding);
 
 /**
  * @brief Generate or decode erasure codes on blocks of data.
@@ -240,8 +240,8 @@ void ec_encode_data_sse(int len, int k, int rows, unsigned char *gftbls, unsigne
  * Arch specific version of ec_encode_data() with same parameters.
  * @requires AVX
  */
-void ec_encode_data_avx(int len, int k, int rows, unsigned char *gftbls, unsigned char **data,
-			unsigned char **coding);
+void ec_encode_data_avx(int len, int k, int rows, unsigned char *gftbls,
+			const unsigned char **data, unsigned char **coding);
 
 /**
  * @brief Generate or decode erasure codes on blocks of data.
@@ -249,8 +249,8 @@ void ec_encode_data_avx(int len, int k, int rows, unsigned char *gftbls, unsigne
  * Arch specific version of ec_encode_data() with same parameters.
  * @requires AVX2
  */
-void ec_encode_data_avx2(int len, int k, int rows, unsigned char *gftbls, unsigned char **data,
-			 unsigned char **coding);
+void ec_encode_data_avx2(int len, int k, int rows, unsigned char *gftbls,
+			 const unsigned char **data, unsigned char **coding);
 
 /**
  * @brief Generate update for encode or decode of erasure codes from single source.
@@ -259,8 +259,8 @@ void ec_encode_data_avx2(int len, int k, int rows, unsigned char *gftbls, unsign
  * @requires SSE4.1
  */
 
-void ec_encode_data_update_sse(int len, int k, int rows, int vec_i, unsigned char *g_tbls,
-			       unsigned char *data, unsigned char **coding);
+void ec_encode_data_update_sse(int len, int k, int rows, int vec_i,
+			       unsigned char *g_tbls, const unsigned char *data, unsigned char **coding);
 
 /**
  * @brief Generate update for encode or decode of erasure codes from single source.
@@ -270,7 +270,7 @@ void ec_encode_data_update_sse(int len, int k, int rows, int vec_i, unsigned cha
  */
 
 void ec_encode_data_update_avx(int len, int k, int rows, int vec_i, unsigned char *g_tbls,
-			       unsigned char *data, unsigned char **coding);
+			       const unsigned char *data, unsigned char **coding);
 
 /**
  * @brief Generate update for encode or decode of erasure codes from single source.
@@ -279,8 +279,8 @@ void ec_encode_data_update_avx(int len, int k, int rows, int vec_i, unsigned cha
  * @requires AVX2
  */
 
-void ec_encode_data_update_avx2(int len, int k, int rows, int vec_i, unsigned char *g_tbls,
-				unsigned char *data, unsigned char **coding);
+void ec_encode_data_update_avx2(int len, int k, int rows, int vec_i,
+				unsigned char *g_tbls, const unsigned char *data, unsigned char **coding);
 
 /**
  * @brief GF(2^8) vector dot product.
@@ -301,7 +301,7 @@ void ec_encode_data_update_avx2(int len, int k, int rows, int vec_i, unsigned ch
  */
 
 void gf_vect_dot_prod_sse(int len, int vlen, unsigned char *gftbls,
-			unsigned char **src, unsigned char *dest);
+			const unsigned char **src, unsigned char *dest);
 
 /**
  * @brief GF(2^8) vector dot product.
@@ -322,7 +322,7 @@ void gf_vect_dot_prod_sse(int len, int vlen, unsigned char *gftbls,
  */
 
 void gf_vect_dot_prod_avx(int len, int vlen, unsigned char *gftbls,
-			unsigned char **src, unsigned char *dest);
+			const unsigned char **src, unsigned char *dest);
 
 /**
  * @brief GF(2^8) vector dot product.
@@ -343,7 +343,7 @@ void gf_vect_dot_prod_avx(int len, int vlen, unsigned char *gftbls,
  */
 
 void gf_vect_dot_prod_avx2(int len, int vlen, unsigned char *gftbls,
-			unsigned char **src, unsigned char *dest);
+			const unsigned char **src, unsigned char *dest);
 
 /**
  * @brief GF(2^8) vector dot product with two outputs.
@@ -365,7 +365,7 @@ void gf_vect_dot_prod_avx2(int len, int vlen, unsigned char *gftbls,
  */
 
 void gf_2vect_dot_prod_sse(int len, int vlen, unsigned char *gftbls,
-			unsigned char **src, unsigned char **dest);
+			const unsigned char **src, unsigned char **dest);
 
 /**
  * @brief GF(2^8) vector dot product with two outputs.
@@ -387,7 +387,7 @@ void gf_2vect_dot_prod_sse(int len, int vlen, unsigned char *gftbls,
  */
 
 void gf_2vect_dot_prod_avx(int len, int vlen, unsigned char *gftbls,
-			unsigned char **src, unsigned char **dest);
+			const unsigned char **src, unsigned char **dest);
 
 /**
  * @brief GF(2^8) vector dot product with two outputs.
@@ -409,7 +409,7 @@ void gf_2vect_dot_prod_avx(int len, int vlen, unsigned char *gftbls,
  */
 
 void gf_2vect_dot_prod_avx2(int len, int vlen, unsigned char *gftbls,
-			unsigned char **src, unsigned char **dest);
+			const unsigned char **src, unsigned char **dest);
 
 /**
  * @brief GF(2^8) vector dot product with three outputs.
@@ -431,7 +431,7 @@ void gf_2vect_dot_prod_avx2(int len, int vlen, unsigned char *gftbls,
  */
 
 void gf_3vect_dot_prod_sse(int len, int vlen, unsigned char *gftbls,
-			unsigned char **src, unsigned char **dest);
+			const unsigned char **src, unsigned char **dest);
 
 /**
  * @brief GF(2^8) vector dot product with three outputs.
@@ -453,7 +453,7 @@ void gf_3vect_dot_prod_sse(int len, int vlen, unsigned char *gftbls,
  */
 
 void gf_3vect_dot_prod_avx(int len, int vlen, unsigned char *gftbls,
-			unsigned char **src, unsigned char **dest);
+			const unsigned char **src, unsigned char **dest);
 
 /**
  * @brief GF(2^8) vector dot product with three outputs.
@@ -475,7 +475,7 @@ void gf_3vect_dot_prod_avx(int len, int vlen, unsigned char *gftbls,
  */
 
 void gf_3vect_dot_prod_avx2(int len, int vlen, unsigned char *gftbls,
-			unsigned char **src, unsigned char **dest);
+			const unsigned char **src, unsigned char **dest);
 
 /**
  * @brief GF(2^8) vector dot product with four outputs.
@@ -497,7 +497,7 @@ void gf_3vect_dot_prod_avx2(int len, int vlen, unsigned char *gftbls,
  */
 
 void gf_4vect_dot_prod_sse(int len, int vlen, unsigned char *gftbls,
-			unsigned char **src, unsigned char **dest);
+			const unsigned char **src, unsigned char **dest);
 
 /**
  * @brief GF(2^8) vector dot product with four outputs.
@@ -519,7 +519,7 @@ void gf_4vect_dot_prod_sse(int len, int vlen, unsigned char *gftbls,
  */
 
 void gf_4vect_dot_prod_avx(int len, int vlen, unsigned char *gftbls,
-			unsigned char **src, unsigned char **dest);
+			const unsigned char **src, unsigned char **dest);
 
 /**
  * @brief GF(2^8) vector dot product with four outputs.
@@ -541,7 +541,7 @@ void gf_4vect_dot_prod_avx(int len, int vlen, unsigned char *gftbls,
  */
 
 void gf_4vect_dot_prod_avx2(int len, int vlen, unsigned char *gftbls,
-			unsigned char **src, unsigned char **dest);
+			const unsigned char **src, unsigned char **dest);
 
 /**
  * @brief GF(2^8) vector dot product with five outputs.
@@ -563,7 +563,7 @@ void gf_4vect_dot_prod_avx2(int len, int vlen, unsigned char *gftbls,
  */
 
 void gf_5vect_dot_prod_sse(int len, int vlen, unsigned char *gftbls,
-			unsigned char **src, unsigned char **dest);
+			const unsigned char **src, unsigned char **dest);
 
 /**
  * @brief GF(2^8) vector dot product with five outputs.
@@ -585,7 +585,7 @@ void gf_5vect_dot_prod_sse(int len, int vlen, unsigned char *gftbls,
  */
 
 void gf_5vect_dot_prod_avx(int len, int vlen, unsigned char *gftbls,
-			unsigned char **src, unsigned char **dest);
+			const unsigned char **src, unsigned char **dest);
 
 /**
  * @brief GF(2^8) vector dot product with five outputs.
@@ -607,7 +607,7 @@ void gf_5vect_dot_prod_avx(int len, int vlen, unsigned char *gftbls,
  */
 
 void gf_5vect_dot_prod_avx2(int len, int vlen, unsigned char *gftbls,
-			unsigned char **src, unsigned char **dest);
+			const unsigned char **src, unsigned char **dest);
 
 /**
  * @brief GF(2^8) vector dot product with six outputs.
@@ -629,7 +629,7 @@ void gf_5vect_dot_prod_avx2(int len, int vlen, unsigned char *gftbls,
  */
 
 void gf_6vect_dot_prod_sse(int len, int vlen, unsigned char *gftbls,
-			unsigned char **src, unsigned char **dest);
+			const unsigned char **src, unsigned char **dest);
 
 /**
  * @brief GF(2^8) vector dot product with six outputs.
@@ -651,7 +651,7 @@ void gf_6vect_dot_prod_sse(int len, int vlen, unsigned char *gftbls,
  */
 
 void gf_6vect_dot_prod_avx(int len, int vlen, unsigned char *gftbls,
-			unsigned char **src, unsigned char **dest);
+			const unsigned char **src, unsigned char **dest);
 
 /**
  * @brief GF(2^8) vector dot product with six outputs.
@@ -673,7 +673,7 @@ void gf_6vect_dot_prod_avx(int len, int vlen, unsigned char *gftbls,
  */
 
 void gf_6vect_dot_prod_avx2(int len, int vlen, unsigned char *gftbls,
-			unsigned char **src, unsigned char **dest);
+			const unsigned char **src, unsigned char **dest);
 
 /**
  * @brief GF(2^8) vector multiply accumulate, arch specific version.
@@ -682,8 +682,8 @@ void gf_6vect_dot_prod_avx2(int len, int vlen, unsigned char *gftbls,
  * @requires SSE4.1
  */
 
-void gf_vect_mad_sse(int len, int vec, int vec_i, unsigned char *gftbls, unsigned char *src,
-		     unsigned char *dest);
+void gf_vect_mad_sse(int len, int vec, int vec_i, unsigned char *gftbls,
+		     const unsigned char *src, unsigned char *dest);
 /**
  * @brief GF(2^8) vector multiply accumulate, arch specific version.
  *
@@ -691,8 +691,8 @@ void gf_vect_mad_sse(int len, int vec, int vec_i, unsigned char *gftbls, unsigne
  * @requires AVX
  */
 
-void gf_vect_mad_avx(int len, int vec, int vec_i, unsigned char *gftbls, unsigned char *src,
-		     unsigned char *dest);
+void gf_vect_mad_avx(int len, int vec, int vec_i, unsigned char *gftbls,
+		     const unsigned char *src, unsigned char *dest);
 
 /**
  * @brief GF(2^8) vector multiply accumulate, arch specific version.
@@ -701,8 +701,8 @@ void gf_vect_mad_avx(int len, int vec, int vec_i, unsigned char *gftbls, unsigne
  * @requires AVX2
  */
 
-void gf_vect_mad_avx2(int len, int vec, int vec_i, unsigned char *gftbls, unsigned char *src,
-		      unsigned char *dest);
+void gf_vect_mad_avx2(int len, int vec, int vec_i, unsigned char *gftbls,
+		      const unsigned char *src, unsigned char *dest);
 
 
 /**
@@ -726,21 +726,21 @@ void gf_vect_mad_avx2(int len, int vec, int vec_i, unsigned char *gftbls, unsign
  * @returns none
  */
 
-void gf_2vect_mad_sse(int len, int vec, int vec_i, unsigned char *gftbls, unsigned char *src,
-		      unsigned char **dest);
+void gf_2vect_mad_sse(int len, int vec, int vec_i, unsigned char *gftbls,
+		      const unsigned char *src, unsigned char **dest);
 
 /**
  * @brief GF(2^8) vector multiply with 2 accumulate. AVX version of gf_2vect_mad_sse().
  * @requires AVX
  */
-void gf_2vect_mad_avx(int len, int vec, int vec_i, unsigned char *gftbls, unsigned char *src,
-		      unsigned char **dest);
+void gf_2vect_mad_avx(int len, int vec, int vec_i, unsigned char *gftbls,
+		      const unsigned char *src, unsigned char **dest);
 /**
  * @brief GF(2^8) vector multiply with 2 accumulate. AVX2 version of gf_2vect_mad_sse().
  * @requires AVX2
  */
-void gf_2vect_mad_avx2(int len, int vec, int vec_i, unsigned char *gftbls, unsigned char *src,
-		       unsigned char **dest);
+void gf_2vect_mad_avx2(int len, int vec, int vec_i, unsigned char *gftbls,
+		       const unsigned char *src, unsigned char **dest);
 
 /**
  * @brief GF(2^8) vector multiply with 3 accumulate. SSE version.
@@ -763,22 +763,22 @@ void gf_2vect_mad_avx2(int len, int vec, int vec_i, unsigned char *gftbls, unsig
  * @returns none
  */
 
-void gf_3vect_mad_sse(int len, int vec, int vec_i, unsigned char *gftbls, unsigned char *src,
-		      unsigned char **dest);
+void gf_3vect_mad_sse(int len, int vec, int vec_i, unsigned char *gftbls,
+		      const unsigned char *src, unsigned char **dest);
 
 /**
  * @brief GF(2^8) vector multiply with 3 accumulate. AVX version of gf_3vect_mad_sse().
  * @requires AVX
  */
-void gf_3vect_mad_avx(int len, int vec, int vec_i, unsigned char *gftbls, unsigned char *src,
-		      unsigned char **dest);
+void gf_3vect_mad_avx(int len, int vec, int vec_i, unsigned char *gftbls,
+		      const unsigned char *src, unsigned char **dest);
 
 /**
  * @brief GF(2^8) vector multiply with 3 accumulate. AVX2 version of gf_3vect_mad_sse().
  * @requires AVX2
  */
-void gf_3vect_mad_avx2(int len, int vec, int vec_i, unsigned char *gftbls, unsigned char *src,
-		       unsigned char **dest);
+void gf_3vect_mad_avx2(int len, int vec, int vec_i, unsigned char *gftbls,
+		       const unsigned char *src, unsigned char **dest);
 
 /**
  * @brief GF(2^8) vector multiply with 4 accumulate. SSE version.
@@ -801,61 +801,61 @@ void gf_3vect_mad_avx2(int len, int vec, int vec_i, unsigned char *gftbls, unsig
  * @returns none
  */
 
-void gf_4vect_mad_sse(int len, int vec, int vec_i, unsigned char *gftbls, unsigned char *src,
-		      unsigned char **dest);
+void gf_4vect_mad_sse(int len, int vec, int vec_i, unsigned char *gftbls,
+		      const unsigned char *src, unsigned char **dest);
 
 /**
  * @brief GF(2^8) vector multiply with 4 accumulate. AVX version of gf_4vect_mad_sse().
  * @requires AVX
  */
-void gf_4vect_mad_avx(int len, int vec, int vec_i, unsigned char *gftbls, unsigned char *src,
-		      unsigned char **dest);
+void gf_4vect_mad_avx(int len, int vec, int vec_i, unsigned char *gftbls,
+		      const unsigned char *src, unsigned char **dest);
 /**
  * @brief GF(2^8) vector multiply with 4 accumulate. AVX2 version of gf_4vect_mad_sse().
  * @requires AVX2
  */
-void gf_4vect_mad_avx2(int len, int vec, int vec_i, unsigned char *gftbls, unsigned char *src,
-		       unsigned char **dest);
+void gf_4vect_mad_avx2(int len, int vec, int vec_i, unsigned char *gftbls,
+		       const unsigned char *src, unsigned char **dest);
 
 /**
  * @brief GF(2^8) vector multiply with 5 accumulate. SSE version.
  * @requires SSE4.1
  */
-void gf_5vect_mad_sse(int len, int vec, int vec_i, unsigned char *gftbls, unsigned char *src,
-		      unsigned char **dest);
+void gf_5vect_mad_sse(int len, int vec, int vec_i, unsigned char *gftbls,
+		      const unsigned char *src, unsigned char **dest);
 
 /**
  * @brief GF(2^8) vector multiply with 5 accumulate. AVX version.
  * @requires AVX
  */
-void gf_5vect_mad_avx(int len, int vec, int vec_i, unsigned char *gftbls, unsigned char *src,
-		      unsigned char **dest);
+void gf_5vect_mad_avx(int len, int vec, int vec_i, unsigned char *gftbls,
+		      const unsigned char *src, unsigned char **dest);
 /**
  * @brief GF(2^8) vector multiply with 5 accumulate. AVX2 version.
  * @requires AVX2
  */
-void gf_5vect_mad_avx2(int len, int vec, int vec_i, unsigned char *gftbls, unsigned char *src,
-		       unsigned char **dest);
+void gf_5vect_mad_avx2(int len, int vec, int vec_i, unsigned char *gftbls,
+		       const unsigned char *src, unsigned char **dest);
 
 /**
  * @brief GF(2^8) vector multiply with 6 accumulate. SSE version.
  * @requires SSE4.1
  */
-void gf_6vect_mad_sse(int len, int vec, int vec_i, unsigned char *gftbls, unsigned char *src,
-		      unsigned char **dest);
+void gf_6vect_mad_sse(int len, int vec, int vec_i, unsigned char *gftbls,
+		      const unsigned char *src, unsigned char **dest);
 /**
  * @brief GF(2^8) vector multiply with 6 accumulate. AVX version.
  * @requires AVX
  */
-void gf_6vect_mad_avx(int len, int vec, int vec_i, unsigned char *gftbls, unsigned char *src,
-		      unsigned char **dest);
+void gf_6vect_mad_avx(int len, int vec, int vec_i, unsigned char *gftbls,
+		      const unsigned char *src, unsigned char **dest);
 
 /**
  * @brief GF(2^8) vector multiply with 6 accumulate. AVX2 version.
  * @requires AVX2
  */
-void gf_6vect_mad_avx2(int len, int vec, int vec_i, unsigned char *gftbls, unsigned char *src,
-		       unsigned char **dest);
+void gf_6vect_mad_avx2(int len, int vec, int vec_i, unsigned char *gftbls,
+		       const unsigned char *src, unsigned char **dest);
 
 #endif
 


### PR DESCRIPTION
The reasoning for this commit is to constify ec_encode_data() function.
It is expected that after this function has run, the data that "src"
argument points to has not changed. Hence this argument should really be
`const`.

All other functions that undergo same changes here are simply called by
ec_encode_data() internally, one way or another.

Signed-off-by: Konstantin Kharlamov <Hi-Angel@yandex.ru>