### PR TITLE
x86: Add ENDBR32/ENDBR64 at function entries for Intel CET

### DIFF
--- a/crc/crc16_t10dif_01.asm
+++ b/crc/crc16_t10dif_01.asm
@@ -75,6 +75,7 @@ section .text
 align 16
 mk_global 	crc16_t10dif_01, function
 crc16_t10dif_01:
+	endbranch
 
 	; adjust the 16-bit initial_crc value, scale it to 32 bits
 	shl	arg1_low32, 16

--- a/crc/crc16_t10dif_02.asm
+++ b/crc/crc16_t10dif_02.asm
@@ -75,6 +75,7 @@ section .text
 align 16
 mk_global 	crc16_t10dif_02, function
 crc16_t10dif_02:
+	endbranch
 
 	; adjust the 16-bit initial_crc value, scale it to 32 bits
 	shl	arg1_low32, 16

--- a/crc/crc16_t10dif_by16_10.asm
+++ b/crc/crc16_t10dif_by16_10.asm
@@ -84,6 +84,7 @@ section .text
 align 16
 mk_global FUNCTION_NAME, function
 FUNCTION_NAME:
+	endbranch
 
 	; adjust the 16-bit initial_crc value, scale it to 32 bits
 	shl		arg1_low32, 16

--- a/crc/crc16_t10dif_by4.asm
+++ b/crc/crc16_t10dif_by4.asm
@@ -68,6 +68,7 @@ section .text
 align 16
 mk_global 	crc16_t10dif_by4, function
 crc16_t10dif_by4:
+	endbranch
 
 	; adjust the 16-bit initial_crc value, scale it to 32 bits
 	shl	arg1_low32, 16

--- a/crc/crc16_t10dif_copy_by4.asm
+++ b/crc/crc16_t10dif_copy_by4.asm
@@ -71,6 +71,7 @@ section .text
 align 16
 mk_global 	crc16_t10dif_copy_by4, function
 crc16_t10dif_copy_by4:
+	endbranch
 
 	; adjust the 16-bit initial_crc value, scale it to 32 bits
 	shl	arg1_low32, 16

--- a/crc/crc16_t10dif_copy_by4_02.asm
+++ b/crc/crc16_t10dif_copy_by4_02.asm
@@ -71,6 +71,7 @@ section .text
 align 16
 mk_global 	crc16_t10dif_copy_by4_02, function
 crc16_t10dif_copy_by4_02:
+	endbranch
 
 	; adjust the 16-bit initial_crc value, scale it to 32 bits
 	shl	arg1_low32, 16

--- a/crc/crc32_gzip_refl_by16_10.asm
+++ b/crc/crc32_gzip_refl_by16_10.asm
@@ -94,6 +94,7 @@ section .text
 align 16
 mk_global FUNCTION_NAME, function
 FUNCTION_NAME:
+	endbranch
 
 	not		arg1_low32
 	sub		rsp, VARIABLE_OFFSET

--- a/crc/crc32_gzip_refl_by8.asm
+++ b/crc/crc32_gzip_refl_by8.asm
@@ -88,6 +88,7 @@ section .text
 align 16
 mk_global  crc32_gzip_refl_by8, function
 crc32_gzip_refl_by8:
+	endbranch
 
         ; unsigned long c = crc ^ 0xffffffffL;
         not     arg1_low32	;

--- a/crc/crc32_gzip_refl_by8_02.asm
+++ b/crc/crc32_gzip_refl_by8_02.asm
@@ -88,6 +88,7 @@ section .text
 align 16
 mk_global  crc32_gzip_refl_by8_02, function
 crc32_gzip_refl_by8_02:
+	endbranch
 	not		arg1_low32
 	sub		rsp, VARIABLE_OFFSET
 

--- a/crc/crc32_ieee_01.asm
+++ b/crc/crc32_ieee_01.asm
@@ -74,6 +74,7 @@ section .text
 align 16
 mk_global 	crc32_ieee_01, function
 crc32_ieee_01:
+	endbranch
 
 	not	arg1_low32      ;~init_crc
 

--- a/crc/crc32_ieee_02.asm
+++ b/crc/crc32_ieee_02.asm
@@ -74,6 +74,7 @@ section .text
 align 16
 mk_global 	crc32_ieee_02, function
 crc32_ieee_02:
+	endbranch
 
 	not	arg1_low32      ;~init_crc
 

--- a/crc/crc32_ieee_by16_10.asm
+++ b/crc/crc32_ieee_by16_10.asm
@@ -84,6 +84,7 @@ section .text
 align 16
 mk_global FUNCTION_NAME, function
 FUNCTION_NAME:
+	endbranch
 
 	not		arg1_low32
 	sub		rsp, VARIABLE_OFFSET

--- a/crc/crc32_ieee_by4.asm
+++ b/crc/crc32_ieee_by4.asm
@@ -76,6 +76,7 @@ section .text
 align 16
 mk_global 	crc32_ieee_by4, function
 crc32_ieee_by4:
+	endbranch
 
 	not arg1_low32
 

--- a/crc/crc32_iscsi_00.asm
+++ b/crc/crc32_iscsi_00.asm
@@ -155,6 +155,7 @@ default rel
 
 mk_global  crc32_iscsi_00, function
 crc32_iscsi_00:
+	endbranch
 
 %ifidn __OUTPUT_FORMAT__, elf64
 %define bufp            rdi

--- a/crc/crc32_iscsi_01.asm
+++ b/crc/crc32_iscsi_01.asm
@@ -52,6 +52,7 @@ default rel
 
 mk_global  crc32_iscsi_01, function
 crc32_iscsi_01:
+	endbranch
 
 %ifidn __OUTPUT_FORMAT__, elf64
 %define bufp            rdi
@@ -214,6 +215,7 @@ non_prefetch:
 %rep 128-1
 
 CONCAT(crc_,i,:)
+	endbranch
 	crc32	crc_init,  qword [block_0 - i*8]
 	crc32	crc1,      qword [block_1 - i*8]
 	crc32	crc2,      qword [block_2 - i*8]

