### PR TITLE
Fixes for ppc64le unit tests

### DIFF
--- a/erasure_code/gf_vect_mul_test.c
+++ b/erasure_code/gf_vect_mul_test.c
@@ -171,7 +171,6 @@ int main(int argc, char *argv[])
 #endif
 	}
 
-#if !defined(ppc64le)
 	// Test all unsupported sizes up to TEST_SIZE
 	for (size = 0; size < TEST_SIZE; size++) {
 		if (size % align != 0 && gf_vect_mul(size, gf_const_tbl, buff1, buff2) == 0) {
@@ -181,10 +180,7 @@ int main(int argc, char *argv[])
 			goto exit;
 		}
 	}
-#else
-	printf
-	    ("WARNING: Test disabled on PPC due to known issue https://github.com/intel/isa-l/issues/263\n");
-#endif
+
 	printf(" done: Pass\n");
 	fflush(0);
 

--- a/erasure_code/ppc64le/ec_base_vsx.c
+++ b/erasure_code/ppc64le/ec_base_vsx.c
@@ -92,6 +92,10 @@ void ec_encode_data_update(int len, int k, int rows, int vec_i, unsigned char *v
 
 int gf_vect_mul(int len, unsigned char *a, void *src, void *dest)
 {
+	/* Size must be aligned to 32 bytes */
+	if ((len % 32) != 0)
+		return -1;
+
 	gf_vect_mul_vsx(len, a, (unsigned char *)src, (unsigned char *)dest);
 	return 0;
 }

--- a/erasure_code/ppc64le/gf_vect_mul_vsx.c
+++ b/erasure_code/ppc64le/gf_vect_mul_vsx.c
@@ -1,5 +1,19 @@
 #include "ec_base_vsx.h"
 
+/*
+ * Same as gf_vect_mul_base in "ec_base.h" but without the size restriction.
+ */
+static void _gf_vect_mul_base(int len, unsigned char *a, unsigned char *src,
+			      unsigned char *dest)
+{
+	//2nd element of table array is ref value used to fill it in
+	unsigned char c = a[1];
+
+	while (len-- > 0)
+		*dest++ = gf_mul(c, *src++);
+	return 0;
+}
+
 void gf_vect_mul_vsx(int len, unsigned char *gftbl, unsigned char *src, unsigned char *dest)
 {
 	unsigned char *s, *t0;
@@ -19,8 +33,7 @@ void gf_vect_mul_vsx(int len, unsigned char *gftbl, unsigned char *src, unsigned
 
 	head = len % 128;
 	if (head != 0) {
-		// errors are ignored.
-		gf_vect_mul_base(head, gftbl, src, dest);
+		_gf_vect_mul_base(head, gftbl, src, dest);
 	}
 
 	vlo0 = EC_vec_xl(0, gftbl);


### PR DESCRIPTION
Some unit tests are currently failing, due to a missing check on the gf_vect_mul function (in ppc64le).
Also, because gf_vect_mul_base is used for encoding, in gf_vect_mul_vsx, which is used in encoding functions like gf_vect_dot_prod_vsx, it must be able to be called for any size. Hence, the implementation is added inside the ppc64le files, without such restriction.

Fixes #263 