### PR TITLE
Fix a handful of spelling mistakes and typos

### DIFF
--- a/Release_notes.txt
+++ b/Release_notes.txt
@@ -139,7 +139,7 @@ v2.31
   - Zlib header can be now created on the fly when starting the compression.
   - Added isal_zlib_hdr_init() function to initialize the zlib header to 0.
 
-* Zero-memory dectection improvements:
+* Zero-memory detection improvements:
   - Optimized AVX implementation.
   - Added new AVX2 and AVX512 implementations.
 
@@ -209,7 +209,7 @@ v2.25
 * Igzip performance improvements and features.
   - Performance improvements for uncompressable files. Random or uncompressable
     files can be up to 3x faster in level 1 or 2 compression.
-  - Additional small file performance improvments.
+  - Additional small file performance improvements.
   - New options in igzip cli: use name from header or not, test compressed file.
 
 * Multi-arch autoconf script.
@@ -331,7 +331,7 @@ v2.14
 
 v2.13
 
-* Erasure code improvments
+* Erasure code improvements
   - 32-bit port of optimized gf_vect_dot_prod() functions.  This makes
     ec_encode_data() functions much faster on 32-bit processors.
   - Avoton performance improvements.  Performance on Avoton for

--- a/crc/crc32_iscsi_01.asm
+++ b/crc/crc32_iscsi_01.asm
@@ -185,7 +185,7 @@ full_block:
 
 ;       ;; branch into array
 ;       jmp     CONCAT(crc_,128,)
-	; Fall thruogh into top of crc array (crc_128)
+	; Fall through into top of crc array (crc_128)
 
 	;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 	;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/examples/ec/ec_piggyback_example.c