--- a/crc/crc64_ecma_norm_by8.asm
+++ b/crc/crc64_ecma_norm_by8.asm
@@ -64,6 +64,7 @@ section .text
 align 16
 mk_global 	crc64_ecma_norm_by8, function
 crc64_ecma_norm_by8:
+	endbranch
 
 	not	arg1      ;~init_crc
 

--- a/crc/crc64_ecma_refl_by8.asm
+++ b/crc/crc64_ecma_refl_by8.asm
@@ -70,6 +70,7 @@ section .text
 align 16
 mk_global crc64_ecma_refl_by8, function
 crc64_ecma_refl_by8:
+	endbranch
         ; uint64_t c = crc ^ 0xffffffff,ffffffffL;
 	not arg1
         sub     rsp, VARIABLE_OFFSET

--- a/crc/crc64_iso_norm_by16_10.asm
+++ b/crc/crc64_iso_norm_by16_10.asm
@@ -71,6 +71,7 @@ section .text
 align 16
 mk_global FUNCTION_NAME, function
 FUNCTION_NAME:
+	endbranch
 	not		arg1
 	sub		rsp, VARIABLE_OFFSET
 

--- a/crc/crc64_iso_norm_by8.asm
+++ b/crc/crc64_iso_norm_by8.asm
@@ -63,6 +63,7 @@ section .text
 align 16
 mk_global 	crc64_iso_norm_by8, function
 crc64_iso_norm_by8:
+	endbranch
 
 	not	arg1      ;~init_crc
 

--- a/crc/crc64_iso_refl_by16_10.asm
+++ b/crc/crc64_iso_refl_by16_10.asm
@@ -72,6 +72,7 @@ section .text
 align 16
 mk_global FUNCTION_NAME, function
 FUNCTION_NAME:
+	endbranch
 	not		arg1
 	sub		rsp, VARIABLE_OFFSET
 

--- a/crc/crc64_iso_refl_by8.asm
+++ b/crc/crc64_iso_refl_by8.asm
@@ -67,6 +67,7 @@ section .text
 align 16
 mk_global crc64_iso_refl_by8, function
 crc64_iso_refl_by8:
+	endbranch
         ; uint64_t c = crc ^ 0xffffffff,ffffffffL;
 	not arg1
         sub     rsp, VARIABLE_OFFSET

--- a/crc/crc64_jones_norm_by8.asm
+++ b/crc/crc64_jones_norm_by8.asm
@@ -63,6 +63,7 @@ section .text
 align 16
 mk_global 	crc64_jones_norm_by8, function
 crc64_jones_norm_by8:
+	endbranch
 
 	not	arg1      ;~init_crc
 

--- a/crc/crc64_jones_refl_by8.asm
+++ b/crc/crc64_jones_refl_by8.asm
@@ -67,6 +67,7 @@ section .text
 align 16
 mk_global crc64_jones_refl_by8, function
 crc64_jones_refl_by8:
+	endbranch
         ; uint64_t c = crc ^ 0xffffffff,ffffffffL;
 	not arg1
         sub     rsp, VARIABLE_OFFSET

--- a/crc/crc_multibinary.asm
+++ b/crc/crc_multibinary.asm
@@ -81,8 +81,10 @@ section .text
 ;;;;
 mk_global crc32_iscsi, function
 crc32_iscsi_mbinit:
+	endbranch
 	call	crc32_iscsi_dispatch_init
 crc32_iscsi:
+	endbranch
 	jmp	qword [crc32_iscsi_dispatched]
 
 crc32_iscsi_dispatch_init:
@@ -115,8 +117,10 @@ crc32_iscsi_dispatch_init:
 ;;;;
 mk_global crc32_ieee, function
 crc32_ieee_mbinit:
+	endbranch
 	call	crc32_ieee_dispatch_init
 crc32_ieee:
+	endbranch
 	jmp	qword [crc32_ieee_dispatched]
 
 crc32_ieee_dispatch_init:
@@ -194,8 +198,10 @@ crc32_ieee_dispatch_init:
 ;;;;
 mk_global crc16_t10dif, function
 crc16_t10dif_mbinit:
+	endbranch
 	call	crc16_t10dif_dispatch_init
 crc16_t10dif:
+	endbranch
 	jmp	qword [crc16_t10dif_dispatched]
 
 crc16_t10dif_dispatch_init:

--- a/erasure_code/gf_2vect_dot_prod_avx.asm
+++ b/erasure_code/gf_2vect_dot_prod_avx.asm
@@ -52,7 +52,7 @@
  %define PS 8
  %define LOG_PS 3
 
- %define func(x) x:
+ %define func(x) x: endbranch
  %macro FUNC_SAVE 0
 	push	r12
  %endmacro
@@ -127,7 +127,7 @@
 
  %define PS 4
  %define LOG_PS 2
- %define func(x) x:
+ %define func(x) x: endbranch
  %define arg(x) [ebp + PS*2 + PS*x]
  %define var(x) [ebp - PS - PS*x]
 

--- a/erasure_code/gf_2vect_dot_prod_avx2.asm
+++ b/erasure_code/gf_2vect_dot_prod_avx2.asm
@@ -54,7 +54,7 @@
  %define PS     8
  %define LOG_PS 3
 
- %define func(x) x:
+ %define func(x) x: endbranch
  %macro FUNC_SAVE 0
 	push	r12
  %endmacro
@@ -131,7 +131,7 @@
 
  %define PS 4
  %define LOG_PS 2
- %define func(x) x:
+ %define func(x) x: endbranch
  %define arg(x) [ebp + PS*2 + PS*x]
  %define var(x) [ebp - PS - PS*x]
 

--- a/erasure_code/gf_2vect_dot_prod_avx512.asm
+++ b/erasure_code/gf_2vect_dot_prod_avx512.asm
@@ -50,7 +50,7 @@
  %define PS     8
  %define LOG_PS 3
 
- %define func(x) x:
+ %define func(x) x: endbranch
  %macro FUNC_SAVE 0
 	push	r12
  %endmacro

