### PR TITLE
aarch64: Fix build on macOS

### DIFF
--- a/crc/aarch64/crc32_gzip_refl_pmull.h
+++ b/crc/aarch64/crc32_gzip_refl_pmull.h
@@ -27,24 +27,24 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #########################################################################
 
-.equ	p4_low_b0, 0x2d95
-.equ	p4_low_b1, 0x8f35
-.equ	p4_high_b0, 0x13d7
-.equ	p4_high_b1, 0x1d95
-.equ	p1_low_b0, 0x9191
-.equ	p1_low_b1, 0xae68
-.equ	p1_high_b0, 0x009e
-.equ	p1_high_b1, 0xccaa
-.equ	p0_low_b0, 0x6765
-.equ	p0_low_b1, 0xb8bc
-.equ	p0_high_b0, p1_high_b0
-.equ	p0_high_b1, p1_high_b1
-.equ	br_low_b0, 0x0641
-.equ	br_low_b1, 0xdb71
-.equ	br_low_b2, 0x1
-.equ	br_high_b0, 0x1641
-.equ	br_high_b1, 0xf701
-.equ	br_high_b2, 0x1
+#define	p4_low_b0 0x2d95
+#define	p4_low_b1 0x8f35
+#define	p4_high_b0 0x13d7
+#define	p4_high_b1 0x1d95
+#define	p1_low_b0 0x9191
+#define	p1_low_b1 0xae68
+#define	p1_high_b0 0x009e
+#define	p1_high_b1 0xccaa
+#define	p0_low_b0 0x6765
+#define	p0_low_b1 0xb8bc
+#define	p0_high_b0 p1_high_b0
+#define	p0_high_b1 p1_high_b1
+#define	br_low_b0 0x0641
+#define	br_low_b1 0xdb71
+#define	br_low_b2 0x1
+#define	br_high_b0 0x1641
+#define	br_high_b1 0xf701
+#define	br_high_b2 0x1
 
 	.text
 ASM_DEF_RODATA

--- a/crc/aarch64/crc32_ieee_norm_pmull.h
+++ b/crc/aarch64/crc32_ieee_norm_pmull.h
@@ -27,24 +27,24 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #########################################################################
 
-.equ	p4_low_b0, 0x8b11
-.equ	p4_low_b1, 0xe622
-.equ	p4_high_b0, 0x794c
-.equ	p4_high_b1, 0x8833
-.equ	p1_low_b0, 0x5605
-.equ	p1_low_b1, 0xe8a4
-.equ	p1_high_b0, 0xcd4c
-.equ	p1_high_b1, 0xc5b9
-.equ	p0_low_b0, 0x678d
-.equ	p0_low_b1, 0x490d
-.equ	p0_high_b0, 0xaa66
-.equ	p0_high_b1, 0xf200
-.equ	br_low_b0, 0x01df
-.equ	br_low_b1, 0x04d1
-.equ	br_low_b2, 0x1
-.equ	br_high_b0, 0x1db7
-.equ	br_high_b1, 0x04c1
-.equ	br_high_b2, 0x1
+#define	p4_low_b0 0x8b11
+#define	p4_low_b1 0xe622
+#define	p4_high_b0 0x794c
+#define	p4_high_b1 0x8833
+#define	p1_low_b0 0x5605
+#define	p1_low_b1 0xe8a4
+#define	p1_high_b0 0xcd4c
+#define	p1_high_b1 0xc5b9
+#define	p0_low_b0 0x678d
+#define	p0_low_b1 0x490d
+#define	p0_high_b0 0xaa66
+#define	p0_high_b1 0xf200
+#define	br_low_b0 0x01df
+#define	br_low_b1 0x04d1
+#define	br_low_b2 0x1
+#define	br_high_b0 0x1db7
+#define	br_high_b1 0x04c1
+#define	br_high_b2 0x1
 
 	.text
 ASM_DEF_RODATA

