### PR TITLE
add libtool dependency for MacOS CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         run: sudo apt install ${{ matrix.assembler }}
         if: runner.os == 'Linux'
       - name: Install build dependencies (Macos)
-        run: brew install ${{ matrix.assembler }} automake autoconf coreutils
+        run: brew install ${{ matrix.assembler }} automake autoconf coreutils libtool
         if: runner.os == 'macOS'
       - name: Build
         run: |


### PR DESCRIPTION
I found that libtool should be installed explicitly depending on HomeBrew state (especially for macos-14 runner).