--- a/erasure_code/gf_2vect_dot_prod_sse.asm
+++ b/erasure_code/gf_2vect_dot_prod_sse.asm
@@ -52,7 +52,7 @@
  %define PS 8
  %define LOG_PS 3
 
- %define func(x) x:
+ %define func(x) x: endbranch
  %macro FUNC_SAVE 0
 	push	r12
  %endmacro
@@ -127,7 +127,7 @@
 
  %define PS 4
  %define LOG_PS 2
- %define func(x) x:
+ %define func(x) x: endbranch
  %define arg(x) [ebp + PS*2 + PS*x]
  %define var(x) [ebp - PS - PS*x]
 

--- a/erasure_code/gf_2vect_mad_avx.asm
+++ b/erasure_code/gf_2vect_mad_avx.asm
@@ -97,7 +97,7 @@
  %define return rax
  %define return.w eax
 
- %define func(x) x:
+ %define func(x) x: endbranch
  %define FUNC_SAVE
  %define FUNC_RESTORE
 %endif

--- a/erasure_code/gf_2vect_mad_avx2.asm
+++ b/erasure_code/gf_2vect_mad_avx2.asm
@@ -104,7 +104,7 @@
  %define return rax
  %define return.w eax
 
- %define func(x) x:
+ %define func(x) x: endbranch
  %define FUNC_SAVE
  %define FUNC_RESTORE
 %endif

--- a/erasure_code/gf_2vect_mad_avx512.asm
+++ b/erasure_code/gf_2vect_mad_avx512.asm
@@ -45,7 +45,7 @@
  %define tmp    r11
  %define tmp2   r10
  %define return rax
- %define func(x) x:
+ %define func(x) x: endbranch
  %define FUNC_SAVE
  %define FUNC_RESTORE
 %endif

--- a/erasure_code/gf_2vect_mad_sse.asm
+++ b/erasure_code/gf_2vect_mad_sse.asm
@@ -97,7 +97,7 @@
  %define return rax
  %define return.w eax
 
- %define func(x) x:
+ %define func(x) x: endbranch
  %define FUNC_SAVE
  %define FUNC_RESTORE
 %endif

--- a/erasure_code/gf_3vect_dot_prod_avx.asm
+++ b/erasure_code/gf_3vect_dot_prod_avx.asm
@@ -52,7 +52,7 @@
  %define PS 8
  %define LOG_PS 3
 
- %define func(x) x:
+ %define func(x) x: endbranch
  %macro FUNC_SAVE 0
 	push	r12
 	push	r13
@@ -139,7 +139,7 @@
 
  %define PS 4
  %define LOG_PS 2
- %define func(x) x:
+ %define func(x) x: endbranch
  %define arg(x) [ebp + PS*2 + PS*x]
  %define var(x) [ebp - PS - PS*x]
 

--- a/erasure_code/gf_3vect_dot_prod_avx2.asm
+++ b/erasure_code/gf_3vect_dot_prod_avx2.asm
@@ -54,7 +54,7 @@
  %define PS     8
  %define LOG_PS 3
 
- %define func(x) x:
+ %define func(x) x: endbranch
  %macro FUNC_SAVE 0
 	push	r12
 	push	r13
@@ -143,7 +143,7 @@
 
  %define PS 4
  %define LOG_PS 2
- %define func(x) x:
+ %define func(x) x: endbranch
  %define arg(x) [ebp + PS*2 + PS*x]
  %define var(x) [ebp - PS - PS*x]
 

--- a/erasure_code/gf_3vect_dot_prod_avx512.asm
+++ b/erasure_code/gf_3vect_dot_prod_avx512.asm
@@ -53,7 +53,7 @@
  %define PS     8
  %define LOG_PS 3
 
- %define func(x) x:
+ %define func(x) x: endbranch
  %macro FUNC_SAVE 0
 	push	r12
 	push	r13

--- a/erasure_code/gf_3vect_dot_prod_sse.asm
+++ b/erasure_code/gf_3vect_dot_prod_sse.asm
@@ -52,7 +52,7 @@
  %define PS 8
  %define LOG_PS 3
 
- %define func(x) x:
+ %define func(x) x: endbranch
  %macro FUNC_SAVE 0
 	push	r12
 	push	r13
@@ -139,7 +139,7 @@
 
  %define PS 4
  %define LOG_PS 2
- %define func(x) x:
+ %define func(x) x: endbranch
  %define arg(x) [ebp + PS*2 + PS*x]
  %define var(x) [ebp - PS - PS*x]
 

--- a/erasure_code/gf_3vect_mad_avx.asm
+++ b/erasure_code/gf_3vect_mad_avx.asm
@@ -97,7 +97,7 @@
  %define return rax
  %define return.w eax
 
- %define func(x) x:
+ %define func(x) x: endbranch
  %define FUNC_SAVE
  %define FUNC_RESTORE
 %endif

--- a/erasure_code/gf_3vect_mad_avx2.asm
+++ b/erasure_code/gf_3vect_mad_avx2.asm
@@ -103,7 +103,7 @@
  %define return rax
  %define return.w eax
 
- %define func(x) x:
+ %define func(x) x: endbranch
  %define FUNC_SAVE
  %define FUNC_RESTORE
 %endif

--- a/erasure_code/gf_3vect_mad_avx512.asm
+++ b/erasure_code/gf_3vect_mad_avx512.asm
@@ -44,7 +44,7 @@
  %define arg5   r9
  %define tmp    r11
  %define return rax
- %define func(x) x:
+ %define func(x) x: endbranch
  %define FUNC_SAVE
  %define FUNC_RESTORE
 %endif

--- a/erasure_code/gf_3vect_mad_sse.asm
+++ b/erasure_code/gf_3vect_mad_sse.asm
@@ -96,7 +96,7 @@
  %define return rax
  %define return.w eax
 
- %define func(x) x:
+ %define func(x) x: endbranch
  %define FUNC_SAVE
  %define FUNC_RESTORE
 %endif

