### PR TITLE
Add macos-14 (arm64) CI (and made it pass finally)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,8 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-latest
+          - macos-13  # x86_64
+          - macos-14  # arm64
         assembler:
           - nasm
     runs-on: ${{ matrix.os }}

--- a/erasure_code/aarch64/gf_6vect_mad_neon.S
+++ b/erasure_code/aarch64/gf_6vect_mad_neon.S
@@ -61,7 +61,7 @@ x_tbl3		.req	x15
 x_tbl4		.req	x16
 x_tbl5		.req	x17
 x_tbl6		.req	x_tbl
-x_const		.req	x18
+x_const		.req	x0
 
 /* vectors */
 v_mask0f	.req	v0

--- a/igzip/aarch64/igzip_decode_huffman_code_block_aarch64.S
+++ b/igzip/aarch64/igzip_decode_huffman_code_block_aarch64.S
@@ -273,7 +273,7 @@ declare Macros
 	declare_generic_reg	arg2,		2, x
 
 	declare_generic_reg	state,		11,x
-	declare_generic_reg	start_out,	18,x
+	declare_generic_reg	start_out,	29,x
 
 	declare_generic_reg	read_in,	3,x
 	declare_generic_reg	read_in_length,	4,w

--- a/igzip/aarch64/igzip_deflate_body_aarch64.S
+++ b/igzip/aarch64/igzip_deflate_body_aarch64.S
@@ -95,7 +95,7 @@ skip_has_hist:
 	declare_generic_reg	m_out_start,	15,x
 	declare_generic_reg	m_out_end,	16,x
 	declare_generic_reg	m_bits,		17,x
-	declare_generic_reg	m_bit_count,	18,w
+	declare_generic_reg	m_bit_count,	2,w
 
 	declare_generic_reg	start_in,	19,x
 	declare_generic_reg	end_in,		20,x

--- a/igzip/aarch64/igzip_deflate_finish_aarch64.S
+++ b/igzip/aarch64/igzip_deflate_finish_aarch64.S
@@ -97,7 +97,7 @@ skip_has_hist:
 	declare_generic_reg	m_out_start,	15,x
 	declare_generic_reg	m_out_end,	16,x
 	declare_generic_reg	m_bits,		17,x
-	declare_generic_reg	m_bit_count,	18,w
+	declare_generic_reg	m_bit_count,	2,w
 
 	declare_generic_reg	start_in,	19,x
 	declare_generic_reg	end_in,		20,x

--- a/igzip/aarch64/isal_deflate_icf_body_hash_hist.S
+++ b/igzip/aarch64/isal_deflate_icf_body_hash_hist.S
@@ -107,7 +107,7 @@ void isal_deflate_icf_body_hash_hist_base(struct isal_zstream *stream);
 	declare_generic_reg	param2,		2,x
 
 	/* local variable */
-	declare_generic_reg	level_buf,	18,x
+	declare_generic_reg	level_buf,	17,x
 	declare_generic_reg	avail_in,	13,w
 	declare_generic_reg	end_in,		13,x
 	declare_generic_reg	start_in,	19,x

--- a/igzip/aarch64/isal_deflate_icf_finish_hash_hist.S
+++ b/igzip/aarch64/isal_deflate_icf_finish_hash_hist.S
@@ -117,7 +117,7 @@ void isal_deflate_icf_finish_hash_hist_aarch64(struct isal_zstream *stream);
 	declare_generic_reg	next_in,		8,x
 	declare_generic_reg	next_out,		10,x
 	declare_generic_reg	next_out_iter,		5,x
-	declare_generic_reg	file_start,		18,x
+	declare_generic_reg	file_start,		17,x
 	declare_generic_reg	last_seen,		14,x
 
 	declare_generic_reg	literal_code,		9,w


### PR DESCRIPTION
- Changed macos-latest CI to macos-13 because macos-latest points 12
- Added macos-14 CI, which is arm64
- ~~Fixed arm64 mach compilation again (cf https://github.com/intel/isa-l/pull/226)~~
- ~~Fixed isal_deflate_icf_finish_lvl1 dispatcher (sorry) (why no one noticed that...)~~
- Avoid using x18 register

CI passed according to https://github.com/cielavenir/isa-l/actions/runs/8114714856