### PR TITLE
Add conda shield to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ Intel(R) Intelligent Storage Acceleration Library
 =================================================
 
 [![Build Status](https://travis-ci.org/intel/isa-l.svg?branch=master)](https://travis-ci.org/intel/isa-l)
+[![Package on conda-forge](https://img.shields.io/conda/v/conda-forge/isa-l.svg)](https://anaconda.org/conda-forge/isa-l)
 
 ISA-L is a collection of optimized low-level functions targeting storage
 applications.  ISA-L includes:


### PR DESCRIPTION
This will make it easier for users to get the latest version. Installing with conda is easier than compiling it yourself. Distro packages (such as Debian's) do not always ship the latest version while conda-forge can. This badge will advertise this install method.

fixes #144 . After this PR the conda-forge package is openly advertised on the readme.

EDIT: To see what the shield looks like, check it [here](https://github.com/rhpvorderman/isa-l/blob/conda_shield/README.md).