### PR TITLE
build: Change include shortcut D to not conflict with env

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,6 +7,7 @@ pkginclude_HEADERS = include/test.h
 noinst_LTLIBRARIES =
 bin_PROGRAMS =
 INCLUDE = -I $(srcdir)/include/
+D =
 
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = libisal.pc

--- a/make.inc
+++ b/make.inc
@@ -113,6 +113,7 @@ ifeq ($(shell uname),Darwin)
   STRIP_gcc  =
 endif
 
+D :=
 INCLUDE   = $(patsubst %,-I%/,$(subst :, ,$(VPATH)))
 CFLAGS   = $(CFLAGS_$(arch)) $(CFLAGS_$(CC)) $(DEBUG) -O2 $(DEFINES) $(INCLUDE)
 ASFLAGS  = $(ASFLAGS_$(arch)) $(ASFLAGS_$(CC)) $(DEBUG_$(AS)) $(DEFINES) $(INCLUDE)


### PR DESCRIPTION
The variable D= can be used to quickly add defines. This sets a null
default so it can only be overridden by the make command line.

fixes #184

Change-Id: I84615174547f36208d6d577c1e30b6fac83139b3
Signed-off-by: Greg Tucker <greg.b.tucker@intel.com>