### PR TITLE
Fix s390 build

### DIFF
--- a/erasure_code/ec_base.c
+++ b/erasure_code/ec_base.c
@@ -171,7 +171,7 @@ void gf_vect_mul_init(unsigned char c, unsigned char *tbl)
 	unsigned char c4 = (c2 << 1) ^ ((c2 & 0x80) ? 0x1d : 0);	//Mult by GF{2}
 	unsigned char c8 = (c4 << 1) ^ ((c4 & 0x80) ? 0x1d : 0);	//Mult by GF{2}
 
-#if __WORDSIZE == 64 || _WIN64 || __x86_64__
+#if (__WORDSIZE == 64 || _WIN64 || __x86_64__) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
 	unsigned long long v1, v2, v4, v8, *t;
 	unsigned long long v10, v20, v40, v80;
 	unsigned char c17, c18, c20, c24;

--- a/igzip/bitbuf2.h
+++ b/igzip/bitbuf2.h
@@ -36,7 +36,6 @@
 #define inline __inline
 #endif
 
-
 /* MAX_BITBUF_BIT WRITE is the maximum number of bits than can be safely written
  * by consecutive calls of write_bits. Note this assumes the bitbuf is in a
  * state that is possible at the exit of write_bits */
@@ -60,28 +59,28 @@ static inline int is_full(struct BitBuf2 *me)
 	return (me->m_out_buf > me->m_out_end);
 }
 
-static inline uint8_t * buffer_ptr(struct BitBuf2 *me)
+static inline uint8_t *buffer_ptr(struct BitBuf2 *me)
 {
 	return me->m_out_buf;
 }
 
 static inline uint32_t buffer_used(struct BitBuf2 *me)
 {
-	return (uint32_t)(me->m_out_buf - me->m_out_start);
+	return (uint32_t) (me->m_out_buf - me->m_out_start);
 }
 
 static inline uint32_t buffer_bits_used(struct BitBuf2 *me)
 {
-	return (8 * (uint32_t)(me->m_out_buf - me->m_out_start) + me->m_bit_count);
+	return (8 * (uint32_t) (me->m_out_buf - me->m_out_start) + me->m_bit_count);
 }
 
 static inline void flush_bits(struct BitBuf2 *me)
 {
 	uint32_t bits;
-	store_u64(me->m_out_buf, me->m_bits);
+	store_le_u64(me->m_out_buf, me->m_bits);
 	bits = me->m_bit_count & ~7;
 	me->m_bit_count -= bits;
-	me->m_out_buf += bits/8;
+	me->m_out_buf += bits / 8;
 	me->m_bits >>= bits;
 
 }
