### PR TITLE
Fix clang build fail

### DIFF
--- a/igzip/aarch64/data_struct_aarch64.h
+++ b/igzip/aarch64/data_struct_aarch64.h
@@ -30,197 +30,186 @@
 #define __AARCH64_DATA_STRUCT_H__
 #ifdef __ASSEMBLY__
 
-#define FIELD(name,size,align) \
-	.set _FIELD_OFFSET,(_FIELD_OFFSET + (align) - 1) & (~ ((align)-1)); \
-	.equ name,_FIELD_OFFSET ;					\
-	.set _FIELD_OFFSET,_FIELD_OFFSET + size;                        \
-	.if align > _STRUCT_ALIGN;                                      \
-		.set _STRUCT_ALIGN, align;                              \
-	.endif;
-
-#define START_STRUCT(name) .set _FIELD_OFFSET,0;.set _STRUCT_ALIGN,0;
-
-#define END_STRUCT(name)   .set _##name##_size,_FIELD_OFFSET;\
-			   .set _##name##_align,_STRUCT_ALIGN
-
-#define CONST(name,value)  .equ name,value
-
+.macro start_struct name:req
+	.set _FIELD_OFFSET,0
+	.set _STRUCT_ALIGN,0
+.endm
+.macro end_struct name:req
+	.set _\name\()_size,_FIELD_OFFSET
+	.set _\name\()_align,_STRUCT_ALIGN
+.endm
+.macro field name:req, size:req, align:req
+	.set _FIELD_OFFSET,(_FIELD_OFFSET + (\align) - 1) & (~ ((\align)-1))
+	.set \name,_FIELD_OFFSET
+	.set _FIELD_OFFSET,_FIELD_OFFSET + \size
+	.if \align > _STRUCT_ALIGN
+		.set _STRUCT_ALIGN, \align
+	.endif
+.endm
 
 /// BitBuf2
-START_STRUCT(BitBuf2)
+start_struct BitBuf2
 	///	 name	size	align
-	FIELD (	 _m_bits,	8,	8 )
-	FIELD (	 _m_bit_count,	4,	4 )
-	FIELD (	 _m_out_buf,	8,	8 )
-	FIELD (	 _m_out_end,	8,	8 )
-	FIELD (	 _m_out_start,	8,	8 )
-END_STRUCT(BitBuf2)
-
+	field _m_bits,	8,	8
+	field _m_bit_count,	4,	4
+	field _m_out_buf,	8,	8
+	field _m_out_end,	8,	8
+	field _m_out_start,	8,	8
+end_struct BitBuf2
 
 /// isal_mod_hist
 #define HIST_ELEM_SIZE 4
-START_STRUCT(isal_mod_hist)
+start_struct isal_mod_hist
 	///	 name	size	align
-	FIELD (	 _d_hist,	30*HIST_ELEM_SIZE,	HIST_ELEM_SIZE )
-	FIELD (	 _ll_hist,	513*HIST_ELEM_SIZE,	HIST_ELEM_SIZE )
-END_STRUCT(isal_mod_hist)
-
+	field _d_hist,	30*HIST_ELEM_SIZE,	HIST_ELEM_SIZE
+	field _ll_hist,	513*HIST_ELEM_SIZE,	HIST_ELEM_SIZE
+end_struct isal_mod_hist
 
 /// hufftables_icf
 #define HUFF_CODE_SIZE 4
-START_STRUCT(hufftables_icf)
+start_struct hufftables_icf
 	///	 name	size	align
-	FIELD (	 _dist_table,	31	*	HUFF_CODE_SIZE,	HUFF_CODE_SIZE )
-	FIELD (	 _lit_len_table,	513	*	HUFF_CODE_SIZE,	HUFF_CODE_SIZE )
-END_STRUCT(hufftables_icf)
-
+	field _dist_table,	31	*	HUFF_CODE_SIZE,	HUFF_CODE_SIZE
+	field _lit_len_table,	513	*	HUFF_CODE_SIZE,	HUFF_CODE_SIZE
+end_struct hufftables_icf
 
 /// hash8k_buf
