### PR TITLE
Add RISC-V V extension support and add R-V V isal_adler32

### DIFF
--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -1,3 +1,6 @@
 include/aarch64_multibinary.h
 include/aarch64_label.h
 **/aarch64/*.h
+
+include/riscv64_multibinary.h
+**/riscv64/*.h

--- a/Makefile.am
+++ b/Makefile.am
@@ -29,10 +29,12 @@ other_tests_x86_64=
 other_tests_x86_32=
 other_tests_aarch64=
 other_tests_ppc64le=
+other_tests_riscv64=
 lsrc_x86_64=
 lsrc_x86_32=
 lsrc_aarch64=
 lsrc_ppc64le=
+lsrc_riscv64=
 lsrc_base_aliases=
 lsrc32=
 unit_tests32=
@@ -83,6 +85,12 @@ libisal_la_SOURCES += ${lsrc_ppc64le}
 other_tests += ${other_tests_ppc64le}
 endif
 
+if CPU_RISCV64
+ARCH=-Driscv64
+libisal_la_SOURCES += ${lsrc_riscv64}
+other_tests += ${other_tests_riscv64}
+endif
+
 if CPU_UNDEFINED
 libisal_la_SOURCES += ${lsrc_base_aliases}
 endif
@@ -131,6 +139,9 @@ endif
 if CPU_AARCH64
   as_filter = $(CC) -D__ASSEMBLY__
 endif
+if CPU_RISCV64
+  as_filter = $(CC) -D__ASSEMBLY__
+endif
 
 CCAS = $(as_filter)
 EXTRA_DIST += tools/yasm-filter.sh tools/nasm-filter.sh
@@ -141,6 +152,9 @@ if CPU_AARCH64
 AM_CCASFLAGS = ${AM_CFLAGS}
 else
 AM_CCASFLAGS = ${yasm_args} ${INCLUDE} ${src_include} ${DEFS} ${D}
+endif
+if CPU_RISCV64
+AM_CCASFLAGS = ${AM_CFLAGS}
 endif
 
 .asm.s:

--- a/configure.ac
+++ b/configure.ac
@@ -39,16 +39,7 @@ AM_CONDITIONAL([CPU_AARCH64], [test "$CPU" = "aarch64"])
 AM_CONDITIONAL([CPU_PPC64LE], [test "$CPU" = "ppc64le"])
 AM_CONDITIONAL([CPU_RISCV64], [test "$CPU" = "riscv64"])
 AM_CONDITIONAL([CPU_UNDEFINED], [test "x$CPU" = "x"])
-
-if test "$CPU" = "x86_64"; then
-   is_x86=yes
-else
-   if test "$CPU" = "x86_32"; then
-      is_x86=yes
-   else
-      is_x86=no
-   fi
-fi
+AM_CONDITIONAL([HAVE_RVV], [false])
 
 # Check for programs
 AC_PROG_CC_STDC
@@ -58,6 +49,40 @@ LT_INIT
 AC_PREFIX_DEFAULT([/usr])
 AC_PROG_SED
 AC_PROG_MKDIR_P
+
+case "${CPU}" in
+
+	x86_64)
+
+		is_x86=yes
+		;;
+
+	x86_32)
+
+		is_x86=yes
+		;;
+
+	riscv64)
+
+		AC_MSG_CHECKING([checking RVV support])
+		AC_COMPILE_IFELSE(
+			[AC_LANG_PROGRAM([], [
+				__asm__ volatile(
+					".option arch, +v\n"
+					"vsetivli zero, 0, e8, m1, ta, ma\n"
+				);
+			])],
+			[AC_DEFINE([HAVE_RVV], [1], [Enable RVV instructions])
+			AM_CONDITIONAL([HAVE_RVV], [true]) rvv=yes],
+			[AM_CONDITIONAL([HAVE_RVV], [false]) rvv=no]
+		)
+		AC_MSG_RESULT([$rvv])
+		;;
+
+	*)
+		is_x86=no
+
+esac
 
 # Options
 AC_ARG_ENABLE([debug],

--- a/configure.ac
+++ b/configure.ac
@@ -31,11 +31,13 @@ AS_CASE([$host_cpu],
   [arm64], [CPU="aarch64"],
   [powerpc64le], [CPU="ppc64le"],
   [ppc64le], [CPU="ppc64le"],
+  [riscv64], [CPU="riscv64"],
 )
 AM_CONDITIONAL([CPU_X86_64], [test "$CPU" = "x86_64"])
 AM_CONDITIONAL([CPU_X86_32], [test "$CPU" = "x86_32"])
 AM_CONDITIONAL([CPU_AARCH64], [test "$CPU" = "aarch64"])
 AM_CONDITIONAL([CPU_PPC64LE], [test "$CPU" = "ppc64le"])
+AM_CONDITIONAL([CPU_RISCV64], [test "$CPU" = "riscv64"])
 AM_CONDITIONAL([CPU_UNDEFINED], [test "x$CPU" = "x"])
 
 if test "$CPU" = "x86_64"; then

--- a/crc/Makefile.am
+++ b/crc/Makefile.am
@@ -36,6 +36,7 @@ lsrc  += \
 lsrc_base_aliases += crc/crc_base_aliases.c
 lsrc_x86_32       += crc/crc_base_aliases.c
 lsrc_ppc64le      += crc/crc_base_aliases.c
+lsrc_riscv64      += crc/crc_base_aliases.c
 
 lsrc_x86_64 += \
 	crc/crc16_t10dif_01.asm \

--- a/erasure_code/Makefile.am
+++ b/erasure_code/Makefile.am
@@ -34,6 +34,7 @@ include erasure_code/ppc64le/Makefile.am
 lsrc         += erasure_code/ec_base.c
 
 lsrc_base_aliases += erasure_code/ec_base_aliases.c
+lsrc_riscv64      += erasure_code/ec_base_aliases.c
 lsrc_x86_64  += \
 		erasure_code/ec_highlevel_func.c \
 		erasure_code/gf_vect_mul_sse.asm \

--- a/igzip/Makefile.am
+++ b/igzip/Makefile.am
@@ -27,6 +27,8 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ########################################################################
 
+include igzip/riscv64/Makefile.am
+
 lsrc        += 	igzip/igzip.c \
 		igzip/hufftables_c.c \
 		igzip/igzip_base.c \
@@ -39,7 +41,7 @@ lsrc        += 	igzip/igzip.c \
 lsrc_base_aliases += igzip/igzip_base_aliases.c igzip/proc_heap_base.c
 lsrc_x86_32       += igzip/igzip_base_aliases.c igzip/proc_heap_base.c
 lsrc_ppc64le      += igzip/igzip_base_aliases.c igzip/proc_heap_base.c
-lsrc_riscv64      += igzip/igzip_base_aliases.c igzip/proc_heap_base.c
+lsrc_riscv64      +=                            igzip/proc_heap_base.c
 
 lsrc_aarch64 +=	igzip/aarch64/igzip_inflate_multibinary_arm64.S  \
 		igzip/aarch64/igzip_multibinary_arm64.S	\

--- a/igzip/Makefile.am
+++ b/igzip/Makefile.am
@@ -39,6 +39,7 @@ lsrc        += 	igzip/igzip.c \
 lsrc_base_aliases += igzip/igzip_base_aliases.c igzip/proc_heap_base.c
 lsrc_x86_32       += igzip/igzip_base_aliases.c igzip/proc_heap_base.c
 lsrc_ppc64le      += igzip/igzip_base_aliases.c igzip/proc_heap_base.c
+lsrc_riscv64      += igzip/igzip_base_aliases.c igzip/proc_heap_base.c
 
 lsrc_aarch64 +=	igzip/aarch64/igzip_inflate_multibinary_arm64.S  \
 		igzip/aarch64/igzip_multibinary_arm64.S	\

--- a/igzip/checksum32_funcs_test.c
+++ b/igzip/checksum32_funcs_test.c
@@ -126,7 +126,7 @@ main(int argc, char *argv[])
 int
 zeros_test(func_case_t *test_func)
 {
-        uint32_t c_dut, c_ref;
+        volatile uint32_t c_dut, c_ref;
         int fail = 0;
         unsigned char *buf = NULL;
 
@@ -153,7 +153,7 @@ zeros_test(func_case_t *test_func)
 int
 simple_pattern_test(func_case_t *test_func)
 {
-        uint32_t c_dut, c_ref;
+        volatile uint32_t c_dut, c_ref;
         int fail = 0;
         unsigned char *buf = NULL;
 
@@ -176,7 +176,7 @@ simple_pattern_test(func_case_t *test_func)
 int
 seeds_sizes_test(func_case_t *test_func)
 {
-        uint32_t c_dut, c_ref;
+        volatile uint32_t c_dut, c_ref;
         int fail = 0;
         int i;
         uint32_t r, s;
@@ -251,7 +251,7 @@ seeds_sizes_test(func_case_t *test_func)
 int
 eob_test(func_case_t *test_func)
 {
-        uint32_t c_dut, c_ref;
+        volatile uint32_t c_dut, c_ref;
         int fail = 0;
         int i;
         unsigned char *buf = NULL;
@@ -277,7 +277,7 @@ eob_test(func_case_t *test_func)
 int
 update_test(func_case_t *test_func)
 {
-        uint32_t c_dut, c_ref;
+        volatile uint32_t c_dut, c_ref;
         int fail = 0;
         int i;
         uint32_t r;
@@ -310,7 +310,7 @@ update_test(func_case_t *test_func)
 int
 update_over_mod_test(func_case_t *test_func)
 {
-        uint32_t c_dut, c_ref;
+        volatile uint32_t c_dut, c_ref;
         int fail = 0;
         int i;
         unsigned char *buf = NULL;

--- a/igzip/riscv64/Makefile.am
+++ b/igzip/riscv64/Makefile.am
@@ -1,0 +1,32 @@
+########################################################################
+#  Copyright (c) 2025 Institute of Software Chinese Academy of Sciences (ISCAS).
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions
+#  are met:
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in
+#      the documentation and/or other materials provided with the
+#      distribution.
+#    * Neither the name of ISCAS Corporation nor the names of its
+#      contributors may be used to endorse or promote products derived
+#      from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+#  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+########################################################################
+
+lsrc_riscv64 += \
+	igzip/riscv64/igzip_multibinary_riscv64_dispatcher.c \
+	igzip/riscv64/igzip_multibinary_riscv64.S

--- a/igzip/riscv64/Makefile.am
+++ b/igzip/riscv64/Makefile.am
@@ -29,4 +29,5 @@
 
 lsrc_riscv64 += \
 	igzip/riscv64/igzip_multibinary_riscv64_dispatcher.c \
-	igzip/riscv64/igzip_multibinary_riscv64.S
+	igzip/riscv64/igzip_multibinary_riscv64.S \
+	igzip/riscv64/igzip_isal_adler32_rvv.S

--- a/igzip/riscv64/igzip_isal_adler32_rvv.S
+++ b/igzip/riscv64/igzip_isal_adler32_rvv.S
@@ -26,6 +26,7 @@
   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 **********************************************************************/