+++ b/examples/ec/ec_piggyback_example.c
@@ -61,7 +61,7 @@ void gf_gen_full_pb_cauchy_matrix(u8 * a, int m, int k)
 {
 	int i, j, p = m - k;
 
-	// Identity matrix in top k x k to indicate a symetric code
+	// Identity matrix in top k x k to indicate a symmetric code
 	memset(a, 0, k * m);
 	for (i = 0; i < k; i++)
 		a[k * i + i] = 1;
@@ -99,7 +99,7 @@ void gf_gen_full_pb_vand_matrix(u8 * a, int m, int k)
 	int i, j, p = m - k;
 	unsigned char q, gen = 1;
 
-	// Identity matrix in top k x k to indicate a symetric code
+	// Identity matrix in top k x k to indicate a symmetric code
 	memset(a, 0, k * m);
 	for (i = 0; i < k; i++)
 		a[k * i + i] = 1;

--- a/igzip/aarch64/igzip_isal_adler32_neon.S
+++ b/igzip/aarch64/igzip_isal_adler32_neon.S
@@ -54,7 +54,7 @@ Macros
 	uint32_t adler32_neon(uint32_t adler32, uint8_t * start, uint32_t length);
 */
 /*
-Arguements list
+Arguments list
 */
 	adler32	.req	w0
 	start	.req	x1

--- a/igzip/aarch64/isal_deflate_icf_body_hash_hist.S
+++ b/igzip/aarch64/isal_deflate_icf_body_hash_hist.S
@@ -106,7 +106,7 @@ void isal_deflate_icf_body_hash_hist_base(struct isal_zstream *stream);
 	declare_generic_reg	param1,		1,x
 	declare_generic_reg	param2,		2,x
 
-	/* local varibale */
+	/* local variable */
 	declare_generic_reg	level_buf,	18,x
 	declare_generic_reg	avail_in,	13,w
 	declare_generic_reg	end_in,		13,x

--- a/igzip/adler32_avx2_4.asm
+++ b/igzip/adler32_avx2_4.asm
@@ -91,7 +91,7 @@ default rel
 	save_reg	r12,  2*16 + 2*8
 	save_reg	r13,  2*16 + 3*8
 	end_prolog
-	mov	init_d, ecx	; initalize init_d from arg1 to keep ecx free
+	mov	init_d, ecx	; initialize init_d from arg1 to keep ecx free
  %endmacro
 
  %macro FUNC_RESTORE 0

--- a/igzip/adler32_sse.asm
+++ b/igzip/adler32_sse.asm
@@ -86,7 +86,7 @@ default rel
 	save_reg	r12,  2*8
 	save_reg	r13,  3*8
 	end_prolog
-	mov	init_d, ecx	; initalize init_d from arg1 to keep ecx free
+	mov	init_d, ecx	; initialize init_d from arg1 to keep ecx free
  %endmacro
 
  %macro FUNC_RESTORE 0

--- a/igzip/huff_codes.c
+++ b/igzip/huff_codes.c
@@ -962,7 +962,7 @@ gen_huff_code_lens(struct heap_tree *heap_space, uint32_t heap_size, uint32_t * 
  * @requires table has been initialized to already contain the code length for each element.
  * @param table: A lookup table used to store the codes.
  * @param table_length: The length of table.
- * @param count: a histogram representing the number of occurences of codes of a given length
+ * @param count: a histogram representing the number of occurrences of codes of a given length
  */
 static inline uint32_t set_huff_codes(struct huff_code *huff_code_table, int table_length,
 				      uint32_t * count)
@@ -1031,7 +1031,7 @@ static inline uint32_t set_dist_huff_codes(struct huff_code *codes, uint32_t * b
  * 0 corresponds to not end of block and all other inputs correspond to end of block.
  * @param hclen: Length of huffman code for huffman codes minus 4.
  * @param hlit: Length of literal/length table minus 257.
- * @parm hdist: Length of distance table minus 1.
+ * @param hdist: Length of distance table minus 1.
  */
 static int create_huffman_header(struct BitBuf2 *header_bitbuf,
 				 struct huff_code *lookup_table,
@@ -1233,7 +1233,7 @@ static inline uint32_t rl_encode(uint16_t * codes, uint32_t num_codes, uint64_t 
  * @brief Creates a two table representation of huffman codes.
  * @param code_table: output table containing the code
  * @param code_size_table: output table containing the code length
- * @param length: the lenght of hufftable
+ * @param length: the length of hufftable
  * @param hufftable: a huffman lookup table
  */
 static void create_code_tables(uint16_t * code_table, uint8_t * code_length_table,
@@ -1262,7 +1262,7 @@ static void create_packed_len_table(uint32_t * packed_table,
 	uint16_t extra_bits_count = 0;
 
 	/* Gain extra bits is the next place where the number of extra bits in
-	 * lenght codes increases. */
+	 * length codes increases. */
 	uint16_t gain_extra_bits = LEN_EXTRA_BITS_START;
 
 	for (i = 257; i < LIT_LEN - 1; i++) {
@@ -1366,7 +1366,7 @@ static int are_hufftables_useable(struct huff_code *lit_len_hufftable,
 
 	max_code_len = max_lit_code_len + max_len_code_len + max_dist_code_len;
 
-	/* Some versions of igzip can write upto one literal, one length and one
+	/* Some versions of igzip can write up to one literal, one length and one
 	 * distance code at the same time. This checks to make sure that is
 	 * always writeable in bitbuf*/
 	return (max_code_len > MAX_BITBUF_BIT_WRITE);

--- a/igzip/huff_codes.h
+++ b/igzip/huff_codes.h
@@ -173,7 +173,7 @@ struct hufftables_icf {
  *
  * @param bb: bitbuf structure where the header huffman code header is written
  * @param hufftables: output huffman code representation
- * @param hist: histogram used to generat huffman code
+ * @param hist: histogram used to generate huffman code
  * @param end_of_block: flag whether this is the final huffman code
  *
  * @returns Returns the length in bits of the block with histogram hist encoded

--- a/igzip/igzip.c
+++ b/igzip/igzip.c
@@ -625,7 +625,7 @@ static void write_constant_compressed_stateless(struct isal_zstream *stream,
 	/* Add smaller repeat codes as necessary. Code280 can describe repeat
 	 * lengths of 115-130 bits. Code10 can describe repeat lengths of 10
 	 * bits. If more than 230 bits, fill code with two code280s. Else if
-	 * more than 115 repeates, fill with code10s until one code280 can
+	 * more than 115 repeats, fill with code10s until one code280 can
 	 * finish the rest of the repeats. Else, fill with code10s and
 	 * literals */
 	if (rep_extra > 115) {

--- a/igzip/igzip_body.asm
+++ b/igzip/igzip_body.asm
@@ -442,7 +442,7 @@ align	16
 	or	code4, code
 	add	code_len2, rcx
 
-	;; Setup for updateing hash
+	;; Setup for updating hash
 	lea	tmp3, [f_i + 2]	; tmp3 <= k
 	add	f_i, len
 

--- a/igzip/igzip_decode_block_stateless.asm
+++ b/igzip/igzip_decode_block_stateless.asm
@@ -399,7 +399,7 @@ stack_size		equ	4 * 8 + 8 * 8
 %define	%%state_offset		%3 ; Type of huff code, should be either LIT or DIST
 %define %%read_in		%4 ; Bits read in from compressed stream
 %define %%read_in_length	%5 ; Number of valid bits in read_in
-%define %%next_sym		%6 ; Returned symobl
+%define %%next_sym		%6 ; Returned symbol
 %define %%next_extra_bits	%7
 %define	%%next_bits		%8
 
@@ -447,7 +447,7 @@ stack_size		equ	4 * 8 + 8 * 8
 %define	%%state_offset		%3
 %define %%read_in		%4 ; Bits read in from compressed stream
 %define %%read_in_length	%5 ; Number of valid bits in read_in
-%define %%next_sym		%6 ; Returned symobl
+%define %%next_sym		%6 ; Returned symbol
 %define %%next_extra_bits	%7
 %define %%next_bits		%8
 

--- a/igzip/igzip_file_perf.c
+++ b/igzip/igzip_file_perf.c
@@ -99,7 +99,7 @@ int usage(void)
 		"  -X        use compression level X with 0 <= X <= 1\n"
 		"  -b <size> input buffer size, 0 buffers all the input\n"
 		"  -i <time> time in seconds to benchmark (at least 0)\n"
-		"  -o <file> output file for compresed data\n"
+		"  -o <file> output file for compressed data\n"
 		"  -d <file> dictionary file used by compression\n"
 		"  -w <size> log base 2 size of history window, between 8 and 15\n");
 

--- a/igzip/igzip_icf_body_h1_gr_bt.asm
+++ b/igzip/igzip_icf_body_h1_gr_bt.asm
@@ -436,7 +436,7 @@ isal_deflate_icf_body_ %+ METHOD %+ _ %+ ARCH %+ :
 
 .len_dist_huffman:
 	dec	f_i
-	;; Setup for updateing hash
+	;; Setup for updating hash
 	lea	tmp3, [f_i + 2]	; tmp3 <= k
 
 	neg	dist

--- a/igzip/igzip_inflate.c
+++ b/igzip/igzip_inflate.c
@@ -454,7 +454,7 @@ static void make_inflate_huff_code_lit_len(struct inflate_huff_code_large *resul
 
 	min_length = last_length;
 	for (; last_length <= ISAL_DECODE_LONG_BITS; last_length++) {
-		/* Copy forward previosly set codes */
+		/* Copy forward previously set codes */
 		memcpy(short_code_lookup + copy_size, short_code_lookup,
 		       sizeof(*short_code_lookup) * copy_size);
 		copy_size *= 2;
@@ -1900,7 +1900,7 @@ static int check_gzip_checksum(struct inflate_state *state)
 	int ret;
 
 	if (state->read_in_length >= 8 * GZIP_TRAILER_LEN) {
-		/* The following is unecessary as state->read_in_length == 64 */
+		/* The following is unnecessary as state->read_in_length == 64 */
 		/* bit_count = state->read_in_length % 8; */
 		/* state->read_in >>= bit_count; */
 		/* state->read_in_length -= bit_count; */

--- a/igzip/igzip_rand_test.c
+++ b/igzip/igzip_rand_test.c
@@ -626,7 +626,7 @@ int isal_inflate_with_checks(struct inflate_state *state, uint32_t compress_len,
 
 	ret = isal_inflate(state);
 
-	/* Verify the stream is in a valid state when no errors occured */
+	/* Verify the stream is in a valid state when no errors occurred */
 	if (ret >= 0) {
 		stream_check =
 		    inflate_state_valid_check(state, in_buf, in_size, out_buf, out_size,
@@ -1210,7 +1210,7 @@ int compress_multi_pass(uint8_t * data, uint32_t data_size, uint8_t * compressed
 
 		/* Setup out buffer for next round of compression */
 		if (stream->avail_out == 0) {
-			/* Save compressed data inot compressed_buf */
+			/* Save compressed data into compressed_buf */
 			if (out_buf != NULL) {
 				memcpy(compressed_buf + out_processed, out_buf,
 				       out_size - stream->avail_out);
@@ -1450,7 +1450,7 @@ int compress_ver_rep_buf(uint8_t * data, uint32_t data_size, uint64_t data_rep_s
 				return COMPRESS_GENERAL_ERROR;
 		}
 
-		/* Verfiy the compressed buffer */
+		/* Verify the compressed buffer */
 		state.next_in = compressed_buf;
 		state.avail_in = compressed_size;
 		state.next_out = NULL;

--- a/igzip/igzip_wrapper_hdr_test.c
+++ b/igzip/igzip_wrapper_hdr_test.c
@@ -86,7 +86,7 @@ void print_error(int32_t error)
 		printf("Incorrect os field found\n");
 		break;
 	case INCORRECT_EXTRA_LEN:
-		printf("Incorect extra_len field found\n");
+		printf("Incorrect extra_len field found\n");
 		break;
 	case INCORRECT_EXTRA_BUF:
 		printf("Incorrect extra buffer found\n");

--- a/igzip/repeated_char_result.h
+++ b/igzip/repeated_char_result.h
@@ -46,7 +46,7 @@
 #define END_OF_BLOCK 0x7
 #define END_OF_BLOCK_LEN 0x4
 
-/* MIN_REPEAT_LEN currently optimizes storage space, another possiblity is to
+/* MIN_REPEAT_LEN currently optimizes storage space, another possibility is to
  * find the size which optimizes speed instead.*/
 #define MIN_REPEAT_LEN 4*1024
 

--- a/include/test.h
+++ b/include/test.h
@@ -73,7 +73,7 @@ extern "C" {
 # define DEBUG_PRINT(x) do {} while (0)
 #endif
 
-/* Decide wether to use benchmark time as an approximation or a minimum. Fewer
+/* Decide whether to use benchmark time as an approximation or a minimum. Fewer
  * calls to the timer are required for the approximation case.*/
 #define BENCHMARK_MIN_TIME 0
 #define BENCHMARK_APPROX_TIME 1
@@ -100,7 +100,7 @@ extern "C" {
 #endif
 # define GHZ 1000000000
 # define UNIT_SCALE (GHZ)
-# define CALLIBRATE_TIME (UNIT_SCALE / 2)
+# define CALIBRATE_TIME (UNIT_SCALE / 2)
 static inline long long get_time(void) {
 	unsigned int dummy;
 	return __rdtscp(&dummy);
@@ -115,7 +115,7 @@ static inline long long get_res(void) {
 #endif
 #ifdef _MSC_VER
 #define UNIT_SCALE get_res()
-#define CALLIBRATE_TIME (UNIT_SCALE / 4)
+#define CALIBRATE_TIME (UNIT_SCALE / 4)
 static inline long long get_time(void) {
 	long long ret = 0;
 	QueryPerformanceCounter(&ret);
@@ -130,7 +130,7 @@ static inline long long get_res(void) {
 #else
 # define NANO_SCALE 1000000000
 # define UNIT_SCALE NANO_SCALE
-# define CALLIBRATE_TIME (UNIT_SCALE / 4)
+# define CALIBRATE_TIME (UNIT_SCALE / 4)
 #ifdef __FreeBSD__
 # define CLOCK_ID CLOCK_MONOTONIC_PRECISE
 #else
@@ -208,15 +208,15 @@ static inline unsigned long long estimate_perf_iterations(struct perf *p,
 		return (total + get_res() - 1) / get_res();
 }
 
-#define CALLIBRATE(PERF, FUNC_CALL) {				\
+#define CALIBRATE(PERF, FUNC_CALL) {				\
 	unsigned long long _i, _iter = 1;			\
 	perf_start(PERF);					\
 	FUNC_CALL;						\
 	perf_pause(PERF);					\
 								\
-	while (get_base_elapsed(PERF) < CALLIBRATE_TIME) {	\
+	while (get_base_elapsed(PERF) < CALIBRATE_TIME) {	\
 		_iter = estimate_perf_iterations(PERF, _iter,	\
-						2 * CALLIBRATE_TIME);	\
+						2 * CALIBRATE_TIME);	\
 		perf_start(PERF);				\
 		for (_i = 0; _i < _iter; _i++) {		\
 			FUNC_CALL;				\
@@ -255,7 +255,7 @@ static inline unsigned long long estimate_perf_iterations(struct perf *p,
 
 #define BENCHMARK(PERF, RUN_TIME, FUNC_CALL) {			\
 	if((RUN_TIME) > 0) {					\
-		CALLIBRATE(PERF, FUNC_CALL);			\
+		CALIBRATE(PERF, FUNC_CALL);			\
 		PERFORMANCE_TEST(PERF, RUN_TIME, FUNC_CALL);	\
 								\
 	} else {						\

--- a/programs/igzip_cli_check.sh
+++ b/programs/igzip_cli_check.sh
@@ -244,7 +244,7 @@ if command -V md5sum >/dev/null 2>&1 && command -V dd >/dev/null 2>&1; then
     dd if=<(for i in `seq 1000`; do cat $TEST_FILE; done) iflag=fullblock bs=1M count=201 2> out.stder | tee >(md5sum > out.sum1) \
 	| $IGZIP -c -T 4 | $IGZIP -d | md5sum > out.sum2 \
 	&& $DIFF out.sum1 out.sum2 || ret=1
-    pass_check $ret "Large stream compresss test"
+    pass_check $ret "Large stream compress test"
     clear_dir
 
     if test -e /dev/urandom; then

--- a/raid/xor_check_sse.asm
+++ b/raid/xor_check_sse.asm
@@ -185,7 +185,7 @@ next_vect:
 ;;;  	prefetch [ptr+pos+(8*16)]
 	jge	next_vect		;Loop for each vect
 
-	;; End of vects, chech that all parity regs = 0
+	;; End of vects, check that all parity regs = 0
 	mov	tmp, vec		;Back to last vector
 	por	xmm0, xmm1
 	por	xmm2, xmm3


### PR DESCRIPTION
There are quite a few spelling mistakes and typos in comments and user facing message literal strings as found using codespell. Fix these.