### PR TITLE
igzip: fix deflate hash bug

### DIFF
--- a/igzip/aarch64/igzip_deflate_hash_aarch64.S
+++ b/igzip/aarch64/igzip_deflate_hash_aarch64.S
@@ -77,7 +77,7 @@ isal_deflate_hash_aarch64:
 
 
         cmp     next_in, end_in
-        bhi     exit_func
+        bcs     exit_func
 
         mov     w7, 0
 loop_start:


### PR DESCRIPTION
There is a  random segment fault if the test_seed is different . That due to the input next_in equal end_in .
And the compare instruction is wrong . fix it with correct instruction .


