### PR TITLE
Replace prefetchnta with prefetcht0 for crc32

### DIFF
--- a/crc/crc32_iscsi_01.asm
+++ b/crc/crc32_iscsi_01.asm
@@ -205,7 +205,7 @@ CONCAT(_crc_,i,:)
 	crc32	crc2,      qword [block_2 - i*8]
 
  %if i > 128*8 / 32	; prefetch next 3KB data
-	prefetchnta [block_2 + 128*32 - i*32]
+	prefetcht0  [block_2 + 128*32 - i*32]
  %endif
 
 %assign i (i-1)


### PR DESCRIPTION
Replace prefetchnta with prefetcht0 for crc32_iscsi
on SPR/EMR, the performance of crc32_iscsi with prefetcht0 is 1.1x of  crc32_iscsi with prefetchnta testing with crc32_iscsi_perf