-START_STRUCT(hash8k_buf)
+start_struct hash8k_buf
 	///	 name	size	align
-	FIELD (	 _hash8k_table,	2	*	IGZIP_HASH8K_HASH_SIZE,	2 )
-END_STRUCT(hash8k_buf)
-
+	field _hash8k_table,	2	*	IGZIP_HASH8K_HASH_SIZE,	2
+end_struct hash8k_buf
 
 /// hash_map_buf
-START_STRUCT(hash_map_buf)
+start_struct hash_map_buf
 	///	 name	size	align
-	FIELD (	 _hash_table,	2	*	IGZIP_HASH_MAP_HASH_SIZE,	2 )
-	FIELD (	 _matches_next,	8,	8 )
-	FIELD (	 _matches_end,	8,	8 )
-	FIELD (	 _matches,	4*4*1024,	4 )
-	FIELD (	 _overflow,	4*LA,	4 )
-END_STRUCT(hash_map_buf)
-
+	field _hash_table,	2	*	IGZIP_HASH_MAP_HASH_SIZE,	2
+	field _matches_next,	8,	8
+	field _matches_end,	8,	8
+	field _matches,	4*4*1024,	4
+	field _overflow,	4*LA,	4
+end_struct hash_map_buf
 
 /// level_buf
 #define DEF_MAX_HDR_SIZE 328
-START_STRUCT(level_buf)
+start_struct level_buf
 	///	 name	size	align
-	FIELD (	 _encode_tables,	_hufftables_icf_size,	_hufftables_icf_align )
-	FIELD (	 _hist,	_isal_mod_hist_size,	_isal_mod_hist_align )
-	FIELD (	 _deflate_hdr_count,	4,	4 )
-	FIELD (	 _deflate_hdr_extra_bits,4,	4 )
-	FIELD (	 _deflate_hdr,	DEF_MAX_HDR_SIZE,	1 )
-	FIELD (	 _icf_buf_next,	8,	8 )
-	FIELD (	 _icf_buf_avail_out,	8,	8 )
-	FIELD (	 _icf_buf_start,	8,	8 )
-	FIELD (	 _lvl_extra,	_hash_map_buf_size,	_hash_map_buf_align )
-END_STRUCT(level_buf)
+	field _encode_tables,	_hufftables_icf_size,	_hufftables_icf_align
+	field _hist,	_isal_mod_hist_size,	_isal_mod_hist_align
+	field _deflate_hdr_count,	4,	4
+	field _deflate_hdr_extra_bits,4,	4
+	field _deflate_hdr,	DEF_MAX_HDR_SIZE,	1
+	field _icf_buf_next,	8,	8
+	field _icf_buf_avail_out,	8,	8
+	field _icf_buf_start,	8,	8
+	field _lvl_extra,	_hash_map_buf_size,	_hash_map_buf_align
+end_struct level_buf
 
-
-CONST( _hash8k_hash_table , _lvl_extra + _hash8k_table )
-CONST( _hash_map_hash_table , _lvl_extra + _hash_table )
-CONST( _hash_map_matches_next , _lvl_extra + _matches_next )
-CONST( _hash_map_matches_end , _lvl_extra + _matches_end )
-CONST( _hash_map_matches , _lvl_extra + _matches )
-CONST( _hist_lit_len , _hist+_ll_hist )
-CONST( _hist_dist , _hist+_d_hist )
-
+.set _hash8k_hash_table , _lvl_extra + _hash8k_table
+.set _hash_map_hash_table , _lvl_extra + _hash_table
+.set _hash_map_matches_next , _lvl_extra + _matches_next
+.set _hash_map_matches_end , _lvl_extra + _matches_end
+.set _hash_map_matches , _lvl_extra + _matches
+.set _hist_lit_len , _hist+_ll_hist
+.set _hist_dist , _hist+_d_hist
 
 /// isal_zstate
