### PR TITLE
crc: optimize by supporting arm xor fusion feature

### DIFF
--- a/crc/aarch64/crc64_refl_common_pmull.h
+++ b/crc/aarch64/crc64_refl_common_pmull.h
@@ -125,8 +125,8 @@ cdecl(\name\()):
 
 	ext	v_tmp_low.16b, v_br_low.16b, v_tmp_low.16b, #8
 
-	eor	v_tmp_low.16b, v_tmp_low.16b, v_tmp_high.16b
-	eor	v_tmp_low.16b, v_tmp_low.16b, v_x3.16b
+	eor	v_tmp_low.16b, v_tmp_high.16b, v_tmp_low.16b
+	eor	v_tmp_low.16b, v_x3.16b, v_tmp_low.16b
 	umov	x_crc_ret, v_tmp_low.d[1]
 
 	b	.crc_tab_pre

--- a/crc/aarch64/crc_common_pmull.h
+++ b/crc/aarch64/crc_common_pmull.h
@@ -204,14 +204,16 @@
 	pmull	v_x2.1q, v_x2.1d, v_p4.1d
 	pmull	v_x3.1q, v_x3.1d, v_p4.1d
 
-	eor	v_x0.16b, v_x0.16b, v_x0_high.16b
-	eor	v_x1.16b, v_x1.16b, v_x1_high.16b
-	eor	v_x2.16b, v_x2.16b, v_x2_high.16b
-	eor	v_x3.16b, v_x3.16b, v_x3_high.16b
-
+	eor	v_x0.16b, v_x0_high.16b, v_x0.16b
 	eor	v_x0.16b, v_x0.16b, v_y0.16b
+
+	eor	v_x1.16b, v_x1_high.16b, v_x1.16b
 	eor	v_x1.16b, v_x1.16b, v_y1.16b
+
+	eor	v_x2.16b, v_x2_high.16b, v_x2.16b
 	eor	v_x2.16b, v_x2.16b, v_y2.16b
+
+	eor	v_x3.16b, v_x3_high.16b, v_x3.16b
 	eor	v_x3.16b, v_x3.16b, v_y3.16b
 	bne	.clmul_loop
 .endm


### PR DESCRIPTION
Arrange the two xor instructions according to the specified paradigm, then the two xor instructions can be fused to execute which can save one issue slot and one execution latency.

This pr can optimize three CRC API's performance.
before
crc16_t10dif_warm: runtime =    3062503 usecs, bandwidth 54259 MB in 3.0625 sec = 17717.47 MB/s
crc16_t10dif_copy_warm: runtime =    3000228 usecs, bandwidth 48098 MB in 3.0002 sec = 16031.58 MB/s
crc16_t10pi_op_copy_insert_warm: runtime =    3062524 usecs, bandwidth 29135 MB in 3.0625 sec = 9513.46 MB/s
crc32_ieee_warm: runtime =    3000027 usecs, bandwidth 42497 MB in 3.0000 sec = 14165.83 MB/s
crc32_iscsi_warm: runtime =    3003593 usecs, bandwidth 29900 MB in 3.0036 sec = 9955.07 MB/s
crc64_ecma_norm_warm: runtime =    3011684 usecs, bandwidth 43900 MB in 3.0117 sec = 14576.85 MB/s
crc64_ecma_refl_warm: runtime =    3000062 usecs, bandwidth 46019 MB in 3.0001 sec = 15339.64 MB/s
crc64_iso_norm_warm: runtime =    3001548 usecs, bandwidth 44482 MB in 3.0015 sec = 14819.89 MB/s
crc64_iso_refl_warm: runtime =    3062572 usecs, bandwidth 47096 MB in 3.0626 sec = 15377.95 MB/s
crc64_jones_norm_warm: runtime =    3000064 usecs, bandwidth 42570 MB in 3.0001 sec = 14189.79 MB/s
crc64_jones_refl_warm: runtime =    3062431 usecs, bandwidth 46978 MB in 3.0624 sec = 15340.34 MB/s
crc64_rocksoft_norm_warm: runtime =    3062524 usecs, bandwidth 884 MB in 3.0625 sec = 288.88 MB/s
crc64_rocksoft_refl_warm: runtime =    3000064 usecs, bandwidth 867 MB in 3.0001 sec = 289.03 MB/s
crc32_gzip_refl_warm: runtime =    3001590 usecs, bandwidth 29899 MB in 3.0016 sec = 9961.37 MB/s
crc32_gzip_refl_base_warm: runtime =    3062512 usecs, bandwidth 885 MB in 3.0625 sec = 289.08 MB/s


After:
crc16_t10dif_warm: runtime =    3062494 usecs, bandwidth 54262 MB in 3.0625 sec = 17718.44 MB/s
crc16_t10dif_copy_warm: runtime =    3062482 usecs, bandwidth 49088 MB in 3.0625 sec = 16028.84 MB/s
crc16_t10pi_op_copy_insert_warm: runtime =    3062523 usecs, bandwidth 29103 MB in 3.0625 sec = 9503.23 MB/s
crc32_ieee_warm: runtime =    3062495 usecs, bandwidth 43382 MB in 3.0625 sec = 14165.79 MB/s
crc32_iscsi_warm: runtime =    3003874 usecs, bandwidth 29906 MB in 3.0039 sec = 9956.03 MB/s
crc64_ecma_norm_warm: runtime =    3062492 usecs, bandwidth 44809 MB in 3.0625 sec = 14631.82 MB/s
**crc64_ecma_refl_warm: runtime =    3000139 usecs, bandwidth 60718 MB in 3.0001 sec = 20238.44 MB/s**
crc64_iso_norm_warm: runtime =    3000148 usecs, bandwidth 44483 MB in 3.0001 sec = 14827.23 MB/s
**crc64_iso_refl_warm: runtime =    3062415 usecs, bandwidth 62129 MB in 3.0624 sec = 20287.89 MB/s**
crc64_jones_norm_warm: runtime =    3004763 usecs, bandwidth 41049 MB in 3.0048 sec = 13661.62 MB/s
**crc64_jones_refl_warm: runtime =    3000646 usecs, bandwidth 60661 MB in 3.0006 sec = 20216.14 MB/s**
crc64_rocksoft_norm_warm: runtime =    3062511 usecs, bandwidth 884 MB in 3.0625 sec = 288.88 MB/s
crc64_rocksoft_refl_warm: runtime =    3000157 usecs, bandwidth 867 MB in 3.0002 sec = 289.03 MB/s
crc32_gzip_refl_warm: runtime =    3003769 usecs, bandwidth 29996 MB in 3.0038 sec = 9986.14 MB/s
crc32_gzip_refl_base_warm: runtime =    3000026 usecs, bandwidth 867 MB in 3.0000 sec = 289.08 MB/s