--- a/erasure_code/gf_4vect_dot_prod_avx.asm
+++ b/erasure_code/gf_4vect_dot_prod_avx.asm
@@ -54,7 +54,7 @@
  %define PS     8
  %define LOG_PS 3
 
- %define func(x) x:
+ %define func(x) x: endbranch
  %macro FUNC_SAVE 0
 	push	r12
 	push	r13
@@ -159,7 +159,7 @@
 
  %define PS     4
  %define LOG_PS 2
- %define func(x) x:
+ %define func(x) x: endbranch
  %define arg(x) [ebp + PS*2 + PS*x]
  %define var(x) [ebp - PS - PS*x]
 

--- a/erasure_code/gf_4vect_dot_prod_avx2.asm
+++ b/erasure_code/gf_4vect_dot_prod_avx2.asm
@@ -56,7 +56,7 @@
  %define PS     8
  %define LOG_PS 3
 
- %define func(x) x:
+ %define func(x) x: endbranch
  %macro FUNC_SAVE 0
 	push	r12
 	push	r13
@@ -163,7 +163,7 @@
 
  %define PS     4
  %define LOG_PS 2
- %define func(x) x:
+ %define func(x) x: endbranch
  %define arg(x) [ebp + PS*2 + PS*x]
  %define var(x) [ebp - PS - PS*x]
 

--- a/erasure_code/gf_4vect_dot_prod_avx512.asm
+++ b/erasure_code/gf_4vect_dot_prod_avx512.asm
@@ -55,7 +55,7 @@
  %define PS     8
  %define LOG_PS 3
 
- %define func(x) x:
+ %define func(x) x: endbranch
  %macro FUNC_SAVE 0
 	push	r12
 	push	r13

--- a/erasure_code/gf_4vect_dot_prod_sse.asm
+++ b/erasure_code/gf_4vect_dot_prod_sse.asm
@@ -54,7 +54,7 @@
  %define PS     8
  %define LOG_PS 3
 
- %define func(x) x:
+ %define func(x) x: endbranch
  %macro FUNC_SAVE 0
 	push	r12
 	push	r13
@@ -159,7 +159,7 @@
 
  %define PS     4
  %define LOG_PS 2
- %define func(x) x:
+ %define func(x) x: endbranch
  %define arg(x) [ebp + PS*2 + PS*x]
  %define var(x) [ebp - PS - PS*x]
 

--- a/erasure_code/gf_4vect_mad_avx.asm
+++ b/erasure_code/gf_4vect_mad_avx.asm
@@ -103,7 +103,7 @@
  %define return rax
  %define return.w eax
 
- %define func(x) x:
+ %define func(x) x: endbranch
  %macro FUNC_SAVE 0
 	push	r12
  %endmacro

--- a/erasure_code/gf_4vect_mad_avx2.asm
+++ b/erasure_code/gf_4vect_mad_avx2.asm
@@ -101,7 +101,7 @@
  %define return rax
  %define return.w eax
 
- %define func(x) x:
+ %define func(x) x: endbranch
  %define FUNC_SAVE
  %define FUNC_RESTORE
 %endif

--- a/erasure_code/gf_4vect_mad_avx512.asm
+++ b/erasure_code/gf_4vect_mad_avx512.asm
@@ -44,7 +44,7 @@
  %define arg5   r9
  %define tmp    r11
  %define return rax
- %define func(x) x:
+ %define func(x) x: endbranch
  %define FUNC_SAVE
  %define FUNC_RESTORE
 %endif

--- a/erasure_code/gf_4vect_mad_sse.asm
+++ b/erasure_code/gf_4vect_mad_sse.asm
@@ -103,7 +103,7 @@
  %define return rax
  %define return.w eax
 
- %define func(x) x:
+ %define func(x) x: endbranch
  %macro FUNC_SAVE 0
 	push	r12
  %endmacro

--- a/erasure_code/gf_5vect_dot_prod_avx.asm
+++ b/erasure_code/gf_5vect_dot_prod_avx.asm
@@ -51,7 +51,7 @@
  %define PS 8
  %define LOG_PS 3
 
- %define func(x) x:
+ %define func(x) x: endbranch
  %macro FUNC_SAVE 0
 	push	r12
 	push	r13

--- a/erasure_code/gf_5vect_dot_prod_avx2.asm
+++ b/erasure_code/gf_5vect_dot_prod_avx2.asm
@@ -53,7 +53,7 @@
  %define PS 8
  %define LOG_PS 3
 
- %define func(x) x:
+ %define func(x) x: endbranch
  %macro FUNC_SAVE 0
 	push	r12
 	push	r13

--- a/erasure_code/gf_5vect_dot_prod_avx512.asm
+++ b/erasure_code/gf_5vect_dot_prod_avx512.asm
@@ -57,7 +57,7 @@
  %define PS     8
  %define LOG_PS 3
 
- %define func(x) x:
+ %define func(x) x: endbranch
  %macro FUNC_SAVE 0
 	push	r12
 	push	r13

--- a/erasure_code/gf_5vect_dot_prod_sse.asm
+++ b/erasure_code/gf_5vect_dot_prod_sse.asm
@@ -51,7 +51,7 @@
  %define PS 8
  %define LOG_PS 3
 
- %define func(x) x:
+ %define func(x) x: endbranch
  %macro FUNC_SAVE 0
 	push	r12
 	push	r13

--- a/erasure_code/gf_5vect_mad_avx.asm
+++ b/erasure_code/gf_5vect_mad_avx.asm
@@ -107,7 +107,7 @@
  %define return rax
  %define return.w eax
 
- %define func(x) x:
+ %define func(x) x: endbranch
  %macro FUNC_SAVE 0
 	push	r12
 	push	r13

--- a/erasure_code/gf_5vect_mad_avx2.asm
+++ b/erasure_code/gf_5vect_mad_avx2.asm
@@ -103,7 +103,7 @@
  %define return rax
  %define return.w eax
 
- %define func(x) x:
+ %define func(x) x: endbranch
  %define FUNC_SAVE
  %define FUNC_RESTORE
 %endif