--- a/crc/aarch64/crc32_iscsi_refl_pmull.h
+++ b/crc/aarch64/crc32_iscsi_refl_pmull.h
@@ -27,24 +27,24 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #########################################################################
 
-.equ	p4_low_b0, 0xef02
-.equ	p4_low_b1, 0x740e
-.equ	p4_high_b0, 0xddf8
-.equ	p4_high_b1, 0x9e4a
-.equ	p1_low_b0, 0x0dfe
-.equ	p1_low_b1, 0xf20c
-.equ	p1_high_b0, 0x7d27
-.equ	p1_high_b1, 0x493c
-.equ	p0_low_b0, 0xaab8
-.equ	p0_low_b1, 0xdd45
-.equ	p0_high_b0, p1_high_b0
-.equ	p0_high_b1, p1_high_b1
-.equ	br_low_b0, 0x76f1
-.equ	br_low_b1, 0x05ec
-.equ	br_low_b2, 0x1
-.equ	br_high_b0, 0x13f1
-.equ	br_high_b1, 0xdea7
-.equ	br_high_b2, 0x0
+#define	p4_low_b0 0xef02
+#define	p4_low_b1 0x740e
+#define	p4_high_b0 0xddf8
+#define	p4_high_b1 0x9e4a
+#define	p1_low_b0 0x0dfe
+#define	p1_low_b1 0xf20c
+#define	p1_high_b0 0x7d27
+#define	p1_high_b1 0x493c
+#define	p0_low_b0 0xaab8
+#define	p0_low_b1 0xdd45
+#define	p0_high_b0 p1_high_b0
+#define	p0_high_b1 p1_high_b1
+#define	br_low_b0 0x76f1
+#define	br_low_b1 0x05ec
+#define	br_low_b2 0x1
+#define	br_high_b0 0x13f1
+#define	br_high_b1 0xdea7
+#define	br_high_b2 0x0
 
 	.text
 

--- a/crc/aarch64/crc64_ecma_norm_pmull.h
+++ b/crc/aarch64/crc64_ecma_norm_pmull.h
@@ -27,41 +27,41 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #########################################################################
 
-.equ	p4_low_b0, (0xf020)
-.equ	p4_low_b1, 0x540d
-.equ	p4_low_b2, 0x43ca
-.equ	p4_low_b3, 0x5f68
-.equ	p4_high_b0, 0xb83f
-.equ	p4_high_b1, 0x1205
-.equ	p4_high_b2, 0xb698
-.equ	p4_high_b3, 0xddf4
+#define	p4_low_b0 (0xf020)
+#define	p4_low_b1 0x540d
+#define	p4_low_b2 0x43ca
+#define	p4_low_b3 0x5f68
+#define	p4_high_b0 0xb83f
+#define	p4_high_b1 0x1205
+#define	p4_high_b2 0xb698
+#define	p4_high_b3 0xddf4
 
-.equ	p1_low_b0, (0xfab6)
-.equ	p1_low_b1, 0xeb52
-.equ	p1_low_b2, 0xc3c7
-.equ	p1_low_b3, 0x05f5
-.equ	p1_high_b0, 0x740e
-.equ	p1_high_b1, 0xd257
-.equ	p1_high_b2, 0x38a7
-.equ	p1_high_b3, 0x4eb9
+#define	p1_low_b0 (0xfab6)
+#define	p1_low_b1 0xeb52
+#define	p1_low_b2 0xc3c7
+#define	p1_low_b3 0x05f5
+#define	p1_high_b0 0x740e
+#define	p1_high_b1 0xd257
+#define	p1_high_b2 0x38a7
+#define	p1_high_b3 0x4eb9
 
