### PR TITLE
build: fix build break on non-x86 platform

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -78,7 +78,7 @@ if test x"$is_x86" = x"yes"; then
 		   intel_cet_enabled=yes],
 		  [AC_MSG_RESULT([no])
 		   intel_cet_enabled=no])
-  AM_CONDITIONAL(INTEL_CET_ENABLED, [test x"$intel_cet_enabled" = x"yes"])
+
 
   # Pick an assembler yasm or nasm
   if test x"$AS" = x""; then
@@ -261,6 +261,7 @@ else
   AM_CONDITIONAL(DARWIN, test "x" = "y")
 fi
 
+AM_CONDITIONAL(INTEL_CET_ENABLED, [test x"$intel_cet_enabled" = x"yes"])
 
 # Check for header files
 AC_CHECK_HEADERS([limits.h stdint.h stdlib.h string.h])


### PR DESCRIPTION
Arm64 and ppc64 build reports below error:
"configure: error: conditional "INTEL_CET_ENABLED" was never defined."
And the error should be report in all non-x86 platform.

Change-Id: I4c1b2fc99091424cfd5c62cf4d6536222b66712d
Signed-off-by: Jerry Yu <jerry.h.yu@arm.com>