### PR TITLE
Fixed clang as assembly

### DIFF
--- a/igzip/aarch64/gen_icf_map.S
+++ b/igzip/aarch64/gen_icf_map.S
@@ -231,7 +231,7 @@ gen_icf_map_h1_aarch64:
 	and	w_tmp2, w_tmp2, hist_size
 	add	dist, w_tmp2, 1
 	ldr	x_tmp0, [next_in]
-	sub	x_tmp1, next_in, x_dist, uxtx
+	sub	x_tmp1, next_in, w_dist, uxtw
 	ldr	x_tmp1, [x_tmp1]
 	eor	x_tmp0, x_tmp1, x_tmp0
 	tzbytecnt	param0,param1

--- a/igzip/aarch64/gen_icf_map.S
+++ b/igzip/aarch64/gen_icf_map.S
@@ -231,7 +231,7 @@ gen_icf_map_h1_aarch64:
 	and	w_tmp2, w_tmp2, hist_size
 	add	dist, w_tmp2, 1
 	ldr	x_tmp0, [next_in]
-	sub	x_tmp1, next_in, x_dist, uxtw
+	sub	x_tmp1, next_in, x_dist, uxtx
 	ldr	x_tmp1, [x_tmp1]
 	eor	x_tmp0, x_tmp1, x_tmp0
 	tzbytecnt	param0,param1

--- a/igzip/aarch64/igzip_decode_huffman_code_block_aarch64.S
+++ b/igzip/aarch64/igzip_decode_huffman_code_block_aarch64.S
@@ -208,7 +208,7 @@ declare Macros
 	lsl	temp,temp,x_read_in_length
 	orr	read_in,read_in,temp
 	add	read_in_length,read_in_length,8
-	uxtw	read_in_length,read_in_length
+	uxtw	x_read_in_length,read_in_length
 
 .endm
 

--- a/include/aarch64_multibinary.h
+++ b/include/aarch64_multibinary.h
@@ -192,6 +192,7 @@
 .endm
 
 #else /* __ASSEMBLY__ */
+#include <stdint.h>
 #include <sys/auxv.h>
 
 


### PR DESCRIPTION
Thanks to recent clang as update, it is possible to assemble isa-l with least modification.
I have tested compression/decompression using Android NDK r21b (NDK r20c is old and does not work)

Maybe we could work on https://github.com/intel/isa-l/issues/107 again.

Signed-off-by: Taiju Yamada <tyamada@bi.a.u-tokyo.ac.jp>