### PR TITLE
gf_vect_mul_sve: fix error for not aligned len

### DIFF
--- a/erasure_code/aarch64/gf_vect_mul_sve.S
+++ b/erasure_code/aarch64/gf_vect_mul_sve.S
@@ -53,12 +53,13 @@ x_len		.req	x0
 x_tbl		.req	x1
 x_src		.req	x2
 x_dest		.req	x3
+x_tmp		.req	x4
 
 /* returns */
 w_ret		.req	w0
 
 /* local variables */
-x_pos		.req	x4
+x_pos		.req	x5
 
 /* vectors */
 z_mask0f	.req	z0
@@ -77,9 +78,10 @@ q_gft1_lo	.req	q6
 q_gft1_hi	.req	q7
 
 cdecl(gf_vect_mul_sve):
-	/* less than 32 bytes, return_fail */
-	cmp	x_len, #32
-	blt	.return_fail
+	/* len not aligned to 32B, return_fail */
+	and	x_tmp, x_len, #0x1f
+	cmp	x_tmp, #0
+	bne	.return_fail
 
 	mov	z_mask0f.b, #0x0f		/* z_mask0f = 0x0F0F...0F */
 	mov	x_pos, #0

--- a/erasure_code/gf_vect_mul_test.c
+++ b/erasure_code/gf_vect_mul_test.c
@@ -171,7 +171,7 @@ int main(int argc, char *argv[])
 #endif
 	}
 
-#if !defined(aarch64) && !defined(ppc64le)
+#if !defined(ppc64le)
 	// Test all unsupported sizes up to TEST_SIZE
 	for (size = 0; size < TEST_SIZE; size++) {
 		if (size % align != 0 && gf_vect_mul(size, gf_const_tbl, buff1, buff2) == 0) {
@@ -183,7 +183,7 @@ int main(int argc, char *argv[])
 	}
 #else
 	printf
-	    ("WARNING: Test disabled on ARM & PPC due to known issue https://github.com/intel/isa-l/issues/263\n");
+	    ("WARNING: Test disabled on PPC due to known issue https://github.com/intel/isa-l/issues/263\n");
 #endif
 	printf(" done: Pass\n");
 	fflush(0);


### PR DESCRIPTION
fix [#268](https://github.com/intel/isa-l/issues/268)

```
# With this Patch:
[root@localhost isa-l]# make check
make --no-print-directory check-am
make --no-print-directory erasure_code/gf_vect_mul_test erasure_code/erasure_code_test erasure_code/gf_inverse_test erasure_code/erasure_code_update_test raid/xor_gen_test raid/pq_gen_test raid/xor_check_test raid/pq_check_test crc/crc16_t10dif_test crc/crc16_t10dif_copy_test crc/crc64_funcs_test crc/crc32_funcs_test igzip/igzip_rand_test igzip/igzip_wrapper_hdr_test igzip/checksum32_funcs_test mem/mem_zero_detect_test
  CCLD     erasure_code/gf_vect_mul_test
  CCLD     erasure_code/erasure_code_test
  CCLD     erasure_code/gf_inverse_test
  CCLD     erasure_code/erasure_code_update_test
  CCLD     raid/xor_gen_test
  CCLD     raid/pq_gen_test
  CCLD     raid/xor_check_test
  CCLD     raid/pq_check_test
  CCLD     crc/crc16_t10dif_test
  CCLD     crc/crc16_t10dif_copy_test
  CCLD     crc/crc64_funcs_test
  CCLD     crc/crc32_funcs_test
  CCLD     igzip/igzip_rand_test
  CCLD     igzip/igzip_wrapper_hdr_test
  CCLD     igzip/checksum32_funcs_test
  CCLD     mem/mem_zero_detect_test
make --no-print-directory check-TESTS
PASS: erasure_code/gf_vect_mul_test
PASS: erasure_code/erasure_code_test
PASS: erasure_code/gf_inverse_test
PASS: erasure_code/erasure_code_update_test
PASS: raid/xor_gen_test
PASS: raid/pq_gen_test
PASS: raid/xor_check_test
PASS: raid/pq_check_test
PASS: crc/crc16_t10dif_test
PASS: crc/crc16_t10dif_copy_test
PASS: crc/crc64_funcs_test
PASS: crc/crc32_funcs_test
PASS: igzip/igzip_rand_test
PASS: igzip/igzip_wrapper_hdr_test
PASS: igzip/checksum32_funcs_test
PASS: mem/mem_zero_detect_test
============================================================================
Testsuite summary for libisal 2.30.0
============================================================================
# TOTAL: 16
# PASS:  16
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```