-START_STRUCT(isal_zstate)
+start_struct isal_zstate
 	///	 name	size	align
-	FIELD (	 _total_in_start,4,	4 )
-	FIELD (	 _block_next,	4,	4 )
-	FIELD (	 _block_end,	4,	4 )
-	FIELD (	 _dist_mask,	4,	4 )
-	FIELD (	 _hash_mask,	4,	4 )
-	FIELD (	 _state,	4,	4 )
-	FIELD (	 _bitbuf,	_BitBuf2_size,	_BitBuf2_align )
-	FIELD (	 _crc,	4,	4 )
-	FIELD (	 _has_wrap_hdr,	1,	1 )
-	FIELD (	 _has_eob_hdr,	1,	1 )
-	FIELD (	 _has_eob,	1,	1 )
-	FIELD (	 _has_hist,	1,	1 )
-	FIELD (	 _has_level_buf_init,	2,	2 )
-	FIELD (	 _count,	4,	4 )
-	FIELD (	 _tmp_out_buff,	16,	1 )
-	FIELD (	 _tmp_out_start,	4,	4 )
-	FIELD (	 _tmp_out_end,	4,	4 )
-	FIELD (	 _b_bytes_valid,	4,	4 )
-	FIELD (	 _b_bytes_processed,	4,	4 )
-	FIELD (	 _buffer,	BSIZE,	1 )
-	FIELD (	 _head,	IGZIP_LVL0_HASH_SIZE*2,	2 )
-END_STRUCT(isal_zstate)
+	field _total_in_start,4,	4
+	field _block_next,	4,	4
+	field _block_end,	4,	4
+	field _dist_mask,	4,	4
+	field _hash_mask,	4,	4
+	field _state,	4,	4
+	field _bitbuf,	_BitBuf2_size,	_BitBuf2_align
+	field _crc,	4,	4
+	field _has_wrap_hdr,	1,	1
+	field _has_eob_hdr,	1,	1
+	field _has_eob,	1,	1
+	field _has_hist,	1,	1
+	field _has_level_buf_init,	2,	2
+	field _count,	4,	4
+	field _tmp_out_buff,	16,	1
+	field _tmp_out_start,	4,	4
+	field _tmp_out_end,	4,	4
+	field _b_bytes_valid,	4,	4
+	field _b_bytes_processed,	4,	4
+	field _buffer,	BSIZE,	1
+	field _head,	IGZIP_LVL0_HASH_SIZE*2,	2
+end_struct isal_zstate
 
-
-
-CONST( _bitbuf_m_bits , _bitbuf+_m_bits )
-CONST( _bitbuf_m_bit_count , _bitbuf+_m_bit_count )
-CONST( _bitbuf_m_out_buf , _bitbuf+_m_out_buf )
-CONST( _bitbuf_m_out_end , _bitbuf+_m_out_end )
-CONST( _bitbuf_m_out_start , _bitbuf+_m_out_start )
-
+.set _bitbuf_m_bits , _bitbuf+_m_bits
+.set _bitbuf_m_bit_count , _bitbuf+_m_bit_count
+.set _bitbuf_m_out_buf , _bitbuf+_m_out_buf
+.set _bitbuf_m_out_end , _bitbuf+_m_out_end
+.set _bitbuf_m_out_start , _bitbuf+_m_out_start
 
 /// isal_zstream
-START_STRUCT(isal_zstream)
+start_struct isal_zstream
 	///	 name	size	align
