### PR TITLE
Strip -isysroot and related flags from asm-filter

### DIFF
--- a/tools/nasm-cet-filter.sh
+++ b/tools/nasm-cet-filter.sh
@@ -22,6 +22,11 @@ while [ -n "$*" ]; do
 	    shift
 	    shift
 	    ;;
+	-isysroot | -iframeworkwithsysroot | -iwithsysroot | -framework )
+	    # Unsupported options with arg
+	    shift
+	    shift
+	    ;;
 	--prefix* )
 	    # Supported options without arg
 	    options="$options $1"

--- a/tools/nasm-filter.sh
+++ b/tools/nasm-filter.sh
@@ -15,6 +15,11 @@ while [ -n "$*" ]; do
 	    shift
 	    shift
 	    ;;
+	-isysroot | -iframeworkwithsysroot | -iwithsysroot | -framework )
+	    # Unsupported options with arg
+	    shift
+	    shift
+	    ;;
 	--prefix* )
 	    # Supported options without arg
 	    options="$options $1"

--- a/tools/yasm-cet-filter.sh
+++ b/tools/yasm-cet-filter.sh
@@ -17,6 +17,11 @@ while [ -n "$*" ]; do
 	    shift
 	    shift
 	    ;;
+	-isysroot | -iframeworkwithsysroot | -iwithsysroot | -framework )
+	    # Unsupported options with arg
+	    shift
+	    shift
+	    ;;
 	-I* | -i* | --prefix* )
 	    # Supported options without arg
 	    options="$options $1"

--- a/tools/yasm-filter.sh
+++ b/tools/yasm-filter.sh
@@ -10,6 +10,11 @@ while [ -n "$*" ]; do
 	    shift
 	    shift
 	    ;;
+	-isysroot | -iframeworkwithsysroot | -iwithsysroot | -framework )
+	    # Unsupported options with arg
+	    shift
+	    shift
+	    ;;
 	-I* | -i* | --prefix* )
 	    # Supported options without arg
 	    options="$options $1"


### PR DESCRIPTION
This helps python-isal compatibility.

Signed-off-by: Taiju Yamada <tyamada@bi.a.u-tokyo.ac.jp>

/cc @rhpvorderman