### PR TITLE
Extend FreeBSD conditional about byte ordering to NetBSD

### DIFF
--- a/include/unaligned.h
+++ b/include/unaligned.h
@@ -34,7 +34,7 @@
 #include "stdlib.h"
 #include "string.h"
 
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__) || defined(__NetBSD__)
 #include <sys/types.h>
 #include <sys/endian.h>
 # define isal_bswap16(x) bswap16(x)


### PR DESCRIPTION
NetBSD has the same byte-ordering idioms as FreeBSD.

With this, the code builds as a python-isal submodule.  (Without, it takes the Linux path and fails because the Linux byteswap.h header is not present.)

Surely OpenBSD would also use these includes, but I don't have an OpenBSD environment handy to test.  I'm happy to add OpenBSD if you want (were it my project I would), but I don't know your conventions for testing of changes.