-	FIELD (	 _next_in,	8,	8 )
-	FIELD (	 _avail_in,	4,	4 )
-	FIELD (	 _total_in,	4,	4 )
-	FIELD (	 _next_out,	8,	8 )
-	FIELD (	 _avail_out,	4,	4 )
-	FIELD (	 _total_out,	4,	4 )
-	FIELD (	 _hufftables,	8,	8 )
-	FIELD (	 _level,	4,	4 )
-	FIELD (	 _level_buf_size,	4,	4 )
-	FIELD (	 _level_buf,	8,	8 )
-	FIELD (	 _end_of_stream,	2,	2 )
-	FIELD (	 _flush,	2,	2 )
-	FIELD (	 _gzip_flag,	2,	2 )
-	FIELD (	 _hist_bits,	2,	2 )
-	FIELD (	 _internal_state,	_isal_zstate_size,	_isal_zstate_align )
-END_STRUCT(isal_zstream)
+	field _next_in,	8,	8
+	field _avail_in,	4,	4
+	field _total_in,	4,	4
+	field _next_out,	8,	8
+	field _avail_out,	4,	4
+	field _total_out,	4,	4
+	field _hufftables,	8,	8
+	field _level,	4,	4
+	field _level_buf_size,	4,	4
+	field _level_buf,	8,	8
+	field _end_of_stream,	2,	2
+	field _flush,	2,	2
+	field _gzip_flag,	2,	2
+	field _hist_bits,	2,	2
+	field _internal_state,	_isal_zstate_size,	_isal_zstate_align
+end_struct isal_zstream
 
-
-
-CONST( _internal_state_total_in_start , _internal_state+_total_in_start )
-CONST( _internal_state_block_next , _internal_state+_block_next )
-CONST( _internal_state_block_end , _internal_state+_block_end )
-CONST( _internal_state_b_bytes_valid , _internal_state+_b_bytes_valid )
-CONST( _internal_state_b_bytes_processed , _internal_state+_b_bytes_processed )
-CONST( _internal_state_crc , _internal_state+_crc )
-CONST( _internal_state_dist_mask , _internal_state+_dist_mask )
-CONST( _internal_state_hash_mask , _internal_state+_hash_mask )
-CONST( _internal_state_bitbuf , _internal_state+_bitbuf )
-CONST( _internal_state_state , _internal_state+_state )
-CONST( _internal_state_count , _internal_state+_count )
-CONST( _internal_state_tmp_out_buff , _internal_state+_tmp_out_buff )
-CONST( _internal_state_tmp_out_start , _internal_state+_tmp_out_start )
-CONST( _internal_state_tmp_out_end , _internal_state+_tmp_out_end )
-CONST( _internal_state_has_wrap_hdr , _internal_state+_has_wrap_hdr )
-CONST( _internal_state_has_eob , _internal_state+_has_eob )
-CONST( _internal_state_has_eob_hdr , _internal_state+_has_eob_hdr )
-CONST( _internal_state_has_hist , _internal_state+_has_hist )
-CONST( _internal_state_has_level_buf_init , _internal_state+_has_level_buf_init )
-CONST( _internal_state_buffer , _internal_state+_buffer )
-CONST( _internal_state_head , _internal_state+_head )
-CONST( _internal_state_bitbuf_m_bits , _internal_state+_bitbuf_m_bits )
-CONST( _internal_state_bitbuf_m_bit_count , _internal_state+_bitbuf_m_bit_count )
-CONST( _internal_state_bitbuf_m_out_buf , _internal_state+_bitbuf_m_out_buf )
-CONST( _internal_state_bitbuf_m_out_end , _internal_state+_bitbuf_m_out_end )
-CONST( _internal_state_bitbuf_m_out_start , _internal_state+_bitbuf_m_out_start )
+.set _internal_state_total_in_start , _internal_state+_total_in_start
+.set _internal_state_block_next , _internal_state+_block_next
+.set _internal_state_block_end , _internal_state+_block_end
+.set _internal_state_b_bytes_valid , _internal_state+_b_bytes_valid
+.set _internal_state_b_bytes_processed , _internal_state+_b_bytes_processed
+.set _internal_state_crc , _internal_state+_crc
+.set _internal_state_dist_mask , _internal_state+_dist_mask
+.set _internal_state_hash_mask , _internal_state+_hash_mask
+.set _internal_state_bitbuf , _internal_state+_bitbuf
+.set _internal_state_state , _internal_state+_state
+.set _internal_state_count , _internal_state+_count
+.set _internal_state_tmp_out_buff , _internal_state+_tmp_out_buff
+.set _internal_state_tmp_out_start , _internal_state+_tmp_out_start
+.set _internal_state_tmp_out_end , _internal_state+_tmp_out_end
+.set _internal_state_has_wrap_hdr , _internal_state+_has_wrap_hdr
+.set _internal_state_has_eob , _internal_state+_has_eob
+.set _internal_state_has_eob_hdr , _internal_state+_has_eob_hdr
+.set _internal_state_has_hist , _internal_state+_has_hist
+.set _internal_state_has_level_buf_init , _internal_state+_has_level_buf_init
+.set _internal_state_buffer , _internal_state+_buffer
+.set _internal_state_head , _internal_state+_head
+.set _internal_state_bitbuf_m_bits , _internal_state+_bitbuf_m_bits
+.set _internal_state_bitbuf_m_bit_count , _internal_state+_bitbuf_m_bit_count
+.set _internal_state_bitbuf_m_out_buf , _internal_state+_bitbuf_m_out_buf
+.set _internal_state_bitbuf_m_out_end , _internal_state+_bitbuf_m_out_end
+.set _internal_state_bitbuf_m_out_start , _internal_state+_bitbuf_m_out_start
 
 ///	 Internal	States