-.equ	p0_low_b0, (0xfab6)
-.equ	p0_low_b1, 0xeb52
-.equ	p0_low_b2, 0xc3c7
-.equ	p0_low_b3, 0x05f5
-.equ	p0_high_b0, 0x0
-.equ	p0_high_b1, 0x0
-.equ	p0_high_b2, 0x0
-.equ	p0_high_b3, 0x0
+#define	p0_low_b0 (0xfab6)
+#define	p0_low_b1 0xeb52
+#define	p0_low_b2 0xc3c7
+#define	p0_low_b3 0x05f5
+#define	p0_high_b0 0x0
+#define	p0_high_b1 0x0
+#define	p0_high_b2 0x0
+#define	p0_high_b3 0x0
 
-.equ	br_low_b0, (0xf872)
-.equ	br_low_b1, 0x6cc4
-.equ	br_low_b2, 0x29d0
-.equ	br_low_b3, 0x578d
-.equ	br_high_b0, 0x3693
-.equ	br_high_b1, 0xa9ea
-.equ	br_high_b2, 0xe1eb
-.equ	br_high_b3, 0x42f0
+#define	br_low_b0 (0xf872)
+#define	br_low_b1 0x6cc4
+#define	br_low_b2 0x29d0
+#define	br_low_b3 0x578d
+#define	br_high_b0 0x3693
+#define	br_high_b1 0xa9ea
+#define	br_high_b2 0xe1eb
+#define	br_high_b3 0x42f0
 
 ASM_DEF_RODATA
 	.align	4

--- a/crc/aarch64/crc64_ecma_refl_pmull.h
+++ b/crc/aarch64/crc64_ecma_refl_pmull.h
@@ -27,37 +27,37 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #########################################################################
 
-.equ	p4_low_b0, 0x41f3
-.equ	p4_low_b1, 0x9dd4
-.equ	p4_low_b2, 0xefbb
-.equ	p4_low_b3, 0x6ae3
-.equ	p4_high_b0, 0x2df4
-.equ	p4_high_b1, 0xa784
-.equ	p4_high_b2, 0x6054
-.equ	p4_high_b3, 0x081f
+#define	p4_low_b0 0x41f3
+#define	p4_low_b1 0x9dd4
+#define	p4_low_b2 0xefbb
+#define	p4_low_b3 0x6ae3
+#define	p4_high_b0 0x2df4
+#define	p4_high_b1 0xa784
+#define	p4_high_b2 0x6054
+#define	p4_high_b3 0x081f
 
-.equ	p1_low_b0, 0x3ae4
-.equ	p1_low_b1, 0xca39
-.equ	p1_low_b2, 0xd497
-.equ	p1_low_b3, 0xe05d
-.equ	p1_high_b0, 0x5f40
-.equ	p1_high_b1, 0xc787
-.equ	p1_high_b2, 0x95af
-.equ	p1_high_b3, 0xdabe
+#define	p1_low_b0 0x3ae4
+#define	p1_low_b1 0xca39
+#define	p1_low_b2 0xd497
+#define	p1_low_b3 0xe05d
+#define	p1_high_b0 0x5f40
+#define	p1_high_b1 0xc787
+#define	p1_high_b2 0x95af
+#define	p1_high_b3 0xdabe
 
-.equ	p0_low_b0, 0x5f40
-.equ	p0_low_b1, 0xc787
-.equ	p0_low_b2, 0x95af
-.equ	p0_low_b3, 0xdabe
+#define	p0_low_b0 0x5f40
+#define	p0_low_b1 0xc787
+#define	p0_low_b2 0x95af
+#define	p0_low_b3 0xdabe
 
-.equ	br_low_b0, 0x63d5
-.equ	br_low_b1, 0x1729
-.equ	br_low_b2, 0x466c
-.equ	br_low_b3, 0x9c3e
-.equ	br_high_b0, 0x1e85
-.equ	br_high_b1, 0xaf0e
-.equ	br_high_b2, 0xaf2b
-.equ	br_high_b3, 0x92d8
+#define	br_low_b0 0x63d5
+#define	br_low_b1 0x1729
+#define	br_low_b2 0x466c
+#define	br_low_b3 0x9c3e
+#define	br_high_b0 0x1e85
+#define	br_high_b1 0xaf0e
+#define	br_high_b2 0xaf2b
+#define	br_high_b3 0x92d8
 
 ASM_DEF_RODATA
 	.align	4