--- a/erasure_code/gf_5vect_mad_avx512.asm
+++ b/erasure_code/gf_5vect_mad_avx512.asm
@@ -45,7 +45,7 @@
  %define tmp    r11
  %define tmp2   r10
  %define return rax
- %define func(x) x:
+ %define func(x) x: endbranch
  %define FUNC_SAVE
  %define FUNC_RESTORE
 %endif

--- a/erasure_code/gf_5vect_mad_sse.asm
+++ b/erasure_code/gf_5vect_mad_sse.asm
@@ -107,7 +107,7 @@
  %define return rax
  %define return.w eax
 
- %define func(x) x:
+ %define func(x) x: endbranch
  %macro FUNC_SAVE 0
 	push	r12
 	push	r13

--- a/erasure_code/gf_6vect_dot_prod_avx.asm
+++ b/erasure_code/gf_6vect_dot_prod_avx.asm
@@ -51,7 +51,7 @@
  %define PS 8
  %define LOG_PS 3
 
- %define func(x) x:
+ %define func(x) x: endbranch
  %macro FUNC_SAVE 0
 	push	r12
 	push	r13

--- a/erasure_code/gf_6vect_dot_prod_avx2.asm
+++ b/erasure_code/gf_6vect_dot_prod_avx2.asm
@@ -53,7 +53,7 @@
  %define PS 8
  %define LOG_PS 3
 
- %define func(x) x:
+ %define func(x) x: endbranch
  %macro FUNC_SAVE 0
 	push	r12
 	push	r13

--- a/erasure_code/gf_6vect_dot_prod_avx512.asm
+++ b/erasure_code/gf_6vect_dot_prod_avx512.asm
@@ -57,7 +57,7 @@
  %define PS     8
  %define LOG_PS 3
 
- %define func(x) x:
+ %define func(x) x: endbranch
  %macro FUNC_SAVE 0
 	push	r12
 	push	r13

--- a/erasure_code/gf_6vect_dot_prod_sse.asm
+++ b/erasure_code/gf_6vect_dot_prod_sse.asm
@@ -51,7 +51,7 @@
  %define PS 8
  %define LOG_PS 3
 
- %define func(x) x:
+ %define func(x) x: endbranch
  %macro FUNC_SAVE 0
 	push	r12
 	push	r13

--- a/erasure_code/gf_6vect_mad_avx.asm
+++ b/erasure_code/gf_6vect_mad_avx.asm
@@ -111,7 +111,7 @@
  %define return rax
  %define return.w eax
 
- %define func(x) x:
+ %define func(x) x: endbranch
  %macro FUNC_SAVE 0
 	push	r12
 	push	r13

--- a/erasure_code/gf_6vect_mad_avx2.asm
+++ b/erasure_code/gf_6vect_mad_avx2.asm
@@ -107,7 +107,7 @@
  %define return rax
  %define return.w eax
 
- %define func(x) x:
+ %define func(x) x: endbranch
  %macro FUNC_SAVE 0
 	push	r12
  %endmacro

--- a/erasure_code/gf_6vect_mad_avx512.asm
+++ b/erasure_code/gf_6vect_mad_avx512.asm
@@ -46,7 +46,7 @@
  %define tmp2   r10
  %define tmp3   r12	;must be saved and restored
  %define return rax
- %define func(x) x:
+ %define func(x) x: endbranch
  %macro FUNC_SAVE 0
 	push	r12
  %endmacro

--- a/erasure_code/gf_6vect_mad_sse.asm
+++ b/erasure_code/gf_6vect_mad_sse.asm
@@ -113,7 +113,7 @@
  %define return rax
  %define return.w eax
 
- %define func(x) x:
+ %define func(x) x: endbranch
  %macro FUNC_SAVE 0
 	push	r12
 	push	r13

--- a/erasure_code/gf_vect_dot_prod_avx.asm
+++ b/erasure_code/gf_vect_dot_prod_avx.asm
@@ -48,7 +48,7 @@
  %endmacro
  %define SSTR SLDR
  %define PS 8
- %define func(x) x:
+ %define func(x) x: endbranch
  %define FUNC_SAVE
  %define FUNC_RESTORE
 %endif
@@ -106,7 +106,7 @@
 
  %define PS 4
  %define LOG_PS 2
- %define func(x) x:
+ %define func(x) x: endbranch
  %define arg(x) [ebp + PS*2 + PS*x]
 
  %define trans   ecx			;trans is for the variables in stack

--- a/erasure_code/gf_vect_dot_prod_avx2.asm
+++ b/erasure_code/gf_vect_dot_prod_avx2.asm
@@ -51,7 +51,7 @@
  %endmacro
  %define SSTR   SLDR
  %define PS     8
- %define func(x) x:
+ %define func(x) x: endbranch
  %define FUNC_SAVE
  %define FUNC_RESTORE
 %endif
@@ -111,7 +111,7 @@
 
  %define PS 4
  %define LOG_PS 2
- %define func(x) x:
+ %define func(x) x: endbranch
  %define arg(x) [ebp + PS*2 + PS*x]
 
  %define trans   ecx			;trans is for the variables in stack

--- a/erasure_code/gf_vect_dot_prod_avx512.asm
+++ b/erasure_code/gf_vect_dot_prod_avx512.asm
@@ -49,7 +49,7 @@
  %define PS     8
  %define LOG_PS 3
 
- %define func(x) x:
+ %define func(x) x: endbranch
  %define FUNC_SAVE
  %define FUNC_RESTORE
 %endif

--- a/erasure_code/gf_vect_dot_prod_sse.asm
+++ b/erasure_code/gf_vect_dot_prod_sse.asm
@@ -48,7 +48,7 @@
  %endmacro
  %define SSTR SLDR
  %define PS 8
- %define func(x) x:
+ %define func(x) x: endbranch
  %define FUNC_SAVE
  %define FUNC_RESTORE
 %endif
@@ -106,7 +106,7 @@
 
  %define PS 4
  %define LOG_PS 2
