### PR TITLE
Fix inconsistent next_in position in inflate_state for ISAL_GZIP_NO_HDR and ISAL_ZLIB_NO_HDR

### DIFF
--- a/igzip/igzip_inflate.c
+++ b/igzip/igzip_inflate.c
@@ -2278,12 +2278,16 @@ int isal_inflate_stateless(struct inflate_state *state)
 
 		case ISAL_ZLIB_NO_HDR:
 			finalize_adler32(state);
+			check_zlib_checksum(state);
 			break;
 
 		case ISAL_GZIP:
 		case ISAL_GZIP_NO_HDR_VER:
 			ret = check_gzip_checksum(state);
 			break;
+		case ISAL_GZIP_NO_HDR:
+		    check_gzip_checksum(state);
+		    break;
 		}
 	}
 
@@ -2325,9 +2329,15 @@ int isal_inflate(struct inflate_state *state)
 		case ISAL_ZLIB_NO_HDR_VER:
 			ret = check_zlib_checksum(state);
 			break;
+        case ISAL_ZLIB_NO_HDR:
+			check_zlib_checksum(state);
+			break;
 		case ISAL_GZIP:
 		case ISAL_GZIP_NO_HDR_VER:
 			ret = check_gzip_checksum(state);
+			break;
+		case ISAL_GZIP_NO_HDR:
+			check_gzip_checksum(state);
 			break;
 		}
 
@@ -2504,11 +2514,15 @@ int isal_inflate(struct inflate_state *state)
 
 			case ISAL_ZLIB_NO_HDR:
 				finalize_adler32(state);
+				check_zlib_checksum(state);
 				break;
 
 			case ISAL_GZIP:
 			case ISAL_GZIP_NO_HDR_VER:
 				ret = check_gzip_checksum(state);
+				break;
+            case ISAL_GZIP_NO_HDR:
+				check_gzip_checksum(state);
 				break;
 			}
 		}


### PR DESCRIPTION
Hi, I found a small inconsistency.

For ISAL_DEFLATE, ISAL_GZIP, ISAL_ZLIB, ISAL_GZIP_NO_HDR_VER and ISAL_ZLIB_NO_HDR_VER the inflate_state works consistently when decompression is finished.

- There may or may not be some bytes in read_in.
- number of bytes == read_in_length // 8
- next_in  == end of block + number of bytes.
- To recover all the bytes after the end of the block, extract all the bytes from read_in.

In the python bindings there is an `unused_data` member that displays all the bytes that were not processed by the decompressor. It can easily be created with the code [here](https://github.com/pycompression/python-isal/blob/5f2486ef0e2971b7b14efc36220ab385cfda4f13/src/isal/igzip_lib.pyx#L484).

Unfortunately that does not work for ISAL_ZLIB_NO_HDR and ISAL_GZIP_NO_HDR. There are the following cases here.
- ISAL_ZLIB_NO_HDR next_in position is at <end_of_zlib_block> +2, read_in_length = 56.
- ISAL_GZIP_NO_HDR next_in position is at <end_of_gzip_block> -1, read_in_length = 56.

These create weird corner cases for ISAL_ZLIB_NO_HDR and ISAL_GZIP_NO_HDR. This code fixes that by running the checksum checking code but without influencing the return code (which effectively just reads and ignores the trailer which is the behavior specified in igzip_lib.h). This makes sure that next_in is at the same position after using ISAL_GZIP_NO_HDR_VER and ISAL_GZIP_NO_HDR, or ISAL_ZLIB_NO_HDR_VER and ISAL_ZLIB_NO_HDR.

