### PR TITLE
AVX512 version of mem_zero_detect()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: Continous integration
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+    tags:
+      - "*"
+
+jobs:
+  check_format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - name: Install indent
+        run: sudo apt install indent
+      - name: Run format check
+        run: bash tools/check_format.sh
+
+  run_tests_unix:
+    needs: check_format
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+        assembler:
+          - nasm
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - name: Install build dependencies (Linux)
+        run: sudo apt install ${{ matrix.assembler }}
+        if: runner.os == 'Linux'
+      - name: Install build dependencies (Macos)
+        run: brew install ${{ matrix.assembler }} automake autoconf coreutils
+        if: runner.os == 'macOS'
+      - name: Build
+        run: |
+          ./autogen.sh
+          ./configure
+          bash -c 'make -j $(nproc)'
+      - name: Run tests
+        run: bash tools/test_checks.sh
+      - name: Run extended tests
+        run: bash tools/test_extended.sh
+        if: runner.os == 'Linux'  # Fails on Mac OS due to nmake consistency issue
+
+  run_tests_windows:
+    needs: check_format
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - name: Set MSVC developer prompt
+        uses: ilammy/msvc-dev-cmd@v1.6.0
+      - name: Install nasm
+        uses: ilammy/setup-nasm@v1.2.0
+      - name: Build
+        run: nmake -f Makefile.nmake

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ isa-l.h
 /libisal.la
 libisal.pc
 programs/igzip
+
+# Test programs
+*perf*
+*test*

--- a/mem/Makefile.am
+++ b/mem/Makefile.am
@@ -34,8 +34,9 @@ lsrc        += 	mem/mem_zero_detect_base.c
 lsrc_base_aliases += mem/mem_zero_detect_base_aliases.c
 lsrc_ppc64le      += mem/mem_zero_detect_base_aliases.c
 
-lsrc_x86_64 += 	mem/mem_zero_detect_avx.asm \
+lsrc_x86_64 += 	mem/mem_zero_detect_avx512.asm \
 		mem/mem_zero_detect_avx2.asm \
+		mem/mem_zero_detect_avx.asm \
 		mem/mem_zero_detect_sse.asm \
 		mem/mem_multibinary.asm
 

--- a/mem/mem_multibinary.asm
+++ b/mem/mem_multibinary.asm
@@ -33,6 +33,7 @@
 default rel
 [bits 64]
 
+extern mem_zero_detect_avx512
 extern mem_zero_detect_avx2
 extern mem_zero_detect_avx
 extern mem_zero_detect_sse
@@ -40,4 +41,4 @@ extern mem_zero_detect_base
 
 mbin_interface isal_zero_detect
 
-mbin_dispatch_init5 isal_zero_detect, mem_zero_detect_base, mem_zero_detect_sse, mem_zero_detect_avx, mem_zero_detect_avx2
+mbin_dispatch_init6 isal_zero_detect, mem_zero_detect_base, mem_zero_detect_sse, mem_zero_detect_avx, mem_zero_detect_avx2, mem_zero_detect_avx512


### PR DESCRIPTION
Hi, i wanted to see how well an AVX512 version of mem_zero_detect() would work over the AVX2 one.
The masking is really useful here: basically we first make a mask to load up to a cacheline boundary, then do 2 aligned load per cycle in the main loop, then load the reminder bytes under mask. With masking plus a couple of cmovs all is now done without branches, it should be faster and has a smaller codesize vs the AVX2 version.

I don't have access to an AVX512 machine yet, so i've only checked mem_zero_detect_test under Intel SDE, so please double check that everything works on a real machine too ;). 