- %define func(x) x:
+ %define func(x) x: endbranch
  %define arg(x) [ebp + PS*2 + PS*x]
 
  %define trans   ecx			;trans is for the variables in stack

--- a/erasure_code/gf_vect_mad_avx.asm
+++ b/erasure_code/gf_vect_mad_avx.asm
@@ -82,7 +82,7 @@
  %define return rax
  %define return.w eax
 
- %define func(x) x:
+ %define func(x) x: endbranch
  %define FUNC_SAVE
  %define FUNC_RESTORE
 %endif

--- a/erasure_code/gf_vect_mad_avx2.asm
+++ b/erasure_code/gf_vect_mad_avx2.asm
@@ -88,7 +88,7 @@
  %define return rax
  %define return.w eax
 
- %define func(x) x:
+ %define func(x) x: endbranch
  %define FUNC_SAVE
  %define FUNC_RESTORE
 %endif

--- a/erasure_code/gf_vect_mad_avx512.asm
+++ b/erasure_code/gf_vect_mad_avx512.asm
@@ -44,7 +44,7 @@
  %define arg5  r9
  %define tmp   r11
  %define return rax
- %define func(x) x:
+ %define func(x) x: endbranch
  %define FUNC_SAVE
  %define FUNC_RESTORE
 %endif

--- a/erasure_code/gf_vect_mad_sse.asm
+++ b/erasure_code/gf_vect_mad_sse.asm
@@ -82,7 +82,7 @@
  %define return rax
  %define return.w eax
 
- %define func(x) x:
+ %define func(x) x: endbranch
  %define FUNC_SAVE
  %define FUNC_RESTORE
 %endif

--- a/erasure_code/gf_vect_mul_avx.asm
+++ b/erasure_code/gf_vect_mul_avx.asm
@@ -42,7 +42,7 @@
  %define arg5  r9
  %define tmp   r11
  %define return rax
- %define func(x) x:
+ %define func(x) x: endbranch
  %define FUNC_SAVE
  %define FUNC_RESTORE
 

--- a/erasure_code/gf_vect_mul_sse.asm
+++ b/erasure_code/gf_vect_mul_sse.asm
@@ -42,7 +42,7 @@
  %define arg5  r9
  %define tmp   r11
  %define return rax
- %define func(x) x:
+ %define func(x) x: endbranch
  %define FUNC_SAVE
  %define FUNC_RESTORE
 

--- a/igzip/adler32_avx2_4.asm
+++ b/igzip/adler32_avx2_4.asm
@@ -55,7 +55,7 @@ default rel
  %define b_d    r8d
  %define end    r13
 
- %define func(x) x:
+ %define func(x) x: endbranch
  %macro FUNC_SAVE 0
 	push	r12
 	push	r13

--- a/igzip/adler32_sse.asm
+++ b/igzip/adler32_sse.asm
@@ -52,7 +52,7 @@ default rel
  %define b_d    r8d
  %define end    r13
 
- %define func(x) x:
+ %define func(x) x: endbranch
  %macro FUNC_SAVE 0
 	push	r12
 	push	r13

--- a/igzip/encode_df_04.asm
+++ b/igzip/encode_df_04.asm
@@ -177,6 +177,7 @@ section .text
 
 global encode_deflate_icf_ %+ ARCH
 encode_deflate_icf_ %+ ARCH:
+	endbranch
 	FUNC_SAVE
 
 %ifnidn ptr, arg1

--- a/igzip/encode_df_06.asm
+++ b/igzip/encode_df_06.asm
@@ -190,6 +190,7 @@ section .text
 
 global encode_deflate_icf_ %+ ARCH
 encode_deflate_icf_ %+ ARCH:
+	endbranch
 	FUNC_SAVE
 
 %ifnidn ptr, arg1

--- a/igzip/igzip_body.asm
+++ b/igzip/igzip_body.asm
@@ -143,6 +143,7 @@ section .text
 ; arg 1: rcx: addr of stream
 global isal_deflate_body_ %+ ARCH
 isal_deflate_body_ %+ ARCH %+ :
+	endbranch
 %ifidn __OUTPUT_FORMAT__, elf64
 	mov	rcx, rdi
 %endif

--- a/igzip/igzip_decode_block_stateless.asm
+++ b/igzip/igzip_decode_block_stateless.asm
@@ -465,6 +465,7 @@ section .text
 
 global decode_huffman_code_block_stateless_ %+ ARCH
 decode_huffman_code_block_stateless_ %+ ARCH %+ :
+	endbranch
 
 	FUNC_SAVE
 

--- a/igzip/igzip_deflate_hash.asm
+++ b/igzip/igzip_deflate_hash.asm
@@ -104,6 +104,7 @@ section .text
 
 global isal_deflate_hash_crc_01
 isal_deflate_hash_crc_01:
+	endbranch
 	FUNC_SAVE
 
 	neg	f_i

--- a/igzip/igzip_finish.asm
+++ b/igzip/igzip_finish.asm
@@ -94,6 +94,7 @@ section .text
 ; arg 1: rcx: addr of stream
 global isal_deflate_finish_01
 isal_deflate_finish_01:
+	endbranch
 	PUSH_ALL	rbx, rsi, rdi, rbp, r12, r13, r14, r15
 	sub	rsp, stack_size
 

--- a/igzip/igzip_gen_icf_map_lh1_04.asm
+++ b/igzip/igzip_gen_icf_map_lh1_04.asm
@@ -147,7 +147,7 @@
 %define stack_size  16
 %define local_storage_offset 0
 
-%define func(x) x:
+%define func(x) x: endbranch
 %macro FUNC_SAVE 0
 	push	rbp
 	push	r12
@@ -175,6 +175,7 @@ section .text
 
 global gen_icf_map_lh1_04
 func(gen_icf_map_lh1_04)
+	endbranch
 	FUNC_SAVE
 
 	mov	file_start, [stream + _next_in]

--- a/igzip/igzip_gen_icf_map_lh1_06.asm
+++ b/igzip/igzip_gen_icf_map_lh1_06.asm
@@ -143,7 +143,7 @@
 	add	rsp, stack_size
 %endm
 %else