-CONST( ZSTATE_NEW_HDR , 0 )
-CONST( ZSTATE_HDR , (ZSTATE_NEW_HDR + 1) )
-CONST( ZSTATE_CREATE_HDR , (ZSTATE_HDR + 1) )
-CONST( ZSTATE_BODY , (ZSTATE_CREATE_HDR + 1) )
-CONST( ZSTATE_FLUSH_READ_BUFFER , (ZSTATE_BODY + 1) )
-CONST( ZSTATE_FLUSH_ICF_BUFFER , (ZSTATE_FLUSH_READ_BUFFER + 1) )
-CONST( ZSTATE_TYPE0_HDR , (ZSTATE_FLUSH_ICF_BUFFER + 1) )
-CONST( ZSTATE_TYPE0_BODY , (ZSTATE_TYPE0_HDR + 1) )
-CONST( ZSTATE_SYNC_FLUSH , (ZSTATE_TYPE0_BODY + 1) )
-CONST( ZSTATE_FLUSH_WRITE_BUFFER , (ZSTATE_SYNC_FLUSH + 1) )
-CONST( ZSTATE_TRL , (ZSTATE_FLUSH_WRITE_BUFFER + 1) )
+.set ZSTATE_NEW_HDR , 0
+.set ZSTATE_HDR , (ZSTATE_NEW_HDR + 1)
+.set ZSTATE_CREATE_HDR , (ZSTATE_HDR + 1)
+.set ZSTATE_BODY , (ZSTATE_CREATE_HDR + 1)
+.set ZSTATE_FLUSH_READ_BUFFER , (ZSTATE_BODY + 1)
+.set ZSTATE_FLUSH_ICF_BUFFER , (ZSTATE_FLUSH_READ_BUFFER + 1)
+.set ZSTATE_TYPE0_HDR , (ZSTATE_FLUSH_ICF_BUFFER + 1)
+.set ZSTATE_TYPE0_BODY , (ZSTATE_TYPE0_HDR + 1)
+.set ZSTATE_SYNC_FLUSH , (ZSTATE_TYPE0_BODY + 1)
+.set ZSTATE_FLUSH_WRITE_BUFFER , (ZSTATE_SYNC_FLUSH + 1)
+.set ZSTATE_TRL , (ZSTATE_FLUSH_WRITE_BUFFER + 1)
 
