### PR TITLE
igzip: fix neon adler32 load after buffer end

### DIFF
--- a/igzip/aarch64/igzip_isal_adler32_neon.S
+++ b/igzip/aarch64/igzip_isal_adler32_neon.S
@@ -70,8 +70,6 @@ local variables
 	declare_var_vector_reg s2acc	, 3
 	declare_var_vector_reg zero	, 16
 	declare_var_vector_reg adler	, 17
-	declare_var_vector_reg back_d0	, 18
-	declare_var_vector_reg back_d1	, 19
 	declare_var_vector_reg sum2	, 20
 	declare_var_vector_reg tmp2	, 20
 
@@ -100,7 +98,6 @@ local variables
 
 	add	end,start,length
 	cbz	loop_cnt,final_accum32
-	ld1 	{back_d0_v.16b-back_d1_v.16b},[start]
 	mov 	loop_const,173
 
 	movi	v16.4s,0
@@ -118,10 +115,8 @@ great_than_32:
 	add	tmp_x,start,loop_const,lsl 5
 
 accum32_neon:
+	ld1 	{d0_v.16b-d1_v.16b},[start]
 	add	start,start,32
-	mov	d0_v.16b,back_d0_v.16b
-	mov	d1_v.16b,back_d1_v.16b
-	ld1 	{back_d0_v.16b-back_d1_v.16b},[start]
 
 	shl	tmp2_v.4s,adacc_v.4s,5
 	add	s2acc_v.4s,s2acc_v.4s,tmp2_v.4s


### PR DESCRIPTION
In the adler32_neon function, during the last iteration of the
loop through "accum32_neon", we would load data after the end of the
buffer (in the ld1 instruction, the "start" register points to the end
of the buffer).

If this memory is unmapped, this would cause a segfault. If the memory
is mapped, the checksum would be correct because that value would
only be used in the next iteration, but since this is the last, that
value is discarded.

To fix this, move the cmp instruction up and add a new branch to skip
the load if we are in the last iteration.

Signed-off-by: Martin Oliveira <martin.oliveira@eideticom.com>