-%define func(x) x:
+%define func(x) x: endbranch
 %macro FUNC_SAVE 0
 	push	rbp
 	push	r12
@@ -166,6 +166,7 @@ section .text
 
 global gen_icf_map_lh1_06
 func(gen_icf_map_lh1_06)
+	endbranch
 	FUNC_SAVE
 
 	mov	file_start, [stream + _next_in]

--- a/igzip/igzip_icf_body_h1_gr_bt.asm
+++ b/igzip/igzip_icf_body_h1_gr_bt.asm
@@ -164,6 +164,7 @@ section .text
 ; arg 1: rcx: addr of stream
 global isal_deflate_icf_body_ %+ METHOD %+ _ %+ ARCH
 isal_deflate_icf_body_ %+ METHOD %+ _ %+ ARCH %+ :
+	endbranch
 %ifidn __OUTPUT_FORMAT__, elf64
 	mov	rcx, rdi
 %endif

--- a/igzip/igzip_icf_finish.asm
+++ b/igzip/igzip_icf_finish.asm
@@ -102,6 +102,7 @@ section .text
 ; arg 1: rcx: addr of stream
 global isal_deflate_icf_finish_ %+ METHOD %+ _01
 isal_deflate_icf_finish_ %+ METHOD %+ _01:
+	endbranch
 	PUSH_ALL	rbx, rsi, rdi, rbp, r12, r13, r14, r15
 	sub	rsp, stack_size
 

--- a/igzip/igzip_set_long_icf_fg_04.asm
+++ b/igzip/igzip_set_long_icf_fg_04.asm
@@ -122,7 +122,7 @@ default rel
 	add	rsp, stack_size
 %endm
 %else
-%define func(x) x:
+%define func(x) x: endbranch
 %macro FUNC_SAVE 0
 	push r12
 	push r13
@@ -141,6 +141,7 @@ section .text
 
 global set_long_icf_fg_04
 func(set_long_icf_fg_04)
+	endbranch
 	FUNC_SAVE
 
 	lea	end_in, [next_in + arg3]

--- a/igzip/igzip_set_long_icf_fg_06.asm
+++ b/igzip/igzip_set_long_icf_fg_06.asm
@@ -129,7 +129,7 @@
 	add	rsp, stack_size
 %endm
 %else
-%define func(x) x:
+%define func(x) x: endbranch
 %macro FUNC_SAVE 0
 	push	r12
 	push	r13
@@ -148,6 +148,7 @@ section .text
 
 global set_long_icf_fg_06
 func(set_long_icf_fg_06)
+	endbranch
 	FUNC_SAVE
 
 	lea	end_in, [next_in + arg3]

--- a/igzip/igzip_update_histogram.asm
+++ b/igzip/igzip_update_histogram.asm
@@ -256,6 +256,7 @@ section .text
 ; void isal_update_histogram
 global isal_update_histogram_ %+ ARCH
 isal_update_histogram_ %+ ARCH %+ :
+	endbranch
 	FUNC_SAVE
 
 %ifnidn	file_start, arg0

--- a/igzip/proc_heap.asm
+++ b/igzip/proc_heap.asm
@@ -60,6 +60,7 @@ section .text
 
 	global build_huff_tree
 build_huff_tree:
+	endbranch
 %ifidn __OUTPUT_FORMAT__, win64
 	push	rsi
 	push	rdi
@@ -108,6 +109,7 @@ build_huff_tree:
 align 32
 	global	build_heap
 build_heap:
+	endbranch
 %ifidn __OUTPUT_FORMAT__, win64
 	push	rsi
 	push	rdi

--- a/include/multibinary.asm
+++ b/include/multibinary.asm
@@ -71,10 +71,12 @@
 	section .text
 	mk_global %1, function
 	%1_mbinit:
+		endbranch
 		;;; only called the first time to setup hardware match
 		call	%1_dispatch_init
 		;;; falls thru to execute the hw optimized code
 	%1:
+		endbranch
 		jmp	mbin_ptr_sz [%1_dispatched]
 %endmacro
 

--- a/include/reg_sizes.asm
+++ b/include/reg_sizes.asm
@@ -200,8 +200,21 @@ section .note.GNU-stack noalloc noexec nowrite progbits
 section .text
 %endif
 %ifidn __OUTPUT_FORMAT__,elf64
+ %define __x86_64__
 section .note.GNU-stack noalloc noexec nowrite progbits
 section .text
+%endif
+%ifidn __OUTPUT_FORMAT__,win64
+ %define __x86_64__
+%endif
+%ifidn __OUTPUT_FORMAT__,macho64
+ %define __x86_64__
+%endif
+
+%ifdef __x86_64__
+ %define endbranch db 0xf3, 0x0f, 0x1e, 0xfa
+%else
+ %define endbranch db 0xf3, 0x0f, 0x1e, 0xfb
 %endif
 
 %ifdef REL_TEXT

--- a/mem/mem_zero_detect_avx.asm
+++ b/mem/mem_zero_detect_avx.asm
@@ -40,7 +40,7 @@
  %define tmpb  r11b
  %define tmp3  arg4
  %define return rax
- %define func(x) x:
+ %define func(x) x: endbranch
  %define FUNC_SAVE
  %define FUNC_RESTORE
 %endif

--- a/mem/mem_zero_detect_sse.asm
+++ b/mem/mem_zero_detect_sse.asm
@@ -40,7 +40,7 @@
  %define tmpb  r11b
  %define tmp3  arg4
  %define return rax
- %define func(x) x:
+ %define func(x) x: endbranch
  %define FUNC_SAVE
  %define FUNC_RESTORE
 %endif

--- a/raid/pq_check_sse.asm
+++ b/raid/pq_check_sse.asm
@@ -46,7 +46,7 @@
  %define tmp   r11
  %define tmp3  arg4
  %define return rax
- %define func(x) x:
+ %define func(x) x: endbranch
  %define FUNC_SAVE
  %define FUNC_RESTORE
 %endif

