### PR TITLE
Update README.md to mention that libtool is needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Building ISA-L
 ### Prerequisites
 
 * Make: GNU 'make' or 'nmake' (Windows).
-* Optional: Building with autotools requires autoconf/automake packages.
+* Optional: Building with autotools requires autoconf/automake/libtool packages.
 * Optional: Manual generation requires help2man package.
 
 x86_64:


### PR DESCRIPTION
libtool is required for the autotool build otherwise you will get the "error: possibly undefined macro: AC_PROG_LD" error message