### PR TITLE
Correct loop bounds check in aarch64 gf_vect_mul

### DIFF
--- a/erasure_code/aarch64/gf_vect_mul_neon.S
+++ b/erasure_code/aarch64/gf_vect_mul_neon.S
@@ -192,6 +192,8 @@ gf_vect_mul_neon:
 	ldp	d14, d15, [sp, #48]
 	add	sp, sp, #64
 	add	x_src_end, x_src_end, #128
+	cmp	x_src, x_src_end
+	beq	.return_pass
 
 .Lloop32_init:
 	sub	x_src_end, x_src_end, #32

--- a/erasure_code/ec_base.c
+++ b/erasure_code/ec_base.c
@@ -331,10 +331,17 @@ void ec_encode_data_update_base(int len, int k, int rows, int vec_i, unsigned ch
 	}
 }
 
-void gf_vect_mul_base(int len, unsigned char *a, unsigned char *src, unsigned char *dest)
+int gf_vect_mul_base(int len, unsigned char *a, unsigned char *src, unsigned char *dest)
 {
 	//2nd element of table array is ref value used to fill it in
 	unsigned char c = a[1];
+
+	// Len must be aligned to 32B
+	if ((len % 32) != 0) {
+		return -1;
+	}
+
 	while (len-- > 0)
 		*dest++ = gf_mul(c, *src++);
+	return 0;
 }