-CONST( _NO_FLUSH , 0 )
-CONST( _SYNC_FLUSH , 1 )
-CONST( _FULL_FLUSH , 2 )
-CONST( _STORED_BLK , 0 )
-CONST( IGZIP_NO_HIST , 0 )
-CONST( IGZIP_HIST , 1 )
-CONST( IGZIP_DICT_HIST , 2 )
+.set _NO_FLUSH , 0
+.set _SYNC_FLUSH , 1
+.set _FULL_FLUSH , 2
+.set _STORED_BLK , 0
+.set IGZIP_NO_HIST , 0
+.set IGZIP_HIST , 1
+.set IGZIP_DICT_HIST , 2
 #endif
 #endif

--- a/igzip/aarch64/gen_icf_map.S
+++ b/igzip/aarch64/gen_icf_map.S
@@ -231,7 +231,7 @@ gen_icf_map_h1_aarch64:
 	and	w_tmp2, w_tmp2, hist_size
 	add	dist, w_tmp2, 1
 	ldr	x_tmp0, [next_in]
-	sub	x_tmp1, next_in, x_dist, uxtw
+	sub	x_tmp1, next_in, w_dist, uxtw
 	ldr	x_tmp1, [x_tmp1]
 	eor	x_tmp0, x_tmp1, x_tmp0
 	tzbytecnt	param0,param1

--- a/igzip/aarch64/igzip_decode_huffman_code_block_aarch64.S
+++ b/igzip/aarch64/igzip_decode_huffman_code_block_aarch64.S
@@ -26,6 +26,7 @@
   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 **********************************************************************/
+
 	.arch armv8-a
 	.text
 	.align	2
@@ -36,20 +37,22 @@
 
 #define ENABLE_TBL_INSTRUCTION	1
 
-#define FIELD(name,size,align) \
-	.set _FIELD_OFFSET,(_FIELD_OFFSET + (align) - 1) & (~ ((align)-1)); \
-	.equ name,_FIELD_OFFSET ;					\
-	.set _FIELD_OFFSET,_FIELD_OFFSET + size;			\
-	.if align > _STRUCT_ALIGN;					\
-		.set _STRUCT_ALIGN, align;				\
-	.endif;
-
-#define START_STRUCT(name) .set _FIELD_OFFSET,0;.set _STRUCT_ALIGN,0;
-
-#define END_STRUCT(name)    .set _##name##_size , _FIELD_OFFSET;\
-			    .set _##name##_align,_STRUCT_ALIGN
-
-#define CONST(name,value)  .equ name,value
+.macro start_struct name:req
+	.set _FIELD_OFFSET,0
+	.set _STRUCT_ALIGN,0
+.endm
+.macro end_struct name:req
+	.set _\name\()_size,_FIELD_OFFSET
+	.set _\name\()_align,_STRUCT_ALIGN
+.endm
+.macro field name:req, size:req, align:req
+	.set _FIELD_OFFSET,(_FIELD_OFFSET + (\align) - 1) & (~ ((\align)-1))
+	.set \name,_FIELD_OFFSET
+	.set _FIELD_OFFSET,_FIELD_OFFSET + \size
+	.if \align > _STRUCT_ALIGN
+		.set _STRUCT_ALIGN, \align
+	.endif
+.endm
 
 #define ISAL_DECODE_LONG_BITS 12
 #define ISAL_DECODE_SHORT_BITS 10
@@ -73,55 +76,54 @@
 
 
 // inflate_huff_code
-START_STRUCT( inflate_huff_code_large )
+start_struct inflate_huff_code_large
 	//	 name	size	align
