### PR TITLE
Include hwcap.h only in C compilation

### DIFF
--- a/include/aarch64_multibinary.h
+++ b/include/aarch64_multibinary.h
@@ -31,13 +31,6 @@
 #ifndef __aarch64__
 #error "This file is for aarch64 only"
 #endif
-#ifdef __APPLE__
-#define SYSCTL_PMULL_KEY "hw.optional.arm.FEAT_PMULL" // from macOS 12 FEAT_* sysctl infos are available
-#define SYSCTL_CRC32_KEY "hw.optional.armv8_crc32"
-#define SYSCTL_SVE_KEY "hw.optional.arm.FEAT_SVE" // this one is just a guess and need to check macOS update
-#else
-#include <asm/hwcap.h>
-#endif
 #include "aarch64_label.h"
 #ifdef __ASSEMBLY__
 /**
@@ -221,7 +214,11 @@
 #include <stdint.h>
 #if defined(__linux__)
 #include <sys/auxv.h>
+#include <asm/hwcap.h>
 #elif defined(__APPLE__)
+#define SYSCTL_PMULL_KEY "hw.optional.arm.FEAT_PMULL" // from macOS 12 FEAT_* sysctl infos are available
+#define SYSCTL_CRC32_KEY "hw.optional.armv8_crc32"
+#define SYSCTL_SVE_KEY "hw.optional.arm.FEAT_SVE" // this one is just a guess and need to check macOS update
 #include <sys/sysctl.h>
 #include <stddef.h>
 static inline int sysctlEnabled(const char* name){


### PR DESCRIPTION
In some twisted case where aarch64 gcc is ancient, it does not recognize SVE mnemonics and as might need to be provided externally. If aarch64-non-eabi-gcc is used, it does not have hwcap.h. Hence it should be included only in C compilation.

Also, it can help (slight) compilation time.