### PR TITLE
aarch64_multibinary.h: Fix -Wasm-operand-widths

### DIFF
--- a/include/aarch64_multibinary.h
+++ b/include/aarch64_multibinary.h
@@ -331,7 +331,7 @@ static inline int sysctlEnabled(const char* name){
  */
 static inline uint32_t get_micro_arch_id(void)
 {
-	uint32_t id=CPU_IMPLEMENTER_RESERVE;
+	uint64_t id=CPU_IMPLEMENTER_RESERVE;
 #ifndef __APPLE__
 	if ((getauxval(AT_HWCAP) & HWCAP_CPUID)) {
 		/** Here will trap into kernel space */


### PR DESCRIPTION
Compilation with clang gave warnings as per below. 
Arm64 is has a width of 64 bit and these warnings came up.

In file included from igzip/aarch64/igzip_multibinary_aarch64_dispatcher.c:29: ./include/aarch64_multibinary.h:338:35: warning: value size does not match register size specified by the constraint and modifier [-Wasm-operand-widths]
                asm("mrs %0, MIDR_EL1 " : "=r" (id));
                                                ^
./include/aarch64_multibinary.h:338:12: note: use constraint modifier "w"
                asm("mrs %0, MIDR_EL1 " : "=r" (id));
                         ^~
                         %w0
1 warning generated.
In file included from mem/aarch64/mem_aarch64_dispatcher.c:29: ./include/aarch64_multibinary.h:338:35: warning: value size does not match register size specified by the constraint and modifier [-Wasm-operand-widths]
                asm("mrs %0, MIDR_EL1 " : "=r" (id));
                                                ^
./include/aarch64_multibinary.h:338:12: note: use constraint modifier "w"
                asm("mrs %0, MIDR_EL1 " : "=r" (id));
                         ^~
                         %w0
1 warning generated.