-	FIELD ( _short_code_lookup_large,	LARGE_SHORT_CODE_SIZE*(1<<(ISAL_DECODE_LONG_BITS)),	LARGE_LONG_CODE_SIZE )
-	FIELD ( _long_code_lookup_large,	LARGE_LONG_CODE_SIZE*MAX_LONG_CODE_LARGE,	LARGE_SHORT_CODE_SIZE )
-END_STRUCT(inflate_huff_code_large)
+	field _short_code_lookup_large,	LARGE_SHORT_CODE_SIZE*(1<<(ISAL_DECODE_LONG_BITS)),	LARGE_LONG_CODE_SIZE
+	field _long_code_lookup_large,	LARGE_LONG_CODE_SIZE*MAX_LONG_CODE_LARGE,	LARGE_SHORT_CODE_SIZE
+end_struct inflate_huff_code_large
 
 // inflate_huff_code
-START_STRUCT( inflate_huff_code_small )
+start_struct inflate_huff_code_small
 	//	 name	size	align
-	FIELD ( _short_code_lookup_small,	SMALL_SHORT_CODE_SIZE*(1<<(ISAL_DECODE_SHORT_BITS)),	SMALL_LONG_CODE_SIZE )
-	FIELD ( _long_code_lookup_small,	SMALL_LONG_CODE_SIZE*MAX_LONG_CODE_SMALL,	SMALL_SHORT_CODE_SIZE )
-END_STRUCT(inflate_huff_code_small)
-
+	field _short_code_lookup_small,	SMALL_SHORT_CODE_SIZE*(1<<(ISAL_DECODE_SHORT_BITS)),	SMALL_LONG_CODE_SIZE
+	field _long_code_lookup_small,	SMALL_LONG_CODE_SIZE*MAX_LONG_CODE_SMALL,	SMALL_SHORT_CODE_SIZE
+end_struct inflate_huff_code_small
 
 // inflate_state
-START_STRUCT( inflate_state )
+start_struct inflate_state
 	//	 name	size	align
-	FIELD ( _next_out,	8,	8 )
-	FIELD ( _avail_out,	4,	4 )
-	FIELD ( _total_out,	4,	4 )
-	FIELD ( _next_in,	8,	8 )
-	FIELD ( _read_in,	8,	8 )
-	FIELD ( _avail_in,	4,	4 )
-	FIELD ( _read_in_length,	4,	4 )
-	FIELD ( _lit_huff_code,	_inflate_huff_code_large_size,	_inflate_huff_code_large_align )
-	FIELD ( _dist_huff_code,	_inflate_huff_code_small_size,	_inflate_huff_code_small_align )
-	FIELD ( _block_state,	4,	4 )
-	FIELD ( _dict_length,	4,	4 )
-	FIELD ( _bfinal,	4,	4 )
-	FIELD ( _crc_flag,	4,	4 )
-	FIELD ( _crc,	4,	4 )
-	FIELD ( _hist_bits,	4,	4 )
-	FIELD ( _type0_block_len,	4,	4 )
-	FIELD ( _write_overflow_lits,	4,	4 )
-	FIELD ( _write_overflow_len,	4,	4 )
-	FIELD ( _copy_overflow_len,	4,	4 )
-	FIELD ( _copy_overflow_dist,	4,	4 )
-END_STRUCT(inflate_state)
+	field _next_out,	8,	8
+	field _avail_out,	4,	4
+	field _total_out,	4,	4
+	field _next_in,	8,	8
+	field _read_in,	8,	8
+	field _avail_in,	4,	4
+	field _read_in_length,	4,	4
+	field _lit_huff_code,	_inflate_huff_code_large_size,	_inflate_huff_code_large_align
+	field _dist_huff_code,	_inflate_huff_code_small_size,	_inflate_huff_code_small_align
+	field _block_state,	4,	4
+	field _dict_length,	4,	4
+	field _bfinal,	4,	4
+	field _crc_flag,	4,	4
+	field _crc,	4,	4
+	field _hist_bits,	4,	4
+	field _type0_block_len,	4,	4
+	field _write_overflow_lits,	4,	4
+	field _write_overflow_len,	4,	4
+	field _copy_overflow_len,	4,	4
+	field _copy_overflow_dist,	4,	4
+end_struct inflate_state
 
