### PR TITLE
More prominently feature language bindings and igzip on README page

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,14 @@ applications.  ISA-L includes:
   implementations.
 * Compression - Fast deflate-compatible data compression.
 * De-compression - Fast inflate-compatible data compression.
+* igzip - A command line application like gzip, accelerated with ISA-L.
 
 Also see:
 * [ISA-L for updates](https://github.com/intel/isa-l).
 * For crypto functions see [isa-l_crypto on github](https://github.com/intel/isa-l_crypto).
 * The [github wiki](https://github.com/intel/isa-l/wiki) including a list of
-  [distros/ports](https://github.com/intel/isa-l/wiki/Ports--Repos) offering binary packages.
+  [distros/ports](https://github.com/intel/isa-l/wiki/Ports--Repos) offering binary packages
+  as well as a list of [language bindings](https://github.com/intel/isa-l/wiki/Language-Bindings).
 * ISA-L [mailing list](https://lists.01.org/hyperkitty/list/isal@lists.01.org/).
 * [Contributing](CONTRIBUTING.md).
 


### PR DESCRIPTION
Igzip and the language bindings wiki page deserve to be properly featured on ISA-L's front page in my opinion.

The `python -m isal.igzip` application functions like `igzip` but has a little (~10%) overhead due to it being implemented in python instead. This has the advantage that it is cross-platform and therefore also works on Windows. There is no strict necessity anymore to try to port igzip to windows (I tried, but quickly found out it was non-trivial for me). Windows users might be happy that an easily installable igzip replacement is out here. In this PR, it features very prominently in the first paragraph, but it could also be moved to the 'Windows' section of the README. Or removed entirely if it is felt that the python bindings do not deserve a top-spot on the README. 
