### PR TITLE
Address type mismatch warnings on riscv64

### DIFF
--- a/igzip/riscv64/igzip_multibinary_riscv64_dispatcher.c
+++ b/igzip/riscv64/igzip_multibinary_riscv64_dispatcher.c
@@ -28,13 +28,18 @@
 **********************************************************************/
 #include "riscv64_multibinary.h"
 
+extern uint32_t
+adler32_rvv(uint32_t, uint8_t *, uint64_t);
+extern uint32_t
+adler32_base(uint32_t, uint8_t *, uint64_t);
+
 DEFINE_INTERFACE_DISPATCHER(isal_adler32)
 {
 #if HAVE_RVV
         const unsigned long hwcap = getauxval(AT_HWCAP);
         if (hwcap & HWCAP_RV('V'))
-                return PROVIDER_INFO(adler32_rvv);
+                return adler32_rvv;
         else
 #endif
-                return PROVIDER_BASIC(adler32);
+                return adler32_base;
 }

--- a/include/riscv64_multibinary.h
+++ b/include/riscv64_multibinary.h
@@ -107,25 +107,5 @@
 #define DEFINE_INTERFACE_DISPATCHER(name)                               \
 	void * name##_dispatcher(void)
 
-#define PROVIDER_BASIC(name)                                            \
-	PROVIDER_INFO(name##_base)
-
-#define DO_DIGNOSTIC(x)	_Pragma GCC diagnostic ignored "-W"#x
-#define DO_PRAGMA(x) _Pragma (#x)
-#define DIGNOSTIC_IGNORE(x) DO_PRAGMA(GCC diagnostic ignored #x)
-#define DIGNOSTIC_PUSH()	DO_PRAGMA(GCC diagnostic push)
-#define DIGNOSTIC_POP()		DO_PRAGMA(GCC diagnostic pop)
-
-
-#define PROVIDER_INFO(_func_entry)                                  	\
-	({	DIGNOSTIC_PUSH()					\
-		DIGNOSTIC_IGNORE(-Wnested-externs)			\
-		extern void  _func_entry(void);				\
-		DIGNOSTIC_POP()						\
-		_func_entry;						\
-	})
-
-
-
 #endif /* __ASSEMBLY__ */
 #endif /* __RISCV_MULTIBINARY_H__ */


### PR DESCRIPTION
The riscv64 dispatcher code uses the same PROVIDER_INFO macro as the aarch64 dispatcher and have the same kind of warnings during compilation:
```
igzip/riscv64/igzip_multibinary_riscv64_dispatcher.c:39:24: warning: type of 'adler32_base' does not match original declaration [-Wlto-type-mismatch]
   39 |                 return PROVIDER_BASIC(adler32);
      |                        ^
igzip/adler32_base.c:34:1: note: return value type mismatch
   34 | adler32_base(uint32_t adler32, uint8_t *start, uint64_t length)
      | ^
igzip/adler32_base.c:34:1: note: type 'uint32_t' should match type 'void'
igzip/adler32_base.c:34:1: note: 'adler32_base' was previously declared here
```
This commit introduces the same correction for riscv64.

See #313 for details.