--- a/crc/aarch64/crc64_iso_norm_pmull.h
+++ b/crc/aarch64/crc64_iso_norm_pmull.h
@@ -27,41 +27,41 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #########################################################################
 
-.equ	p4_low_b0, (0x0101)
-.equ	p4_low_b1, 0x0100
-.equ	p4_low_b2, 0x0001
-.equ	p4_low_b3, 0x0000
-.equ	p4_high_b0, 0x1b1b
-.equ	p4_high_b1, 0x1b00
-.equ	p4_high_b2, 0x001b
-.equ	p4_high_b3, 0x0000
+#define	p4_low_b0 (0x0101)
+#define	p4_low_b1 0x0100
+#define	p4_low_b2 0x0001
+#define	p4_low_b3 0x0000
+#define	p4_high_b0 0x1b1b
+#define	p4_high_b1 0x1b00
+#define	p4_high_b2 0x001b
+#define	p4_high_b3 0x0000
 
-.equ	p1_low_b0, (0x0145)
-.equ	p1_low_b1, 0x0000
-.equ	p1_low_b2, 0x0000
-.equ	p1_low_b3, 0x0000
-.equ	p1_high_b0, 0x1db7
-.equ	p1_high_b1, 0x0000
-.equ	p1_high_b2, 0x0000
-.equ	p1_high_b3, 0x0000
+#define	p1_low_b0 (0x0145)
+#define	p1_low_b1 0x0000
+#define	p1_low_b2 0x0000
+#define	p1_low_b3 0x0000
+#define	p1_high_b0 0x1db7
+#define	p1_high_b1 0x0000
+#define	p1_high_b2 0x0000
+#define	p1_high_b3 0x0000
 
-.equ	p0_low_b0, (0x0145)
-.equ	p0_low_b1, 0x0000
-.equ	p0_low_b2, 0x0000
-.equ	p0_low_b3, 0x0000
-.equ	p0_high_b0, 0x0000
-.equ	p0_high_b1, 0x0000
-.equ	p0_high_b2, 0x0000
-.equ	p0_high_b3, 0x0000
+#define	p0_low_b0 (0x0145)
+#define	p0_low_b1 0x0000
+#define	p0_low_b2 0x0000
+#define	p0_low_b3 0x0000
+#define	p0_high_b0 0x0000
+#define	p0_high_b1 0x0000
+#define	p0_high_b2 0x0000
+#define	p0_high_b3 0x0000
 
-.equ	br_low_b0, (0x001b)
-.equ	br_low_b1, 0x0000
-.equ	br_low_b2, 0x0000
-.equ	br_low_b3, 0x0000
-.equ	br_high_b0, 0x001b
-.equ	br_high_b1, 0x0000
-.equ	br_high_b2, 0x0000
-.equ	br_high_b3, 0x0000
+#define	br_low_b0 (0x001b)
+#define	br_low_b1 0x0000
+#define	br_low_b2 0x0000
+#define	br_low_b3 0x0000
+#define	br_high_b0 0x001b
+#define	br_high_b1 0x0000
+#define	br_high_b2 0x0000
+#define	br_high_b3 0x0000
 
 ASM_DEF_RODATA
 	.align	4

--- a/crc/aarch64/crc64_iso_refl_pmull.h
+++ b/crc/aarch64/crc64_iso_refl_pmull.h
@@ -27,37 +27,37 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #########################################################################
 
