### PR TITLE
erasure_code: add missing aarch64 and powerpc interface for ec_init_t…

### DIFF
--- a/erasure_code/aarch64/ec_aarch64_dispatcher.c
+++ b/erasure_code/aarch64/ec_aarch64_dispatcher.c
@@ -117,3 +117,8 @@ DEFINE_INTERFACE_DISPATCHER(gf_vect_mul)
 	return PROVIDER_BASIC(gf_vect_mul);
 
 }
+
+DEFINE_INTERFACE_DISPATCHER(ec_init_tables)
+{
+	return PROVIDER_BASIC(ec_init_tables);
+}

--- a/erasure_code/aarch64/ec_multibinary_arm.S
+++ b/erasure_code/aarch64/ec_multibinary_arm.S
@@ -34,3 +34,4 @@ mbin_interface gf_vect_mul
 mbin_interface gf_vect_dot_prod
 mbin_interface gf_vect_mad
 mbin_interface ec_encode_data_update
+mbin_interface ec_init_tables

--- a/erasure_code/ppc64le/ec_base_vsx.c
+++ b/erasure_code/ppc64le/ec_base_vsx.c
@@ -95,3 +95,8 @@ int gf_vect_mul(int len, unsigned char *a, void *src, void *dest)
 	gf_vect_mul_vsx(len, a, (unsigned char *)src, (unsigned char *)dest);
 	return 0;
 }
+
+void ec_init_tables(int k, int rows, unsigned char *a, unsigned char *g_tbls)
+{
+	return ec_init_tables_base(k, rows, a, g_tbls);
+}


### PR DESCRIPTION
…ables

ec_init_tables is now a multi-implementation function, so it requires a dispatcher for all architectures.