### PR TITLE
Add help2man as prerequisites in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ Building ISA-L
 ### Prerequisites
 
 * Make: GNU 'make' or 'nmake' (Windows).
-* Manual Generation: 'help2man'.
 * Optional: Building with autotools requires autoconf/automake packages.
+* Optional: Manual generation requires help2man package.
 
 x86_64:
 * Assembler: nasm. Version 2.15 or later suggested (other versions of nasm and

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Building ISA-L
 ### Prerequisites
 
 * Make: GNU 'make' or 'nmake' (Windows).
+* Manual Generation: 'help2man'.
 * Optional: Building with autotools requires autoconf/automake packages.
 
 x86_64:


### PR DESCRIPTION
Since this commit c872426b1c04c3c8d6b4601b440ef4b6cc55e98d added a man file for igzip, the `help2man` tool was used to generate manuals and was included in the build process since then.

https://github.com/intel/isa-l/blob/78f5c31e66fedab78328e592c49eefe4c2a733df/programs/Makefile.am#L37-L38

If users run `make` without help2man, it would throw an error at the last step:

```bash
/bin/bash: help2man: command not found
Makefile:4170: recipe for target 'programs/igzip.1' failed
make[1]: [programs/igzip.1] Error 127 (ignored)
```

This PR adds a line to README to remind users of that.