+#if HAVE_RVV
 .option         arch, +v
 .global         adler32_rvv
 .type           adler32_rvv, %function
@@ -74,3 +75,4 @@ adler32_rvv:
   add           a0, t2, t3                           // a0 = A + B
 
   ret
+#endif

--- a/igzip/riscv64/igzip_isal_adler32_rvv.S
+++ b/igzip/riscv64/igzip_isal_adler32_rvv.S
@@ -1,0 +1,76 @@
+/**********************************************************************
+  Copyright (c) 2025 Institute of Software Chinese Academy of Sciences (ISCAS).
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of ISCAS Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+.option         arch, +v
+.global         adler32_rvv
+.type           adler32_rvv, %function
+adler32_rvv:
+  slli          t2, a0, 48
+  srli          t2, t2, 48                           // t2: A = adler32 & 0xffff;
+  srliw         t3, a0, 16                           // t3: B = adler32 >> 16;
+  beqz          a2, 2f
+
+  vsetvli       zero, a2, e64, m8, tu, ma
+  vmv.v.i       v8, 0
+  vmv.v.i       v16, 0
+  vmv.s.x       v24, zero
+  mv            t6, a2                               // t6 = length
+  vsetvli       zero, zero, e32, m4, tu, ma
+  vmv.s.x       v8, t2                               // v8 = adler32 & 0xffff
+
+1:
+  vsetvli       t1, a2, e8, m1, tu, ma
+  vle8.v        v0, (a1)
+  vsetvli       zero, zero, e32, m4, tu, ma
+  vzext.vf4     v4, v0
+  vid.v         v12                                  // 0, 1, 2, .. vl-1
+  vadd.vv       v8, v8, v4
+  vrsub.vx      v12, v12, a2                         // len, len-1, len-2
+  vwmaccu.vv    v16, v12, v4                         // v16: B += weight * next
+  sub           a2, a2, t1
+  add           a1, a1, t1
+  bnez          a2, 1b
+
+  vsetvli       zero, t6, e32, m4, tu, ma
+  vwredsumu.vs  v24, v8, v24
+  mul           a7, t6, t2                           // B += A(init) * len
+  vsetvli       zero, t6, e64, m8, tu, ma
+  vmv.s.x       v0, a7
+  vredsum.vs    v0, v16, v0
+  vmv.x.s       t4, v0                               // B = t4
+  vmv.x.s       t2, v24                              // A = t2
+  add           t3, t4, t3
+
+2:
+  li            t0, 65521
+  remu          t2, t2, t0                           // A = A % ADLER_MOD
+  remu          t3, t3, t0                           // B = B % ADLER_MOD
+  slli          t3, t3, 16                           // B << 16
+  add           a0, t2, t3                           // a0 = A + B
+
+  ret

--- a/igzip/riscv64/igzip_multibinary_riscv64.S
+++ b/igzip/riscv64/igzip_multibinary_riscv64.S
@@ -29,7 +29,8 @@
 
 #include "riscv64_multibinary.h"
 
-mbin_interface_base isal_adler32, adler32_base
+mbin_interface		isal_adler32
+
 mbin_interface_base gen_icf_map_lh1, gen_icf_map_h1_base
 mbin_interface_base decode_huffman_code_block_stateless, decode_huffman_code_block_stateless_base
 mbin_interface_base isal_deflate_icf_finish_lvl3, isal_deflate_icf_finish_hash_map_base

--- a/igzip/riscv64/igzip_multibinary_riscv64.S
+++ b/igzip/riscv64/igzip_multibinary_riscv64.S
@@ -1,0 +1,49 @@
+/**********************************************************************
+  Copyright (c) 2025 Institute of Software Chinese Academy of Sciences (ISCAS).
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of ISCAS Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+#include "riscv64_multibinary.h"
+
+mbin_interface_base isal_adler32, adler32_base
+mbin_interface_base gen_icf_map_lh1, gen_icf_map_h1_base
+mbin_interface_base decode_huffman_code_block_stateless, decode_huffman_code_block_stateless_base
+mbin_interface_base isal_deflate_icf_finish_lvl3, isal_deflate_icf_finish_hash_map_base
+mbin_interface_base isal_deflate_hash_lvl3, isal_deflate_hash_base
+mbin_interface_base isal_deflate_hash_lvl1, isal_deflate_hash_base
+mbin_interface_base isal_deflate_icf_body_lvl2, isal_deflate_icf_body_hash_hist_base
+mbin_interface_base isal_deflate_icf_finish_lvl1, isal_deflate_icf_finish_hash_hist_base
+mbin_interface_base isal_deflate_finish, isal_deflate_finish_base
+mbin_interface_base isal_deflate_body, isal_deflate_body_base
+mbin_interface_base isal_deflate_hash_lvl2, isal_deflate_hash_base
+mbin_interface_base encode_deflate_icf, encode_deflate_icf_base
+mbin_interface_base set_long_icf_fg, set_long_icf_fg_base
+mbin_interface_base isal_deflate_icf_body_lvl3, icf_body_hash1_fillgreedy_lazy
+mbin_interface_base isal_deflate_icf_body_lvl1, isal_deflate_icf_body_hash_hist_base
+mbin_interface_base isal_deflate_hash_lvl0, isal_deflate_hash_base
+mbin_interface_base isal_deflate_icf_finish_lvl2, isal_deflate_icf_finish_hash_hist_base
+mbin_interface_base isal_update_histogram, isal_update_histogram_base

--- a/igzip/riscv64/igzip_multibinary_riscv64.S
+++ b/igzip/riscv64/igzip_multibinary_riscv64.S
@@ -29,7 +29,11 @@
 
 #include "riscv64_multibinary.h"
 
-mbin_interface		isal_adler32
+#if HAVE_RVV
+    mbin_interface		isal_adler32
+#else
+    mbin_interface_base		isal_adler32, adler32_base
+#endif
 
 mbin_interface_base gen_icf_map_lh1, gen_icf_map_h1_base
 mbin_interface_base decode_huffman_code_block_stateless, decode_huffman_code_block_stateless_base

--- a/igzip/riscv64/igzip_multibinary_riscv64_dispatcher.c
+++ b/igzip/riscv64/igzip_multibinary_riscv64_dispatcher.c
@@ -30,9 +30,11 @@
 
 DEFINE_INTERFACE_DISPATCHER(isal_adler32)
 {
+#if HAVE_RVV
         const unsigned long hwcap = getauxval(AT_HWCAP);
         if (hwcap & HWCAP_RV('V'))
                 return PROVIDER_INFO(adler32_rvv);
         else
+#endif
                 return PROVIDER_BASIC(adler32);
 }

--- a/igzip/riscv64/igzip_multibinary_riscv64_dispatcher.c
+++ b/igzip/riscv64/igzip_multibinary_riscv64_dispatcher.c
@@ -1,0 +1,34 @@
+/**********************************************************************
+  Copyright (c) 2025 Institute of Software Chinese Academy of Sciences (ISCAS).
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of ISCAS Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+#include "riscv64_multibinary.h"
+
+DEFINE_INTERFACE_DISPATCHER(isal_adler32)
+{
+        return PROVIDER_BASIC(adler32);
+}

--- a/igzip/riscv64/igzip_multibinary_riscv64_dispatcher.c
+++ b/igzip/riscv64/igzip_multibinary_riscv64_dispatcher.c
@@ -30,5 +30,9 @@
 
 DEFINE_INTERFACE_DISPATCHER(isal_adler32)
 {
-        return PROVIDER_BASIC(adler32);
+        const unsigned long hwcap = getauxval(AT_HWCAP);
+        if (hwcap & HWCAP_RV('V'))
+                return PROVIDER_INFO(adler32_rvv);
+        else
+                return PROVIDER_BASIC(adler32);
 }

--- a/include/riscv64_multibinary.h
+++ b/include/riscv64_multibinary.h
@@ -1,0 +1,131 @@
+/**********************************************************************
+  Copyright (c) 2025 Institute of Software Chinese Academy of Sciences (ISCAS).
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of ISCAS Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+#ifndef __RISCV_MULTIBINARY_H__
+#define __RISCV_MULTIBINARY_H__
+#ifndef __riscv
+#error "This file is for riscv only"
+#endif
+
+#ifdef __ASSEMBLY__
+
+/**
+ * # mbin_interface : the wrapper layer for isal-l api
+ *
+ * ## references:
+ * * aarch64_multibinary.h
+ * ## Usage:
+ *
+ * 	1. Define dispather function
+ * 	2. name must be \name\()_dispatcher
+ * 	3. Prototype should be *"void * \name\()_dispatcher"*
+ * 	4. The dispather should return the right function pointer , revision and a string information .
+ **/
+.macro mbin_interface name:req
+	.section .data
+	.align 3
+	.global \name\()_dispatcher_info
+	.type \name\()_dispatcher_info, @object
+\name\()_dispatcher_info:
+	.quad \name\()_mbinit
+	.section .text
+	.global \name\()_mbinit
+\name\()_mbinit:
+	addi        sp, sp, -32
+	sd          ra, 24(sp)
+	sd          a0, 0(sp)
+	sd          a1, 8(sp)
+	sd          a2, 16(sp)
+	call        \name\()_dispatcher
+	mv          t2, a0
+	la          t0, \name\()_dispatcher_info
+	sd          a0, 0(t0)
+	ld          ra, 24(sp)
+	ld          a0, 0(sp)
+	ld          a1, 8(sp)
+	ld          a2, 16(sp)
+	addi        sp, sp, 32
+	jr          t2
+.global \name\()
+.type \name,%function
+\name\():
+	la          t0, \name\()_dispatcher_info
+	ld          t1, 0(t0)
+	jr          t1
+.size \name,. - \name
+.endm
+
+/**
+ * mbin_interface_base is used for the interfaces which have only
+ * noarch implementation
+ */
+.macro mbin_interface_base name:req, base:req
+	.extern \base
+	.data
+	.align 3
+	.global \name\()_dispatcher_info
+	.type \name\()_dispatcher_info, @object
+\name\()_dispatcher_info:
+	.dword \base
+	.text
+	.global \name
+	.type \name, @function
+\name:
+	la      t0, \name\()_dispatcher_info
+	ld      t0, (t0)
+	jr      t0
+.endm
+#else /* __ASSEMBLY__ */
+#include <sys/auxv.h>
+#define HWCAP_RV(letter) (1ul << ((letter) - 'A'))
+
+#define DEFINE_INTERFACE_DISPATCHER(name)                               \
+	void * name##_dispatcher(void)
+
+#define PROVIDER_BASIC(name)                                            \
+	PROVIDER_INFO(name##_base)
+
+#define DO_DIGNOSTIC(x)	_Pragma GCC diagnostic ignored "-W"#x
+#define DO_PRAGMA(x) _Pragma (#x)
+#define DIGNOSTIC_IGNORE(x) DO_PRAGMA(GCC diagnostic ignored #x)
+#define DIGNOSTIC_PUSH()	DO_PRAGMA(GCC diagnostic push)
+#define DIGNOSTIC_POP()		DO_PRAGMA(GCC diagnostic pop)
+
+
+#define PROVIDER_INFO(_func_entry)                                  	\
+	({	DIGNOSTIC_PUSH()					\
+		DIGNOSTIC_IGNORE(-Wnested-externs)			\
+		extern void  _func_entry(void);				\
+		DIGNOSTIC_POP()						\
+		_func_entry;						\
+	})
+
+
+
+#endif /* __ASSEMBLY__ */
+#endif /* __RISCV_MULTIBINARY_H__ */

--- a/mem/Makefile.am
+++ b/mem/Makefile.am
@@ -33,6 +33,7 @@ lsrc        += 	mem/mem_zero_detect_base.c
 
 lsrc_base_aliases += mem/mem_zero_detect_base_aliases.c
 lsrc_ppc64le      += mem/mem_zero_detect_base_aliases.c
+lsrc_riscv64      += mem/mem_zero_detect_base_aliases.c
 
 lsrc_x86_64 += 	mem/mem_zero_detect_avx512.asm \
 		mem/mem_zero_detect_avx2.asm \

--- a/raid/Makefile.am
+++ b/raid/Makefile.am
@@ -33,6 +33,7 @@ lsrc        += 	raid/raid_base.c
 
 lsrc_base_aliases += raid/raid_base_aliases.c
 lsrc_ppc64le      += raid/raid_base_aliases.c
+lsrc_riscv64      += raid/raid_base_aliases.c
 
 lsrc_x86_64 += \
 		raid/xor_gen_sse.asm \


### PR DESCRIPTION
Include V extension checks at both build and runtime, and optimize isal_adler32

```
banana_f3:
        new: adler32_warm: runtime =    3062612 usecs, bandwidth 3861 MB in 3.0626 sec = 1261.01 MB/s
        old: adler32_warm: runtime =    3062505 usecs, bandwidth 1027 MB in 3.0625 sec = 335.64 MB/s
```