### PR TITLE
Fix mingw build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,56 @@ jobs:
       - name: Run extended tests
         run: bash tools/test_extended.sh
 
+  run_tests_mingw_linux_64:
+    needs: check_format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - name: Install build dependencies (Linux)
+        run: sudo apt install nasm mingw-w64
+      - name: Build
+        shell: bash
+        run: |
+          make -j $(nproc) -f Makefile.unx programs/igzip tests arch=mingw host_cpu=x86_64
+      # wine does not seem available, hence cannot run tests.
+
+  run_tests_mingw_linux_32:
+    needs: check_format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - name: Install build dependencies (Linux)
+        run: sudo apt install nasm mingw-w64
+      - name: Build
+        shell: bash
+        run: |
+          make -j $(nproc) -f Makefile.unx programs/igzip tests arch=mingw host_cpu=base_aliases CC=i686-w64-mingw32-gcc
+
+  run_tests_mingw_windows_64:
+    needs: check_format
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - name: Install nasm
+        uses: ilammy/setup-nasm@v1.2.0
+      - name: Build
+        shell: bash
+        run: |
+          make -j $(nproc) -f Makefile.unx programs/igzip tests SIM= arch=mingw host_cpu=x86_64 AR=x86_64-w64-mingw32-gcc-ar
+      - name: Run tests
+        shell: bash
+        run: |
+          # autoconf is missing, hence simulates test_checks.sh
+          make -j $(nproc) -f Makefile.unx check D=TEST_SEED=0 SIM= arch=mingw host_cpu=x86_64 AR=x86_64-w64-mingw32-gcc-ar
+      - name: Run extended tests
+        shell: bash
+        run: |
+          # simulates test_extended.sh
+          make -j $(nproc) -f Makefile.unx perf D=TEST_SEED=0 SIM= arch=mingw host_cpu=x86_64 AR=x86_64-w64-mingw32-gcc-ar
+          make -j $(nproc) -f Makefile.unx test D=TEST_SEED=0 SIM= arch=mingw host_cpu=x86_64 AR=x86_64-w64-mingw32-gcc-ar
+
+  # seems like i686-w64-mingw32-gcc is not available on windows runner.
+
   run_tests_windows:
     needs: check_format
     runs-on: windows-latest

--- a/include/unaligned.h
+++ b/include/unaligned.h
@@ -50,7 +50,7 @@
 #define isal_bswap16(x) bswap_16(x)
 #define isal_bswap32(x) bswap_32(x)
 #define isal_bswap64(x) bswap_64(x)
-#elif defined _WIN64
+#elif defined _WIN32
 #define isal_bswap16(x) _byteswap_ushort(x)
 #define isal_bswap32(x) _byteswap_ulong(x)
 #define isal_bswap64(x) _byteswap_uint64(x)

--- a/make.inc
+++ b/make.inc
@@ -201,8 +201,12 @@ ASFLAGS += -DAS_FEATURE_LEVEL=$(as_feature_level) $(D_HAVE_AS_KNOWS_AVX512_y)
 
 
 # Check for pthreads
-have_threads ?= $(shell printf "int main(void){return 0;}\n" | $(CC) -x c - -o /dev/null -lpthread && echo y )
-THREAD_LD_$(have_threads) := -lpthread
+ifeq ($(arch),mingw)
+have_threads ?= y
+else
+have_threads ?= $(shell printf "int main(void){return 0;}\n" | $(CC) -x c - -o /dev/null -pthread && echo y )
+endif
+THREAD_LD_$(have_threads) := -pthread
 THREAD_CFLAGS_$(have_threads) := -DHAVE_THREADS
 
 progs: $(bin_PROGRAMS)

--- a/make.inc
+++ b/make.inc
@@ -76,13 +76,14 @@ ARFLAGS_win64 = -out:$@
 ASFLAGS_mingw = -f win64
 ARFLAGS_mingw = cr $@
 
+ifneq ($(arch),mingw)
 LDFLAGS_so = -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -Wl,-soname,$(soname)
-
 ifeq ($(shell uname),Linux)
 ifeq ($(host_cpu),x86_64)
   CFLAGS_ += -fcf-protection=full
   ASFLAGS_ += -DINTEL_CET_ENABLED
   LDFLAGS += -Wl,-z,ibt -Wl,-z,shstk -Wl,-z,cet-report=error
+endif
 endif
 endif
 


### PR DESCRIPTION
- After c1839611750d6b13eafd98316e5a914b105e56f7 , `make -f Makefile.unx programs/igzip arch=mingw host_cpu=x86_64` fails without b886279c224d05b90cf1eb25103180515177f3ee .
- Even then, `make -f Makefile.unx programs/igzip arch=mingw host_cpu=base_aliases CC=i686-w64-mingw32-gcc` fails, which is fixed by 13272ef5de281102b9d2ba8b0cda7a7477ef627e .