-.equ	p4_low_b0, 0x0001
-.equ	p4_low_b1, 0xb000
-.equ	p4_low_b2, 0x01b1
-.equ	p4_low_b3, 0x01b0
-.equ	p4_high_b0, 0x0001
-.equ	p4_high_b1, 0x0000
-.equ	p4_high_b2, 0x0101
-.equ	p4_high_b3, 0xb100
+#define	p4_low_b0 0x0001
+#define	p4_low_b1 0xb000
+#define	p4_low_b2 0x01b1
+#define	p4_low_b3 0x01b0
+#define	p4_high_b0 0x0001
+#define	p4_high_b1 0x0000
+#define	p4_high_b2 0x0101
+#define	p4_high_b3 0xb100
 
-.equ	p1_low_b0, 0x0001
-.equ	p1_low_b1, 0x0000
-.equ	p1_low_b2, 0x0000
-.equ	p1_low_b3, 0x6b70
-.equ	p1_high_b0, 0x0001
-.equ	p1_high_b1, 0x0000
-.equ	p1_high_b2, 0x0000
-.equ	p1_high_b3, 0xf500
+#define	p1_low_b0 0x0001
+#define	p1_low_b1 0x0000
+#define	p1_low_b2 0x0000
+#define	p1_low_b3 0x6b70
+#define	p1_high_b0 0x0001
+#define	p1_high_b1 0x0000
+#define	p1_high_b2 0x0000
+#define	p1_high_b3 0xf500
 
-.equ	p0_low_b0, 0x0001
-.equ	p0_low_b1, 0x0000
-.equ	p0_low_b2, 0x0000
-.equ	p0_low_b3, 0xf500
+#define	p0_low_b0 0x0001
+#define	p0_low_b1 0x0000
+#define	p0_low_b2 0x0000
+#define	p0_low_b3 0xf500
 
-.equ	br_low_b0, 0x0001
-.equ	br_low_b1, 0x0000
-.equ	br_low_b2, 0x0000
-.equ	br_low_b3, 0xb000
-.equ	br_high_b0, 0x0001
-.equ	br_high_b1, 0x0000
-.equ	br_high_b2, 0x0000
-.equ	br_high_b3, 0xb000
+#define	br_low_b0 0x0001
+#define	br_low_b1 0x0000
+#define	br_low_b2 0x0000
+#define	br_low_b3 0xb000
+#define	br_high_b0 0x0001
+#define	br_high_b1 0x0000
+#define	br_high_b2 0x0000
+#define	br_high_b3 0xb000
 
 ASM_DEF_RODATA
 	.align	4

--- a/crc/aarch64/crc64_jones_norm_pmull.h
+++ b/crc/aarch64/crc64_jones_norm_pmull.h
@@ -27,41 +27,41 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #########################################################################
 
-.equ	p4_low_b0, (0xd25e)
-.equ	p4_low_b1, 0xca43
-.equ	p4_low_b2, 0x1e58
-.equ	p4_low_b3, 0x4e50
-.equ	p4_high_b0, 0xf643
-.equ	p4_high_b1, 0x8f27
-.equ	p4_high_b2, 0x6158
-.equ	p4_high_b3, 0x13c9
+#define	p4_low_b0 (0xd25e)
+#define	p4_low_b1 0xca43
+#define	p4_low_b2 0x1e58
+#define	p4_low_b3 0x4e50
+#define	p4_high_b0 0xf643
+#define	p4_high_b1 0x8f27
+#define	p4_high_b2 0x6158
+#define	p4_high_b3 0x13c9
 
-.equ	p1_low_b0, (0x7038)
-.equ	p1_low_b1, 0x5001
-.equ	p1_low_b2, 0xed27
-.equ	p1_low_b3, 0x4445
-.equ	p1_high_b0, 0xd736
-.equ	p1_high_b1, 0x7cfb
-.equ	p1_high_b2, 0x7415
-.equ	p1_high_b3, 0x698b
+#define	p1_low_b0 (0x7038)
+#define	p1_low_b1 0x5001
+#define	p1_low_b2 0xed27
+#define	p1_low_b3 0x4445
+#define	p1_high_b0 0xd736
+#define	p1_high_b1 0x7cfb
+#define	p1_high_b2 0x7415
+#define	p1_high_b3 0x698b
 
