### PR TITLE
build: Fix nmake check for multiple arch

### DIFF
--- a/tools/test_extended.sh
+++ b/tools/test_extended.sh
@@ -171,7 +171,7 @@ msg+=$'Custom hufftable build: Pass\n'
 $MAKE -f Makefile.unx clean
 
 test_start "nmake_file_consistency"
-$MAKE -f Makefile.unx test_nmake_file
+$MAKE -f Makefile.unx host_cpu="x86_64" test_nmake_file
 test_end "nmake_file_consistency" $?
 msg+=$'Nmake file consistency: Pass\n'
 


### PR DESCRIPTION
Alternate way to fix where nmake consistency can be cross-checked. 