### PR TITLE
Fix wrong return type

### DIFF
--- a/erasure_code/ppc64le/gf_vect_mul_vsx.c
+++ b/erasure_code/ppc64le/gf_vect_mul_vsx.c
@@ -11,7 +11,7 @@ static void _gf_vect_mul_base(int len, unsigned char *a, unsigned char *src,
 
 	while (len-- > 0)
 		*dest++ = gf_mul(c, *src++);
-	return 0;
+	return;
 }
 
 void gf_vect_mul_vsx(int len, unsigned char *gftbl, unsigned char *src, unsigned char *dest)


### PR DESCRIPTION
erasure_code/ppc64le/gf_vect_mul_vsx.c: In function '_gf_vect_mul_base': erasure_code/ppc64le/gf_vect_mul_vsx.c:14:16: error: 'return' with a value, in function returning void [-Wreturn-mismatch]
   14 |         return 0;
      |                ^
erasure_code/ppc64le/gf_vect_mul_vsx.c:6:13: note: declared here
    6 | static void _gf_vect_mul_base(int len, unsigned char *a, unsigned char *src,
      |             ^~~~~~~~~~~~~~~~~