-.equ	p0_low_b0, (0x7038)
-.equ	p0_low_b1, 0x5001
-.equ	p0_low_b2, 0xed27
-.equ	p0_low_b3, 0x4445
-.equ	p0_high_b0, 0x0000
-.equ	p0_high_b1, 0x0000
-.equ	p0_high_b2, 0x0000
-.equ	p0_high_b3, 0x0000
+#define	p0_low_b0 (0x7038)
+#define	p0_low_b1 0x5001
+#define	p0_low_b2 0xed27
+#define	p0_low_b3 0x4445
+#define	p0_high_b0 0x0000
+#define	p0_high_b1 0x0000
+#define	p0_high_b2 0x0000
+#define	p0_high_b3 0x0000
 
-.equ	br_low_b0, (0x6cf8)
-.equ	br_low_b1, 0x98be
-.equ	br_low_b2, 0xeeb2
-.equ	br_low_b3, 0xddf3
-.equ	br_high_b0, 0x35a9
-.equ	br_high_b1, 0x94c9
-.equ	br_high_b2, 0xd235
-.equ	br_high_b3, 0xad93
+#define	br_low_b0 (0x6cf8)
+#define	br_low_b1 0x98be
+#define	br_low_b2 0xeeb2
+#define	br_low_b3 0xddf3
+#define	br_high_b0 0x35a9
+#define	br_high_b1 0x94c9
+#define	br_high_b2 0xd235
+#define	br_high_b3 0xad93
 
 ASM_DEF_RODATA
 	.align	4

--- a/crc/aarch64/crc64_jones_refl_pmull.h
+++ b/crc/aarch64/crc64_jones_refl_pmull.h
@@ -27,37 +27,37 @@
 #  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #########################################################################
 
-.equ	p4_low_b0, 0xb4fb
-.equ	p4_low_b1, 0x6d9a
-.equ	p4_low_b2, 0xefb1
-.equ	p4_low_b3, 0xaf86
-.equ	p4_high_b0, 0x14e4
-.equ	p4_high_b1, 0x34f0
-.equ	p4_high_b2, 0x84a6
-.equ	p4_high_b3, 0xf497
+#define	p4_low_b0 0xb4fb
+#define	p4_low_b1 0x6d9a
+#define	p4_low_b2 0xefb1
+#define	p4_low_b3 0xaf86
+#define	p4_high_b0 0x14e4
+#define	p4_high_b1 0x34f0
+#define	p4_high_b2 0x84a6
+#define	p4_high_b3 0xf497
 
-.equ	p1_low_b0, 0xa32c
-.equ	p1_low_b1, 0x505d
-.equ	p1_low_b2, 0xbe7d
-.equ	p1_low_b3, 0xd9d7
-.equ	p1_high_b0, 0x4444
-.equ	p1_high_b1, 0xc96f
-.equ	p1_high_b2, 0x0015
-.equ	p1_high_b3, 0x381d
+#define	p1_low_b0 0xa32c
+#define	p1_low_b1 0x505d
+#define	p1_low_b2 0xbe7d
+#define	p1_low_b3 0xd9d7
+#define	p1_high_b0 0x4444
+#define	p1_high_b1 0xc96f
+#define	p1_high_b2 0x0015
+#define	p1_high_b3 0x381d
 
-.equ	p0_low_b0, 0x4444
-.equ	p0_low_b1, 0xc96f
-.equ	p0_low_b2, 0x0015
-.equ	p0_low_b3, 0x381d
+#define	p0_low_b0 0x4444
+#define	p0_low_b1 0xc96f
+#define	p0_low_b2 0x0015
+#define	p0_low_b3 0x381d
 