@@ -91,7 +90,7 @@ static inline void flush(struct BitBuf2 *me)
 {
 	uint32_t bytes;
 	if (me->m_bit_count) {
-		store_u64(me->m_out_buf, me->m_bits);
+		store_le_u64(me->m_out_buf, me->m_bits);
 		bytes = (me->m_bit_count + 7) / 8;
 		me->m_out_buf += bytes;
 	}
@@ -114,14 +113,14 @@ static inline void write_bits_unsafe(struct BitBuf2 *me, uint64_t code, uint32_t
 }
 
 static inline void write_bits(struct BitBuf2 *me, uint64_t code, uint32_t count)
-{	/* Assumes there is space to fit code into m_bits. */
+{				/* Assumes there is space to fit code into m_bits. */
 	me->m_bits |= code << me->m_bit_count;
 	me->m_bit_count += count;
 	flush_bits(me);
 }
 
 static inline void write_bits_flush(struct BitBuf2 *me, uint64_t code, uint32_t count)
-{	/* Assumes there is space to fit code into m_bits. */
+{				/* Assumes there is space to fit code into m_bits. */
 	me->m_bits |= code << me->m_bit_count;
 	me->m_bit_count += count;
 	flush(me);

--- a/igzip/encode_df.h
+++ b/igzip/encode_df.h
@@ -20,11 +20,17 @@
 #define ICF_CODE_LEN 32
 
 struct deflate_icf {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 	uint32_t lit_len:LIT_LEN_BIT_COUNT;
 	uint32_t lit_dist:DIST_LIT_BIT_COUNT;
 	uint32_t dist_extra:ICF_CODE_LEN - DIST_LIT_BIT_COUNT - ICF_DIST_OFFSET;
+#else
+	uint32_t dist_extra:ICF_CODE_LEN - DIST_LIT_BIT_COUNT - ICF_DIST_OFFSET;
+	uint32_t lit_dist:DIST_LIT_BIT_COUNT;
+	uint32_t lit_len:LIT_LEN_BIT_COUNT;
+#endif
 };
 
 struct deflate_icf *encode_deflate_icf(struct deflate_icf *next_in, struct deflate_icf *end_in,
-			               struct BitBuf2 *bb, struct hufftables_icf * hufftables);
+				       struct BitBuf2 *bb, struct hufftables_icf *hufftables);
 #endif

--- a/igzip/generate_custom_hufftables.c
+++ b/igzip/generate_custom_hufftables.c
@@ -291,13 +291,13 @@ void isal_update_histogram_dict(uint8_t * start_stream, int dict_length, int len
 	memset(last_seen, 0, sizeof(histogram->hash_table));	/* Initialize last_seen to be 0. */
 
 	for (current = start_stream; current < end_dict - 4; current++) {
-		literal = load_u32(current);
+		literal = load_le_u32(current);
 		hash = compute_hash(literal) & LVL0_HASH_MASK;
 		last_seen[hash] = (current - start_stream) & 0xFFFF;
 	}
 
 	for (current = start_stream + dict_length; current < end_stream - 3; current++) {
-		literal = load_u32(current);
+		literal = load_le_u32(current);
 		hash = compute_hash(literal) & LVL0_HASH_MASK;
 		seen = last_seen[hash];
 		last_seen[hash] = (current - start_stream) & 0xFFFF;
@@ -317,7 +317,7 @@ void isal_update_histogram_dict(uint8_t * start_stream, int dict_length, int len
 					end = end_stream - 3;
 				next_hash++;
 				for (; next_hash < end; next_hash++) {
-					literal = load_u32(next_hash);
+					literal = load_le_u32(next_hash);
 					hash = compute_hash(literal) & LVL0_HASH_MASK;
 					last_seen[hash] = (next_hash - start_stream) & 0xFFFF;
 				}

--- a/igzip/huff_codes.c
+++ b/igzip/huff_codes.c
@@ -680,7 +680,7 @@ void isal_update_histogram_base(uint8_t * start_stream, int length,
 	end_stream = start_stream + length;
 	memset(last_seen, 0, sizeof(histogram->hash_table));	/* Initialize last_seen to be 0. */
 	for (current = start_stream; current < end_stream - 3; current++) {
-		literal = load_u32(current);
+		literal = load_le_u32(current);
 		hash = compute_hash(literal) & LVL0_HASH_MASK;
 		seen = last_seen[hash];
 		last_seen[hash] = (current - start_stream) & 0xFFFF;
@@ -700,7 +700,7 @@ void isal_update_histogram_base(uint8_t * start_stream, int length,
 					end = end_stream - 3;
 				next_hash++;
 				for (; next_hash < end; next_hash++) {
-					literal = load_u32(next_hash);
+					literal = load_le_u32(next_hash);
 					hash = compute_hash(literal) & LVL0_HASH_MASK;
 					last_seen[hash] = (next_hash - start_stream) & 0xFFFF;
 				}

--- a/igzip/huff_codes.h
+++ b/igzip/huff_codes.h
@@ -104,15 +104,26 @@
  */
 struct huff_code {
 	union {
-                struct {
-                        uint32_t code_and_extra:24;
-                        uint32_t length2:8;
-                };
+		struct {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+			uint32_t code_and_extra:24;
+			uint32_t length2:8;
+#else
+			uint32_t length2:8;
+			uint32_t code_and_extra:24;
+#endif
+		};
 
 		struct {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 			uint16_t code;
 			uint8_t extra_bit_count;
 			uint8_t length;
+#else
+			uint8_t length;
+			uint8_t extra_bit_count;
+			uint16_t code;
+#endif
 		};
 
 		uint32_t code_and_length;
@@ -120,8 +131,13 @@ struct huff_code {
 };
 
 struct tree_node {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 	uint32_t child;
 	uint32_t depth;
+#else
+	uint32_t depth;
+	uint32_t child;
+#endif
 };
 
 struct heap_tree {
@@ -164,7 +180,7 @@ struct hufftables_icf {
  * with the set hufftable
  */
 uint64_t
-create_hufftables_icf(struct BitBuf2 *bb, struct hufftables_icf * hufftables,
-                  struct isal_mod_hist *hist, uint32_t end_of_block);
+create_hufftables_icf(struct BitBuf2 *bb, struct hufftables_icf *hufftables,
+		      struct isal_mod_hist *hist, uint32_t end_of_block);
 
 #endif

--- a/igzip/huffman.h
+++ b/igzip/huffman.h
@@ -58,15 +58,14 @@ static inline uint32_t bsr(uint32_t val)
 	if (val != 0) {
 		_BitScanReverse(&ret, val);
 		msb = ret + 1;
-	}
-	else
+	} else
 		msb = 0;
 #elif defined( __LZCNT__)
 	msb = 32 - __lzcnt32(val);
 #elif defined(__x86_64__) || defined(__aarch64__)
-	msb = (val == 0)? 0 : 32 - __builtin_clz(val);
+	msb = (val == 0) ? 0 : 32 - __builtin_clz(val);
 #else
-	for(msb = 0; val > 0; val >>= 1)
+	for (msb = 0; val > 0; val >>= 1)
 		msb++;
 #endif
 	return msb;
@@ -81,17 +80,18 @@ static inline uint32_t tzbytecnt(uint64_t val)
 	cnt = cnt / 8;
 #elif defined(__x86_64__) || defined(__aarch64__)
 
-	cnt = (val == 0)? 64 : __builtin_ctzll(val);
+	cnt = (val == 0) ? 64 : __builtin_ctzll(val);
 	cnt = cnt / 8;
 
 #else
-	for(cnt = 8; val > 0; val <<= 8)
+	for (cnt = 8; val > 0; val <<= 8)
 		cnt -= 1;
 #endif
 	return cnt;
 }
 
-static void compute_dist_code(struct isal_hufftables *hufftables, uint16_t dist, uint64_t *p_code, uint64_t *p_len)
+static void compute_dist_code(struct isal_hufftables *hufftables, uint16_t dist,
+			      uint64_t * p_code, uint64_t * p_len)
 {
 	assert(dist > IGZIP_DIST_TABLE_SIZE);
 
@@ -116,7 +116,8 @@ static void compute_dist_code(struct isal_hufftables *hufftables, uint16_t dist,
 	*p_len = len + num_extra_bits;
 }
 
-static inline void get_dist_code(struct isal_hufftables *hufftables, uint32_t dist, uint64_t *code, uint64_t *len)
+static inline void get_dist_code(struct isal_hufftables *hufftables, uint32_t dist,
+				 uint64_t * code, uint64_t * len)
 {
 	if (dist < 1)
 		dist = 0;
@@ -132,7 +133,8 @@ static inline void get_dist_code(struct isal_hufftables *hufftables, uint32_t di
 	}
 }
 
-static inline void get_len_code(struct isal_hufftables *hufftables, uint32_t length, uint64_t *code, uint64_t *len)
+static inline void get_len_code(struct isal_hufftables *hufftables, uint32_t length,
+				uint64_t * code, uint64_t * len)
 {
 	assert(length >= 3);
 	assert(length <= 258);
@@ -143,7 +145,8 @@ static inline void get_len_code(struct isal_hufftables *hufftables, uint32_t len
 	*len = code_len & 0x1F;
 }
 
-static inline void get_lit_code(struct isal_hufftables *hufftables, uint32_t lit, uint64_t *code, uint64_t *len)
+static inline void get_lit_code(struct isal_hufftables *hufftables, uint32_t lit,
+				uint64_t * code, uint64_t * len)
 {
 	assert(lit <= 256);
 
@@ -151,7 +154,7 @@ static inline void get_lit_code(struct isal_hufftables *hufftables, uint32_t lit
 	*len = hufftables->lit_table_sizes[lit];
 }
 
-static void compute_dist_icf_code(uint32_t dist, uint32_t *code, uint32_t *extra_bits)
+static void compute_dist_icf_code(uint32_t dist, uint32_t * code, uint32_t * extra_bits)
 {
 	uint32_t msb;
 	uint32_t num_extra_bits;
@@ -166,7 +169,7 @@ static void compute_dist_icf_code(uint32_t dist, uint32_t *code, uint32_t *extra
 	assert(*code < 30);
 }
 
-static inline void get_dist_icf_code(uint32_t dist, uint32_t *code, uint32_t *extra_bits)
+static inline void get_dist_icf_code(uint32_t dist, uint32_t * code, uint32_t * extra_bits)
 {
 	assert(dist >= 1);
 	assert(dist <= 32768);
@@ -178,7 +181,7 @@ static inline void get_dist_icf_code(uint32_t dist, uint32_t *code, uint32_t *ex
 	}
 }
 
-static inline void get_len_icf_code(uint32_t length, uint32_t *code)
+static inline void get_len_icf_code(uint32_t length, uint32_t * code)
 {
 	assert(length >= 3);
 	assert(length <= 258);
@@ -186,7 +189,7 @@ static inline void get_len_icf_code(uint32_t length, uint32_t *code)
 	*code = length + 254;
 }
 
-static inline void get_lit_icf_code(uint32_t lit, uint32_t *code)
+static inline void get_lit_icf_code(uint32_t lit, uint32_t * code)
 {
 	assert(lit <= 256);
 
@@ -234,9 +237,10 @@ static inline uint32_t compute_hash_mad(uint32_t data)
 	return data;
 }
 
-static inline uint32_t compute_long_hash(uint64_t data) {
+static inline uint32_t compute_long_hash(uint64_t data)
+{
 
-	return compute_hash(data >> 32)^compute_hash(data);
+	return compute_hash(data >> 32) ^ compute_hash(data);
 }
 
 /**
@@ -251,48 +255,48 @@ static inline int compare258(uint8_t * str1, uint8_t * str2, uint32_t max_length
 	uint64_t test;
 	uint64_t loop_length;
 
-	if(max_length > 258)
+	if (max_length > 258)
 		max_length = 258;
 
 	loop_length = max_length & ~0x7;
 
-	for(count = 0; count < loop_length; count += 8){
-		test = load_u64(str1);
-		test ^= load_u64(str2);
-		if(test != 0)
+	for (count = 0; count < loop_length; count += 8) {
+		test = load_le_u64(str1);
+		test ^= load_le_u64(str2);
+		if (test != 0)
 			return count + tzbytecnt(test);
 		str1 += 8;
 		str2 += 8;
 	}
 
-	switch(max_length % 8){
+	switch (max_length % 8) {
 
 	case 7:
-		if(*str1++ != *str2++)
+		if (*str1++ != *str2++)
 			return count;
 		count++;
 	case 6:
-		if(*str1++ != *str2++)
+		if (*str1++ != *str2++)
 			return count;
 		count++;
 	case 5:
-		if(*str1++ != *str2++)
+		if (*str1++ != *str2++)
 			return count;
 		count++;
 	case 4:
-		if(*str1++ != *str2++)
+		if (*str1++ != *str2++)
 			return count;
 		count++;
 	case 3:
-		if(*str1++ != *str2++)
+		if (*str1++ != *str2++)
 			return count;
 		count++;
 	case 2:
-		if(*str1++ != *str2++)
+		if (*str1++ != *str2++)
 			return count;
 		count++;
 	case 1:
-		if(*str1 != *str2)
+		if (*str1 != *str2)
 			return count;
 		count++;
 	}
@@ -314,43 +318,43 @@ static inline int compare(uint8_t * str1, uint8_t * str2, uint32_t max_length)
 
 	loop_length = max_length & ~0x7;
 
-	for(count = 0; count < loop_length; count += 8){
-		test = load_u64(str1);
-		test ^= load_u64(str2);
-		if(test != 0)
+	for (count = 0; count < loop_length; count += 8) {
+		test = load_le_u64(str1);
+		test ^= load_le_u64(str2);
+		if (test != 0)
 			return count + tzbytecnt(test);
 		str1 += 8;
 		str2 += 8;
 	}
 
-	switch(max_length % 8){
+	switch (max_length % 8) {
 
 	case 7:
-		if(*str1++ != *str2++)
+		if (*str1++ != *str2++)
 			return count;
 		count++;
 	case 6:
-		if(*str1++ != *str2++)
+		if (*str1++ != *str2++)
 			return count;
 		count++;
 	case 5:
-		if(*str1++ != *str2++)
+		if (*str1++ != *str2++)
 			return count;
 		count++;
 	case 4:
-		if(*str1++ != *str2++)
+		if (*str1++ != *str2++)
 			return count;
 		count++;
 	case 3:
-		if(*str1++ != *str2++)
+		if (*str1++ != *str2++)
 			return count;
 		count++;
 	case 2:
-		if(*str1++ != *str2++)
+		if (*str1++ != *str2++)
 			return count;
 		count++;
 	case 1:
-		if(*str1 != *str2)
+		if (*str1 != *str2)
 			return count;
 		count++;
 	}

--- a/igzip/igzip_base.c
+++ b/igzip/igzip_base.c
@@ -58,7 +58,7 @@ void isal_deflate_body_base(struct isal_zstream *stream)
 			return;
 		}
 
-		literal = load_u32(next_in);
+		literal = load_le_u32(next_in);
 		hash = compute_hash(literal) & hash_mask;
 		dist = (next_in - file_start - last_seen[hash]) & 0xFFFF;
 		last_seen[hash] = (uint64_t) (next_in - file_start);
@@ -79,7 +79,7 @@ void isal_deflate_body_base(struct isal_zstream *stream)
 				next_hash++;
 
 				for (; next_hash < end; next_hash++) {
-					literal = load_u32(next_hash);
+					literal = load_le_u32(next_hash);
 					hash = compute_hash(literal) & hash_mask;
 					last_seen[hash] = (uint64_t) (next_hash - file_start);
 				}
@@ -140,7 +140,7 @@ void isal_deflate_finish_base(struct isal_zstream *stream)
 				return;
 			}
 
-			literal = load_u32(next_in);
+			literal = load_le_u32(next_in);
 			hash = compute_hash(literal) & hash_mask;
 			dist = (next_in - file_start - last_seen[hash]) & 0xFFFF;
 			last_seen[hash] = (uint64_t) (next_in - file_start);
@@ -159,7 +159,7 @@ void isal_deflate_finish_base(struct isal_zstream *stream)
 					next_hash++;
 
 					for (; next_hash < end - 3; next_hash++) {
-						literal = load_u32(next_hash);
+						literal = load_le_u32(next_hash);
 						hash = compute_hash(literal) & hash_mask;
 						last_seen[hash] =
 						    (uint64_t) (next_hash - file_start);
@@ -227,7 +227,7 @@ void isal_deflate_hash_base(uint16_t * hash_table, uint32_t hash_mask,
 	uint16_t index = current_index - dict_len;
 
 	while (next_in <= end_in) {
-		literal = load_u32(next_in);
+		literal = load_le_u32(next_in);
 		hash = compute_hash(literal) & hash_mask;
 		hash_table[hash] = index;
 		index++;

--- a/igzip/igzip_icf_base.c
+++ b/igzip/igzip_icf_base.c
@@ -73,7 +73,7 @@ void isal_deflate_icf_body_hash_hist_base(struct isal_zstream *stream)
 			return;
 		}
 
-		literal = load_u32(next_in);
+		literal = load_le_u32(next_in);
 		hash = compute_hash(literal) & hash_mask;
 		dist = (next_in - file_start - last_seen[hash]) & 0xFFFF;
 		last_seen[hash] = (uint64_t) (next_in - file_start);
@@ -94,7 +94,7 @@ void isal_deflate_icf_body_hash_hist_base(struct isal_zstream *stream)
 				next_hash++;
 
 				for (; next_hash < end; next_hash++) {
-					literal = load_u32(next_hash);
+					literal = load_le_u32(next_hash);
 					hash = compute_hash(literal) & hash_mask;
 					last_seen[hash] = (uint64_t) (next_hash - file_start);
 				}
@@ -168,7 +168,7 @@ void isal_deflate_icf_finish_hash_hist_base(struct isal_zstream *stream)
 			return;
 		}
 
-		literal = load_u32(next_in);
+		literal = load_le_u32(next_in);
 		hash = compute_hash(literal) & hash_mask;
 		dist = (next_in - file_start - last_seen[hash]) & 0xFFFF;
 		last_seen[hash] = (uint64_t) (next_in - file_start);
@@ -186,7 +186,7 @@ void isal_deflate_icf_finish_hash_hist_base(struct isal_zstream *stream)
 				next_hash++;
 
 				for (; next_hash < end - 3; next_hash++) {
-					literal = load_u32(next_hash);
+					literal = load_le_u32(next_hash);
 					hash = compute_hash(literal) & hash_mask;
 					last_seen[hash] = (uint64_t) (next_hash - file_start);
 				}
@@ -278,7 +278,7 @@ void isal_deflate_icf_finish_hash_map_base(struct isal_zstream *stream)
 			return;
 		}
 
-		literal = load_u32(next_in);
+		literal = load_le_u32(next_in);
 		hash = compute_hash_mad(literal) & hash_mask;
 		dist = (next_in - file_start - last_seen[hash]) & 0xFFFF;
 		last_seen[hash] = (uint64_t) (next_in - file_start);
@@ -296,7 +296,7 @@ void isal_deflate_icf_finish_hash_map_base(struct isal_zstream *stream)
 				next_hash++;
 
 				for (; next_hash < end - 3; next_hash++) {
-					literal = load_u32(next_hash);
+					literal = load_le_u32(next_hash);
 					hash = compute_hash_mad(literal) & hash_mask;
 					last_seen[hash] = (uint64_t) (next_hash - file_start);
 				}
@@ -361,7 +361,7 @@ void isal_deflate_hash_mad_base(uint16_t * hash_table, uint32_t hash_mask,
 	uint16_t index = current_index - dict_len;
 
 	while (next_in <= end_in) {
-		literal = load_u32(next_in);
+		literal = load_le_u32(next_in);
 		hash = compute_hash_mad(literal) & hash_mask;
 		hash_table[hash] = index;
 		index++;

--- a/igzip/igzip_rand_test.c
+++ b/igzip/igzip_rand_test.c
@@ -546,7 +546,7 @@ int inflate_stateless_pass(uint8_t * compress_buf, uint64_t compress_len,
 
 			if (!ret)
 				ret =
-				    check_gzip_trl(load_u64(state.next_in - offset),
+				    check_gzip_trl(load_le_u64(state.next_in - offset),
 						   state.crc, uncompress_buf, *uncompress_len);
 			else if (ret == ISAL_INCORRECT_CHECKSUM)
 				ret = INCORRECT_GZIP_TRAILER;
@@ -558,7 +558,7 @@ int inflate_stateless_pass(uint8_t * compress_buf, uint64_t compress_len,
 
 			if (!ret)
 				ret =
-				    check_zlib_trl(load_u32(state.next_in - offset),
+				    check_zlib_trl(load_le_u32(state.next_in - offset),
 						   state.crc, uncompress_buf, *uncompress_len);
 			else if (ret == ISAL_INCORRECT_CHECKSUM)
 				ret = INCORRECT_ZLIB_TRAILER;
@@ -743,6 +743,7 @@ int inflate_multi_pass(uint8_t * compress_buf, uint64_t compress_len,
 					printf("Failed to allocate memory\n");
 					return MALLOC_FAILED;
 				}
+				memset(uncomp_tmp, 0, uncomp_tmp_size);
 
 				state->avail_out = uncomp_tmp_size;
 				state->next_out = uncomp_tmp;
@@ -802,7 +803,7 @@ int inflate_multi_pass(uint8_t * compress_buf, uint64_t compress_len,
 				    || gzip_flag == IGZIP_GZIP)
 					compress_len -= gzip_trl_bytes;
 				ret =
-				    check_gzip_trl(load_u64(compress_buf + compress_len),
+				    check_gzip_trl(load_le_u64(compress_buf + compress_len),
 						   state->crc, uncompress_buf,
 						   *uncompress_len);
 			} else if (gzip_flag == IGZIP_ZLIB_NO_HDR) {
@@ -810,7 +811,7 @@ int inflate_multi_pass(uint8_t * compress_buf, uint64_t compress_len,
 				    || gzip_flag == ISAL_ZLIB_NO_HDR_VER)
 					compress_len -= zlib_trl_bytes;
 				ret =
-				    check_zlib_trl(load_u32(compress_buf + compress_len),
+				    check_zlib_trl(load_le_u32(compress_buf + compress_len),
 						   state->crc, uncompress_buf,
 						   *uncompress_len);
 			}
@@ -1152,6 +1153,7 @@ int compress_multi_pass(uint8_t * data, uint32_t data_size, uint8_t * compressed
 		if (rand() % 2 == 0)
 			isal_deflate_set_dict(stream, dict, dict_len);
 		else {
+			memset(&dict_str, 0, sizeof(dict_str));
 			isal_deflate_process_dict(stream, &dict_str, dict, dict_len);
 			isal_deflate_reset_dict(stream, &dict_str);
 		}
@@ -1347,6 +1349,7 @@ int compress_single_pass(uint8_t * data, uint32_t data_size, uint8_t * compresse
 		if (rand() % 2 == 0)
 			isal_deflate_set_dict(&stream, dict, dict_len);
 		else {
+			memset(&dict_str, 0, sizeof(dict_str));
 			isal_deflate_process_dict(&stream, &dict_str, dict, dict_len);
 			isal_deflate_reset_dict(&stream, &dict_str);
 		}

--- a/igzip/proc_heap_base.c
+++ b/igzip/proc_heap_base.c
@@ -74,12 +74,12 @@ uint32_t build_huff_tree(struct heap_tree *heap_space, uint64_t heap_size, uint6
 
 		heapify(heap, heap_size, 1);
 
-		store_u16((uint8_t *) & heap[node_ptr], h1);
-		store_u16((uint8_t *) & heap[node_ptr - 1], h2);
+		store_native_u16_to_u64(&heap[node_ptr], h1);
+		store_native_u16_to_u64(&heap[node_ptr - 1], h2);
 		node_ptr -= 2;
 
 	}
 	h1 = heap[1];
-	store_u16((uint8_t *) & heap[node_ptr], h1);
+	store_native_u16_to_u64(&heap[node_ptr], h1);
 	return node_ptr;
 }

--- a/include/unaligned.h
+++ b/include/unaligned.h
@@ -31,46 +31,174 @@
 #define UNALIGNED_H
 
 #include "stdint.h"
+#include "stdlib.h"
 #include "string.h"
 
-static inline uint16_t load_u16(uint8_t * buf) {
+#ifdef __FreeBSD__
+#include <sys/types.h>
+#include <sys/endian.h>
+# define isal_bswap16(x) bswap16(x)
+# define isal_bswap32(x) bswap32(x)
+# define isal_bswap64(x) bswap64(x)
+#elif defined (__APPLE__)
+#include <libkern/OSByteOrder.h>
+# define isal_bswap16(x) OSSwapInt16(x)
+# define isal_bswap32(x) OSSwapInt32(x)
+# define isal_bswap64(x) OSSwapInt64(x)
+#elif defined (__GNUC__) && !defined (__MINGW32__)
+# include <byteswap.h>
+# define isal_bswap16(x) bswap_16(x)
+# define isal_bswap32(x) bswap_32(x)
+# define isal_bswap64(x) bswap_64(x)
+#elif defined _WIN64
+# define isal_bswap16(x) _byteswap_ushort(x)
+# define isal_bswap32(x) _byteswap_ulong(x)
+# define isal_bswap64(x) _byteswap_uint64(x)
+#endif
+
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+# define to_be16(x) isal_bswap16(x)
+# define from_be16(x) isal_bswap16(x)
+# define to_be32(x) isal_bswap32(x)
+# define from_be32(x) isal_bswap32(x)
+# define to_be64(x) isal_bswap64(x)
+# define from_be64(x) isal_bswap64(x)
+# define to_le16(x) (x)
+# define from_le16(x) (x)
+# define to_le32(x) (x)
+# define from_le32(x) (x)
+# define to_le64(x) (x)
+# define from_le64(x) (x)
+#else
+# define to_be16(x) (x)
+# define from_be16(x) (x)
+# define to_be32(x) (x)
+# define from_be32(x) (x)
+# define to_be64(x) (x)
+# define from_be64(x) (x)
+# define to_le16(x) isal_bswap16(x)
+# define from_le16(x) isal_bswap16(x)
+# define to_le32(x) isal_bswap32(x)
+# define from_le32(x) isal_bswap32(x)
+# define to_le64(x) isal_bswap64(x)
+# define from_le64(x) isal_bswap64(x)
+#endif
+
+static inline uint16_t load_native_u16(uint8_t * buf)
+{
 	uint16_t ret;
 	memcpy(&ret, buf, sizeof(ret));
 	return ret;
 }
 
-static inline uint32_t load_u32(uint8_t * buf) {
+static inline uint16_t load_le_u16(uint8_t * buf)
+{
+	return from_le16(load_native_u16(buf));
+}
+
+static inline uint16_t load_be_u16(uint8_t * buf)
+{
+	return from_be16(load_native_u16(buf));
+}
+
+static inline uint32_t load_native_u32(uint8_t * buf)
+{
 	uint32_t ret;
 	memcpy(&ret, buf, sizeof(ret));
 	return ret;
 }
 
-static inline uint64_t load_u64(uint8_t * buf) {
+static inline uint32_t load_le_u32(uint8_t * buf)
+{
+	return from_le32(load_native_u32(buf));
+}
+
+static inline uint32_t load_be_u32(uint8_t * buf)
+{
+	return from_be32(load_native_u32(buf));
+}
+
+static inline uint64_t load_native_u64(uint8_t * buf)
+{
 	uint64_t ret;
 	memcpy(&ret, buf, sizeof(ret));
 	return ret;
 }
 
-static inline uintmax_t load_umax(uint8_t * buf) {
-	uintmax_t ret;
-	memcpy(&ret, buf, sizeof(ret));
-	return ret;
+static inline uint64_t load_le_u64(uint8_t * buf)
+{
+	return from_le64(load_native_u64(buf));
 }
 
-static inline void store_u16(uint8_t * buf, uint16_t val) {
+static inline uint64_t load_be_u64(uint8_t * buf)
+{
+	return from_be64(load_native_u64(buf));
+}
+
+static inline uintmax_t load_le_umax(uint8_t * buf)
+{
+	switch (sizeof(uintmax_t)) {
+	case sizeof(uint32_t):
+		return from_le32(load_native_u32(buf));
+	case sizeof(uint64_t):
+		return from_le64(load_native_u64(buf));
+	default:
+		return 0;
+	}
+}
+
+static inline void store_native_u16(uint8_t * buf, uint16_t val)
+{
 	memcpy(buf, &val, sizeof(val));
 }
 
-static inline void store_u32(uint8_t * buf, uint32_t val) {
+static inline void store_le_u16(uint8_t * buf, uint16_t val)
+{
+	store_native_u16(buf, to_le16(val));
+}
+
+static inline void store_be_u16(uint8_t * buf, uint16_t val)
+{
+	store_native_u16(buf, to_be16(val));
+}
+
+static inline void store_native_u16_to_u64(uint64_t * buf, uint16_t val)
+{
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+	store_native_u16((uint8_t *) buf, val);
+#else
+	store_native_u16((uint8_t *) buf + 6, val);
+#endif
+}
+
+static inline void store_native_u32(uint8_t * buf, uint32_t val)
+{
 	memcpy(buf, &val, sizeof(val));
 }
 
-static inline void store_u64(uint8_t * buf, uint64_t val) {
+static inline void store_le_u32(uint8_t * buf, uint32_t val)
+{
+	store_native_u32(buf, to_le32(val));
+}
+
+static inline void store_be_u32(uint8_t * buf, uint32_t val)
+{
+	store_native_u32(buf, to_be32(val));
+}
+
+static inline void store_native_u64(uint8_t * buf, uint64_t val)
+{
 	memcpy(buf, &val, sizeof(val));
 }
 
-static inline void store_umax(uint8_t * buf, uintmax_t val) {
-	memcpy(buf, &val, sizeof(val));
+static inline void store_le_u64(uint8_t * buf, uint64_t val)
+{
+	store_native_u64(buf, to_le64(val));
+}
+
+static inline void store_be_u64(uint8_t * buf, uint64_t val)
+{
+	store_native_u64(buf, to_be64(val));
 }
 
 #endif

--- a/mem/mem_zero_detect_base.c
+++ b/mem/mem_zero_detect_base.c
@@ -39,7 +39,7 @@ int mem_zero_detect_base(void *buf, size_t n)
 	// Check buffer in native machine width comparisons
 	while (n >= sizeof(uintmax_t)) {
 		n -= sizeof(uintmax_t);
-		if (load_umax(c) != 0)
+		if (load_le_umax(c) != 0)
 			return -1;
 		c += sizeof(uintmax_t);
 	}
@@ -53,12 +53,12 @@ int mem_zero_detect_base(void *buf, size_t n)
 	case 5:
 		a |= *c++;	// fall through to case 4
 	case 4:
-		a |= load_u32(c);
+		a |= load_le_u32(c);
 		break;
 	case 3:
 		a |= *c++;	// fall through to case 2
 	case 2:
-		a |= load_u16(c);
+		a |= load_le_u16(c);
 		break;
 	case 1:
 		a |= *c;

--- a/tests/fuzz/igzip_simple_round_trip_fuzz_test.c
+++ b/tests/fuzz/igzip_simple_round_trip_fuzz_test.c
@@ -118,9 +118,9 @@ int LLVMFuzzerTestOneInput(const uint8_t * data, size_t size)
 	int trailer_idx = cstate.total_out - trailer_size[wrapper_type];
 
 	if (wrapper_type == IGZIP_GZIP || wrapper_type == IGZIP_GZIP_NO_HDR)
-		crc = load_u32(&isal_cmp_buf[trailer_idx]);
+		crc = load_le_u32(&isal_cmp_buf[trailer_idx]);
 	else if (wrapper_type == IGZIP_ZLIB || wrapper_type == IGZIP_ZLIB_NO_HDR)
-		crc = bswap_32(load_u32(&isal_cmp_buf[trailer_idx]));
+		crc = load_be_u32(&isal_cmp_buf[trailer_idx]);
 
 	assert(istate.crc == crc);
 	free(isal_cmp_buf);


### PR DESCRIPTION
The goal of this patch is to make isa-l testsuite pass on s390 with
minimal changes to the library. The one and only reason isa-l does not
work on s390 at the moment is that s390 is big-endian, and isa-l
assumes little-endian at a lot of places.

There are two flavors of this: loading/storing integers from/to
memory, and overlapping structs. Loads/stores are already helpfully
wrapped by unaligned.h header, so replace the functions there with
endianness-aware variants. Solve struct member overlap by reversing
their order on big-endian.

Also, fix a couple of usages of uninitialized memory in the testsuite
(found with MemorySanitizer).

Fixes s390x part of #188.

Signed-off-by: Ilya Leoshkevich <iii@linux.ibm.com>