-CONST( _lit_huff_code_short_code_lookup , _lit_huff_code+_short_code_lookup_large )
-CONST( _lit_huff_code_long_code_lookup , _lit_huff_code+_long_code_lookup_large )
-CONST( _dist_huff_code_short_code_lookup , _dist_huff_code+_short_code_lookup_small )
-CONST( _dist_huff_code_long_code_lookup , _dist_huff_code+_long_code_lookup_small )
-CONST( ISAL_BLOCK_NEW_HDR , 0 )
-CONST( ISAL_BLOCK_HDR , 1 )
-CONST( ISAL_BLOCK_TYPE0 , 2 )
-CONST( ISAL_BLOCK_CODED , 3 )
-CONST( ISAL_BLOCK_INPUT_DONE , 4 )
-CONST( ISAL_BLOCK_FINISH , 5 )
+.set _lit_huff_code_short_code_lookup , _lit_huff_code+_short_code_lookup_large
+.set _lit_huff_code_long_code_lookup , _lit_huff_code+_long_code_lookup_large
+.set _dist_huff_code_short_code_lookup , _dist_huff_code+_short_code_lookup_small
+.set _dist_huff_code_long_code_lookup , _dist_huff_code+_long_code_lookup_small
+.set ISAL_BLOCK_NEW_HDR , 0
+.set ISAL_BLOCK_HDR , 1
+.set ISAL_BLOCK_TYPE0 , 2
+.set ISAL_BLOCK_CODED , 3
+.set ISAL_BLOCK_INPUT_DONE , 4
+.set ISAL_BLOCK_FINISH , 5
 
 /* Inflate Return values */
 #define ISAL_DECOMP_OK 0	/* No errors encountered while decompressing */
@@ -208,7 +210,7 @@ declare Macros
 	lsl	temp,temp,x_read_in_length
 	orr	read_in,read_in,temp
 	add	read_in_length,read_in_length,8
-	uxtw	read_in_length,read_in_length
+	uxtw	x_read_in_length,read_in_length
 
 .endm
 
@@ -262,9 +264,9 @@ declare Macros
 				struct inflate_state *state,
 				uint8_t * start_out)
 */
-	declare_generic_reg	arg0		0, x
-	declare_generic_reg	arg1		1, x
-	declare_generic_reg	arg2		2, x
+	declare_generic_reg	arg0,		0, x
+	declare_generic_reg	arg1,		1, x
+	declare_generic_reg	arg2,		2, x
 
 	declare_generic_reg	state,		11,x
 	declare_generic_reg	start_out,	18,x
@@ -328,7 +330,6 @@ decode_huffman_code_block_stateless_aarch64:
 	ld1	{v1.16b,v2.16b,v3.16b},[rfc_table]
 	add	rfc_table,rfc_table,48
 	ld1	{v4.16b-v7.16b},[rfc_table]
-
 #endif
 
 	/*
@@ -661,7 +662,6 @@ byte_copy_loop:
 	bne	byte_copy_loop
 	b	decompress_data_end
 	.size	decode_huffman_code_block_stateless_aarch64, .-decode_huffman_code_block_stateless_aarch64
-
 	.type	rfc_lookup_table, %object
 
 rfc_lookup_table:


### PR DESCRIPTION
@cielavenir, I re-org your commits . Please review that.  I think your patches have two topics

-  Clang support : It can be verified with current test matrix.
-  Arm64 Apple support: It can not be tested now. Please help review and verified it .

I am not sure if you think it is reasonable to merge this PR and abandon #162 and #164 ?
If No, Could you re-org your patches ? 

@gbtucker  , please review `include/aarch64_multibinary.h` . I am not sure if there are copy rights issues