-.equ	br_low_b0, 0x9f77
-.equ	br_low_b1, 0x9aef
-.equ	br_low_b2, 0xfa32
-.equ	br_low_b3, 0x3e6c
-.equ	br_high_b0, 0x936b
-.equ	br_high_b1, 0x5897
-.equ	br_high_b2, 0x2653
-.equ	br_high_b3, 0x2b59
+#define	br_low_b0 0x9f77
+#define	br_low_b1 0x9aef
+#define	br_low_b2 0xfa32
+#define	br_low_b3 0x3e6c
+#define	br_high_b0 0x936b
+#define	br_high_b1 0x5897
+#define	br_high_b2 0x2653
+#define	br_high_b3 0x2b59
 
 ASM_DEF_RODATA
 	.align	4

--- a/crc/aarch64/crc64_rocksoft_norm_pmull.h
+++ b/crc/aarch64/crc64_rocksoft_norm_pmull.h
@@ -28,47 +28,47 @@
 #########################################################################
 
 # rk15
-.equ	p4_low_b0, 0x488c
-.equ	p4_low_b1, 0x0488
-.equ	p4_low_b2, 0x4e6a
-.equ	p4_low_b3, 0xb441
+#define	p4_low_b0 0x488c
+#define	p4_low_b1 0x0488
+#define	p4_low_b2 0x4e6a
+#define	p4_low_b3 0xb441
 # rk16
-.equ	p4_high_b0, 0x9860
-.equ	p4_high_b1, 0x9b66
-.equ	p4_high_b2, 0x30f1
-.equ	p4_high_b3, 0xa42a
+#define	p4_high_b0 0x9860
+#define	p4_high_b1 0x9b66
+#define	p4_high_b2 0x30f1
+#define	p4_high_b3 0xa42a
 
 # rk1
-.equ	p1_low_b0, 0x2f08
-.equ	p1_low_b1, 0xf0dd
-.equ	p1_low_b2, 0xc948
-.equ	p1_low_b3, 0x6b08
+#define	p1_low_b0 0x2f08
+#define	p1_low_b1 0xf0dd
+#define	p1_low_b2 0xc948
+#define	p1_low_b3 0x6b08
 # rk2
-.equ	p1_high_b0, 0x76ae
-.equ	p1_high_b1, 0x7f04
-.equ	p1_high_b2, 0x8ba9
-.equ	p1_high_b3, 0x0857
+#define	p1_high_b0 0x76ae
+#define	p1_high_b1 0x7f04
+#define	p1_high_b2 0x8ba9
+#define	p1_high_b3 0x0857
 
 # rk1
-.equ	p0_low_b0, 0x2f08
-.equ	p0_low_b1, 0xf0dd
-.equ	p0_low_b2, 0xc948
-.equ	p0_low_b3, 0x6b08
-.equ	p0_high_b0, 0x0000
-.equ	p0_high_b1, 0x0000
-.equ	p0_high_b2, 0x0000
-.equ	p0_high_b3, 0x0000
+#define	p0_low_b0 0x2f08
+#define	p0_low_b1 0xf0dd
+#define	p0_low_b2 0xc948
+#define	p0_low_b3 0x6b08
+#define	p0_high_b0 0x0000
+#define	p0_high_b1 0x0000
+#define	p0_high_b2 0x0000
+#define	p0_high_b3 0x0000
 
 # rk7
-.equ	br_low_b0, 0x6fc8
-.equ	br_low_b1, 0x98be
-.equ	br_low_b2, 0xeeb2
-.equ	br_low_b3, 0xddf3
+#define	br_low_b0 0x6fc8
+#define	br_low_b1 0x98be
+#define	br_low_b2 0xeeb2
+#define	br_low_b3 0xddf3
 # rk8