--- a/erasure_code/ec_base_aliases.c
+++ b/erasure_code/ec_base_aliases.c
@@ -56,6 +56,5 @@ void ec_encode_data_update(int len, int k, int rows, int vec_i, unsigned char *v
 
 int gf_vect_mul(int len, unsigned char *a, void *src, void *dest)
 {
-	gf_vect_mul_base(len, a, (unsigned char *)src, (unsigned char *)dest);
-	return 0;
+	return gf_vect_mul_base(len, a, (unsigned char *)src, (unsigned char *)dest);
 }

--- a/erasure_code/gf_vect_mul_base_test.c
+++ b/erasure_code/gf_vect_mul_base_test.c
@@ -63,7 +63,10 @@ int main(int argc, char *argv[])
 	for (i = 0; i < TEST_SIZE; i++)
 		buff1[i] = rand();
 
-	gf_vect_mul_base(TEST_SIZE, gf_const_tbl, buff1, buff2);
+	if (gf_vect_mul_base(TEST_SIZE, gf_const_tbl, buff1, buff2) != 0) {
+		printf("fail fill with rand data\n");
+		return 1;
+	}
 
 	for (i = 0; i < TEST_SIZE; i++)
 		if (gf_mul(a, buff1[i]) != buff2[i]) {
@@ -72,8 +75,10 @@ int main(int argc, char *argv[])
 			return 1;
 		}
 
-	gf_vect_mul_base(TEST_SIZE, gf_const_tbl, buff1, buff3);
-
+	if (gf_vect_mul_base(TEST_SIZE, gf_const_tbl, buff1, buff3) != 0) {
+		printf("fail fill with rand data for buff1\n");
+		return -1;
+	}
 	// Check reference function
 	for (i = 0; i < TEST_SIZE; i++)
 		if (buff2[i] != buff3[i]) {
@@ -89,7 +94,10 @@ int main(int argc, char *argv[])
 	printf("Random tests ");
 	for (a = 0; a != 255; a++) {
 		gf_vect_mul_init(a, gf_const_tbl);
-		gf_vect_mul_base(TEST_SIZE, gf_const_tbl, buff1, buff2);
+		if (gf_vect_mul_base(TEST_SIZE, gf_const_tbl, buff1, buff2) != 0) {
+			printf("fail random tests\n");
+			return 1;
+		}
 
 		for (i = 0; i < TEST_SIZE; i++)
 			if (gf_mul(a, buff1[i]) != buff2[i]) {
@@ -110,7 +118,11 @@ int main(int argc, char *argv[])
 		efence_buff1 = buff1 + size;
 		efence_buff2 = buff2 + size;
 
-		gf_vect_mul_base(TEST_SIZE - size, gf_const_tbl, efence_buff1, efence_buff2);
+		if (gf_vect_mul_base
+		    (TEST_SIZE - size, gf_const_tbl, efence_buff1, efence_buff2) != 0) {
+			printf("fail tests at end of buffer\n");
+			return -1;
+		}
 
 		for (i = 0; i < TEST_SIZE - size; i++)
 			if (gf_mul(a, efence_buff1[i]) != efence_buff2[i]) {

--- a/erasure_code/gf_vect_mul_test.c
+++ b/erasure_code/gf_vect_mul_test.c
@@ -61,7 +61,10 @@ int main(int argc, char *argv[])
 	for (i = 0; i < TEST_SIZE; i++)
 		buff1[i] = rand();
 
-	gf_vect_mul(TEST_SIZE, gf_const_tbl, buff1, buff2);
+	if (gf_vect_mul(TEST_SIZE, gf_const_tbl, buff1, buff2) != 0) {
+		printf("fail creating buff2\n");
+		return -1;
+	}
 
 	for (i = 0; i < TEST_SIZE; i++) {
 		if (gf_mul(a, buff1[i]) != buff2[i]) {
@@ -71,8 +74,10 @@ int main(int argc, char *argv[])
 		}
 	}
 
-	gf_vect_mul_base(TEST_SIZE, gf_const_tbl, buff1, buff3);
-
+	if (gf_vect_mul_base(TEST_SIZE, gf_const_tbl, buff1, buff3) != 0) {
+		printf("fail fill with rand data\n");
+		return -1;
+	}
 	// Check reference function
 	for (i = 0; i < TEST_SIZE; i++) {
 		if (buff2[i] != buff3[i]) {
@@ -88,7 +93,10 @@ int main(int argc, char *argv[])
 	// Check each possible constant
 	for (a = 0; a != 255; a++) {
 		gf_vect_mul_init(a, gf_const_tbl);
-		gf_vect_mul(TEST_SIZE, gf_const_tbl, buff1, buff2);
+		if (gf_vect_mul(TEST_SIZE, gf_const_tbl, buff1, buff2) != 0) {
+			printf("fail creating buff2\n");
+			return -1;
+		}
 
 		for (i = 0; i < TEST_SIZE; i++)
 			if (gf_mul(a, buff1[i]) != buff2[i]) {
@@ -103,7 +111,10 @@ int main(int argc, char *argv[])
 	for (tsize = TEST_SIZE; tsize > 0; tsize -= 32) {
 		a = rand();
 		gf_vect_mul_init(a, gf_const_tbl);
-		gf_vect_mul(tsize, gf_const_tbl, buff1, buff2);
+		if (gf_vect_mul(tsize, gf_const_tbl, buff1, buff2) != 0) {
+			printf("fail creating buff2 (len %d)\n", tsize);
+			return -1;
+		}
 
 		for (i = 0; i < tsize; i++)
 			if (gf_mul(a, buff1[i]) != buff2[i]) {
@@ -138,8 +149,11 @@ int main(int argc, char *argv[])
 				return 1;
 			}
 
-		gf_vect_mul_base(TEST_SIZE - size, gf_const_tbl, efence_buff1, efence_buff3);
-
+		if (gf_vect_mul_base
+		    (TEST_SIZE - size, gf_const_tbl, efence_buff1, efence_buff3) != 0) {
+			printf("fail line up TEST_SIZE from end\n");
+			return -1;
+		}
 		// Check reference function
 		for (i = 0; i < TEST_SIZE - size; i++)
 			if (efence_buff2[i] != efence_buff3[i]) {
@@ -150,6 +164,16 @@ int main(int argc, char *argv[])
 			}
 
 		putchar('.');
+	}
+
+	// Test all unsupported sizes up to TEST_SIZE
+	for (size = 0; size < TEST_SIZE; size++) {
+		if (size % align != 0 && gf_vect_mul(size, gf_const_tbl, buff1, buff2) == 0) {
+			printf
+			    ("fail expecting nonzero return code for unaligned size param (%d)\n",
+			     size);
+			return 1;
+		}
 	}
 
 	printf(" done: Pass\n");

--- a/erasure_code/ppc64le/gf_vect_mul_vsx.c
+++ b/erasure_code/ppc64le/gf_vect_mul_vsx.c
@@ -19,6 +19,7 @@ void gf_vect_mul_vsx(int len, unsigned char *gftbl, unsigned char *src, unsigned
 
 	head = len % 128;
 	if (head != 0) {
+		// errors are ignored.
 		gf_vect_mul_base(head, gftbl, src, dest);
 	}
 

--- a/include/gf_vect_mul.h
+++ b/include/gf_vect_mul.h
@@ -140,10 +140,11 @@ void gf_vect_mul_init(unsigned char c, unsigned char* gftbl);
  * 		only use 2nd element is used.
  * @param src   Pointer to src data array. Must be aligned to 32B.
  * @param dest  Pointer to destination data array. Must be aligned to 32B.
+ * @returns 0 pass, other fail
  */
 
-void gf_vect_mul_base(int len, unsigned char *a, unsigned char *src,
-			unsigned char *dest);
+int gf_vect_mul_base(int len, unsigned char *a, unsigned char *src,
+                      unsigned char *dest);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Prior to this change, a missing loop bounds check in the aarch64 version of gf_vect_mul would cause the routine to return 1 (error) in the normal case.

This change introduces a check and branch to "return_pass" (success), and also adds checks of the return code of gf_vect_mul to the supplied unit test; it was previously ignored.