### PR TITLE
x86: Generate .note.gnu.property section for ELF output

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -117,11 +117,22 @@ test: $(addsuffix .run,$(unit_tests))
 	@echo Completed run: $<
 
 # Support for yasm/nasm/gas
+if INTEL_CET_ENABLED
+export CET_LD=$(LD)
+endif
 if USE_YASM
+if INTEL_CET_ENABLED
+  as_filter = ${srcdir}/tools/yasm-cet-filter.sh
+else
   as_filter = ${srcdir}/tools/yasm-filter.sh
 endif
+endif
 if USE_NASM
+if INTEL_CET_ENABLED
+  as_filter = ${srcdir}/tools/nasm-cet-filter.sh
+else
   as_filter = ${srcdir}/tools/nasm-filter.sh
+endif
 endif
 if CPU_AARCH64
   as_filter = $(CC) -D__ASSEMBLY__

--- a/configure.ac
+++ b/configure.ac
@@ -51,6 +51,7 @@ fi
 
 # Check for programs
 AC_PROG_CC_STDC
+AC_PROG_LD
 AC_USE_SYSTEM_EXTENSIONS
 AM_SILENT_RULES([yes])
 LT_INIT
@@ -68,6 +69,17 @@ AS_IF([test "x$enable_debug" = "xyes"], [
 
 # If this build is for x86, look for yasm and nasm
 if test x"$is_x86" = x"yes"; then
+  AC_MSG_CHECKING([whether Intel CET is enabled])
+  AC_TRY_COMPILE([],[
+#ifndef __CET__
+# error CET is not enabled
+#endif],
+		  [AC_MSG_RESULT([yes])
+		   intel_cet_enabled=yes],
+		  [AC_MSG_RESULT([no])
+		   intel_cet_enabled=no])
+  AM_CONDITIONAL(INTEL_CET_ENABLED, [test x"$intel_cet_enabled" = x"yes"])
+
   # Pick an assembler yasm or nasm
   if test x"$AS" = x""; then
     # Check for yasm and yasm features

--- a/tools/nasm-cet-filter.sh
+++ b/tools/nasm-cet-filter.sh
@@ -1,0 +1,56 @@
+#/bin/sh
+
+# Filter out unnecessary options added by automake
+
+while [ -n "$*" ]; do
+    case "$1" in
+	-o )
+	    # Supported options with arg
+	    options="$options $1 $2"
+	    shift
+	    object="$1"
+	    shift
+	    ;;
+	-f | -D )
+	    # Supported options with arg
+	    options="$options $1 $2"
+	    shift
+	    shift
+	    ;;
+	-I | -i )
+	    options="$options $1 $2/"
+	    shift
+	    shift
+	    ;;
+	--prefix* )
+	    # Supported options without arg
+	    options="$options $1"
+	    shift
+	    ;;
+	-I* | -i* )
+	    options="$options $1/"
+	    shift
+	    ;;
+	-D* ) # For defines we need to remove spaces
+	    case "$1" in
+		*' '* ) ;;
+		*) options="$options $1" ;;
+	    esac
+	    shift
+	    ;;
+	#-blah )
+	# Unsupported options with args - none known
+	-* )
+	    # Unsupported options with no args
+	    shift
+	    ;;
+	* )
+	    args="$args $1"
+	    shift
+	    ;;
+    esac
+done
+
+nasm $options $args
+$CET_LD -r -z ibt -z shstk -o $object.tmp $object
+mv $object.tmp $object

--- a/tools/yasm-cet-filter.sh
+++ b/tools/yasm-cet-filter.sh
@@ -1,0 +1,47 @@
+#/bin/sh
+
+# Filter out unnecessary options added by automake
+
+while [ -n "$*" ]; do
+    case "$1" in
+	-o )
+	    # Supported options with arg
+	    options="$options $1 $2"
+	    shift
+	    object="$1"
+	    shift
+	    ;;
+	-f | -I | -i | -D )
+	    # Supported options with arg
+	    options="$options $1 $2"
+	    shift
+	    shift
+	    ;;
+	-I* | -i* | --prefix* )
+	    # Supported options without arg
+	    options="$options $1"
+	    shift
+	    ;;
+	-D* ) # For defines we need to remove spaces
+	    case "$1" in
+		*' '* ) ;;
+		*) options="$options $1" ;;
+	    esac
+	    shift
+	    ;;
+	#-blah )
+	# Unsupported options with args - none known
+	-* )
+	    # Unsupported options with no args
+	    shift
+	    ;;
+	* )
+	    args="$args $1"
+	    shift
+	    ;;
+    esac
+done
+
+yasm $options $args
+$CET_LD -r -z ibt -z shstk -o $object.tmp $object
+mv $object.tmp $object


### PR DESCRIPTION
We should generate .note.gnu.property section with x86 assembly codes
for ELF outputs to mark Intel CET support when Intel CET is enabled
since all input files must be marked with Intel CET support in order
for linker to mark output with Intel CET support.  Since nasm and yasm
can't generate the proper .note.gnu.property section, yasm-cet-filter.sh
and yasm-filter.sh are added to generate the proper .note.gnu.property
with linker help.

Verified with

$ CC="gcc -Wl,-z,cet-report=error -fcf-protection" CXX="g++ -Wl,-z,cet-report=error -fcf-protection" .../configure x86_64-linux
$ make -j8

on Linux/x86-64.

This is for #137 