-.equ	br_high_b0, 0x3659
-.equ	br_high_b1, 0x94c9
-.equ	br_high_b2, 0xd235
-.equ	br_high_b3, 0xad93
+#define	br_high_b0 0x3659
+#define	br_high_b1 0x94c9
+#define	br_high_b2 0xd235
+#define	br_high_b3 0xad93
 
 ASM_DEF_RODATA
 	.align	4

--- a/crc/aarch64/crc64_rocksoft_refl_pmull.h
+++ b/crc/aarch64/crc64_rocksoft_refl_pmull.h
@@ -28,43 +28,43 @@
 #########################################################################
 
 # rk16
-.equ	p4_low_b0, 0xa84a
-.equ	p4_low_b1, 0x1e18
-.equ	p4_low_b2, 0xcdb3
-.equ	p4_low_b3, 0x0c32
+#define	p4_low_b0 0xa84a
+#define	p4_low_b1 0x1e18
+#define	p4_low_b2 0xcdb3
+#define	p4_low_b3 0x0c32
 # rk15
-.equ	p4_high_b0, 0x045a
-.equ	p4_high_b1, 0xace5
-.equ	p4_high_b2, 0x2240
-.equ	p4_high_b3, 0x6224
+#define	p4_high_b0 0x045a
+#define	p4_high_b1 0xace5
+#define	p4_high_b2 0x2240
+#define	p4_high_b3 0x6224
 
 # rk2
-.equ	p1_low_b0, 0xd420
-.equ	p1_low_b1, 0x2ba3
-.equ	p1_low_b2, 0x41fd
-.equ	p1_low_b3, 0xeadc
+#define	p1_low_b0 0xd420
+#define	p1_low_b1 0x2ba3
+#define	p1_low_b2 0x41fd
+#define	p1_low_b3 0xeadc
 # rk1
-.equ	p1_high_b0, 0x21ac
-.equ	p1_high_b1, 0x2526
-.equ	p1_high_b2, 0x761e
-.equ	p1_high_b3, 0x21e9
+#define	p1_high_b0 0x21ac
+#define	p1_high_b1 0x2526
+#define	p1_high_b2 0x761e
+#define	p1_high_b3 0x21e9
 
 # rk1
-.equ	p0_low_b0, 0x21ac
-.equ	p0_low_b1, 0x2526
-.equ	p0_low_b2, 0x761e
-.equ	p0_low_b3, 0x21e9
+#define	p0_low_b0 0x21ac
+#define	p0_low_b1 0x2526
+#define	p0_low_b2 0x761e
+#define	p0_low_b3 0x21e9
 
 # rk7
-.equ	br_low_b0, 0x9f77
-.equ	br_low_b1, 0x9aef
-.equ	br_low_b2, 0xfa32
-.equ	br_low_b3, 0x27ec
+#define	br_low_b0 0x9f77
+#define	br_low_b1 0x9aef
+#define	br_low_b2 0xfa32
+#define	br_low_b3 0x27ec
 # rk8 + 1?
-.equ	br_high_b0, 0x936b
-.equ	br_high_b1, 0x5897
-.equ	br_high_b2, 0x2653
-.equ	br_high_b3, 0x34d9
+#define	br_high_b0 0x936b
+#define	br_high_b1 0x5897
+#define	br_high_b2 0x2653
+#define	br_high_b3 0x34d9
 
 ASM_DEF_RODATA
 	.align	4


### PR DESCRIPTION
Somewhere between Command Line Tools for Xcode 16.2 and 16.3, clang started complaining like

    <instantiation>:91:26: error: unexpected token in argument list
     movk x7, br_low_b2, lsl 32
                             ^
    crc/aarch64/crc32_ieee_norm_pmull.S:34:1: note: while in macro instantiation
    crc32_norm_func crc32_ieee_norm_pmull

It seems to do with some change to macro expansion; work around it by replacing .equ directives with #defines.

Fixes #352