--- a/raid/pq_check_sse_i32.asm
+++ b/raid/pq_check_sse_i32.asm
@@ -46,7 +46,7 @@
  %define tmp   r11
  %define return rax
  %define PS 8
- %define func(x) x:
+ %define func(x) x: endbranch
  %define FUNC_SAVE
  %define FUNC_RESTORE
 
@@ -79,7 +79,7 @@
  %define arg1   ecx
  %define return eax
  %define PS 4
- %define func(x) x:
+ %define func(x) x: endbranch
  %define arg(x) [ebp+8+PS*x]
  %define arg2  edi	; must sav/restore
  %define arg3  esi

--- a/raid/pq_gen_avx.asm
+++ b/raid/pq_gen_avx.asm
@@ -46,7 +46,7 @@
  %define tmp   r11
  %define tmp3  arg4
  %define return rax
- %define func(x) x:
+ %define func(x) x: endbranch
  %define FUNC_SAVE
  %define FUNC_RESTORE
 %endif

--- a/raid/pq_gen_avx2.asm
+++ b/raid/pq_gen_avx2.asm
@@ -46,7 +46,7 @@
  %define tmp   r11
  %define tmp3  arg4
  %define return rax
- %define func(x) x:
+ %define func(x) x: endbranch
  %define FUNC_SAVE
  %define FUNC_RESTORE
 %endif

--- a/raid/pq_gen_avx512.asm
+++ b/raid/pq_gen_avx512.asm
@@ -49,7 +49,7 @@
  %define tmp   r11
  %define tmp3  arg4
  %define return rax
- %define func(x) x:
+ %define func(x) x: endbranch
  %define FUNC_SAVE
  %define FUNC_RESTORE
 %endif

--- a/raid/pq_gen_sse.asm
+++ b/raid/pq_gen_sse.asm
@@ -46,7 +46,7 @@
  %define tmp   r11
  %define tmp3  arg4
  %define return rax
- %define func(x) x:
+ %define func(x) x: endbranch
  %define FUNC_SAVE
  %define FUNC_RESTORE
 %endif

--- a/raid/pq_gen_sse_i32.asm
+++ b/raid/pq_gen_sse_i32.asm
@@ -46,7 +46,7 @@
  %define tmp   r11
  %define return rax
  %define PS 8
- %define func(x) x:
+ %define func(x) x: endbranch
  %define FUNC_SAVE
  %define FUNC_RESTORE
 
@@ -78,7 +78,7 @@
  %define arg1   ecx
  %define return eax
  %define PS 4
- %define func(x) x:
+ %define func(x) x: endbranch
  %define arg(x) [ebp+8+PS*x]
  %define arg2  edi	; must sav/restore
  %define arg3  esi

--- a/raid/raid_multibinary.asm
+++ b/raid/raid_multibinary.asm
@@ -74,8 +74,10 @@ section .text
 ;;;;
 mk_global  pq_check, function
 pq_check_mbinit:
+	endbranch
 	call	pq_check_dispatch_init
 pq_check:
+	endbranch
 	jmp     qword [pq_check_dispatched]
 
 pq_check_dispatch_init:
@@ -106,8 +108,10 @@ pq_check_dispatch_init:
 ;;;;
 mk_global  xor_check, function
 xor_check_mbinit:
+	endbranch
 	call    xor_check_dispatch_init
 xor_check:
+	endbranch
 	jmp     qword [xor_check_dispatched]
 
 xor_check_dispatch_init:

--- a/raid/xor_check_sse.asm
+++ b/raid/xor_check_sse.asm
@@ -49,7 +49,7 @@
  %define tmp3  arg4
  %define return rax
  %define PS 8
- %define func(x) x:
+ %define func(x) x: endbranch
  %define FUNC_SAVE
  %define FUNC_RESTORE
 
@@ -88,7 +88,7 @@
  %define tmp3   edx
  %define return eax
  %define PS 4
- %define func(x) x:
+ %define func(x) x: endbranch
  %define arg(x) [ebp+8+PS*x]
  %define arg2  edi	; must sav/restore
  %define arg3  esi

--- a/raid/xor_gen_avx.asm
+++ b/raid/xor_gen_avx.asm
@@ -45,7 +45,7 @@
  %define arg5  r9
  %define tmp   r11
  %define tmp3  arg4
- %define func(x) x:
+ %define func(x) x: endbranch
  %define return rax
  %define FUNC_SAVE
  %define FUNC_RESTORE

--- a/raid/xor_gen_avx512.asm
+++ b/raid/xor_gen_avx512.asm
@@ -47,7 +47,7 @@
  %define arg5  r9
  %define tmp   r11
  %define tmp3  arg4
- %define func(x) x:
+ %define func(x) x: endbranch
  %define return rax
  %define FUNC_SAVE
  %define FUNC_RESTORE

--- a/raid/xor_gen_sse.asm
+++ b/raid/xor_gen_sse.asm
@@ -49,7 +49,7 @@
  %define tmp3  arg4
  %define return rax
  %define PS 8
- %define func(x) x:
+ %define func(x) x: endbranch
  %define FUNC_SAVE
  %define FUNC_RESTORE
 
@@ -88,7 +88,7 @@
  %define tmp3   edx
  %define return eax
  %define PS 4
- %define func(x) x:
+ %define func(x) x: endbranch
  %define arg(x) [ebp+8+PS*x]
  %define arg2  edi	; must sav/restore
  %define arg3  esi


### PR DESCRIPTION
To support Intel CET, all indirect branch targets must start with
ENDBR32/ENDBR64.  Here is a patch to define endbranch and add it to
function entries in x86 assembly codes which are indirect branch
targets as discovered by running testsuite on Intel CET machine and
visual inspection.

Verified with

$ CC="gcc -Wl,-z,cet-report=error -fcf-protection" CXX="g++ -Wl,-z,cet-report=error -fcf-protection" .../configure x86_64-linux
$ make -j8
$ make -j8 check

with both nasm and yasm on both CET and non-CET machines.

Signed-off-by: H.J. Lu <hjl.tools@gmail.com>

This is for #137.