### PR TITLE
build: Remove ms link flag for msvcrt

### DIFF
--- a/Makefile.nmake
+++ b/Makefile.nmake
@@ -167,8 +167,8 @@ objs = \
 INCLUDES   = -I./ -Ierasure_code/ -Iraid/ -Icrc/ -Iigzip/ -Iprograms/ -Imem/ -Iinclude/ -Itests/fuzz/ -Iexamples/ec/
 # Modern asm feature level, consider upgrading nasm/yasm before decreasing feature_level
 FEAT_FLAGS = -DHAVE_AS_KNOWS_AVX512 -DAS_FEATURE_LEVEL=10
-CFLAGS_REL = -O2 -DNDEBUG /Z7 /MD /Gy
-CFLAGS_DBG = -Od -DDEBUG /Z7 /MDd
+CFLAGS_REL = -O2 -DNDEBUG /Z7 /Gy
+CFLAGS_DBG = -Od -DDEBUG /Z7
 LINKFLAGS  = -nologo -incremental:no -debug
 CFLAGS     = $(CFLAGS_REL) -nologo -D_USE_MATH_DEFINES $(FEAT_FLAGS) $(INCLUDES) $(D)
 AFLAGS     = -f win64 $(FEAT_FLAGS) $(INCLUDES) $(D)

--- a/tools/gen_nmake.mk
+++ b/tools/gen_nmake.mk
@@ -21,8 +21,8 @@ Makefile.nmake tst.nmake: FORCE
 	@echo 'INCLUDES   = $(INCLUDE)'	>> $@
 	@echo '# Modern asm feature level, consider upgrading nasm/yasm before decreasing feature_level'	>> $@
 	@echo 'FEAT_FLAGS = -DHAVE_AS_KNOWS_AVX512 -DAS_FEATURE_LEVEL=10'	>> $@
-	@echo 'CFLAGS_REL = -O2 -DNDEBUG /Z7 /MD /Gy'		>> $@
-	@echo 'CFLAGS_DBG = -Od -DDEBUG /Z7 /MDd'			>> $@
+	@echo 'CFLAGS_REL = -O2 -DNDEBUG /Z7 /Gy'		>> $@
+	@echo 'CFLAGS_DBG = -Od -DDEBUG /Z7'			>> $@
 	@echo 'LINKFLAGS  = -nologo -incremental:no -debug'	>> $@
 	@echo 'CFLAGS     = $$(CFLAGS_REL) -nologo -D_USE_MATH_DEFINES $$(FEAT_FLAGS) $$(INCLUDES) $$(D)'	>> $@
 	@echo 'AFLAGS     = -f win64 $$(FEAT_FLAGS) $$(INCLUDES) $$(D)'	>> $@


### PR DESCRIPTION
The cflag to link with dynamic msvcrt /MD is not necessary and causes
warnings when static linking.  Fixes #219

Change-Id: I0085d468afc4acbe323b0783cbbc6760b4c70704
Signed-off-by: Greg Tucker <greg.b.tucker@intel.com>