### PR TITLE
igzip: Fix aarch64 registry width for bfinal

### DIFF
--- a/igzip/aarch64/igzip_decode_huffman_code_block_aarch64.S
+++ b/igzip/aarch64/igzip_decode_huffman_code_block_aarch64.S
@@ -292,7 +292,7 @@ declare Macros
 	declare_generic_reg	block_state,	8,w
 	declare_generic_reg	block_state_adr,9,x
 	declare_generic_reg	look_back_dist,	10,w
-	declare_generic_reg	bfinal,		22,x
+	declare_generic_reg	bfinal,		22,w
 
 	declare_generic_reg	next_out,	12,x
 	declare_generic_reg	avail_out,	13,w
@@ -607,8 +607,8 @@ next_lit_eq_256:
 				ISAL_BLOCK_INPUT_DONE : ISAL_BLOCK_NEW_HDR;
 	*/
 	mov	block_state, ISAL_BLOCK_INPUT_DONE
-	cmp	w_bfinal,0
-	csel	block_state, block_state, w_bfinal, ne
+	cmp	bfinal,0
+	csel	block_state, block_state, bfinal, ne
 	str	block_state, [block_state_adr]
 
 	b	block_state_loop


### PR DESCRIPTION
We only ever load 32 bits into it, and we only ever want to compare against 32 bits. There was no need to declare it as 64 bits.

Furthermore, there were cases where a 64 bit comparison around `isal_out_overflow_1` led us to erroneously set the block state to `ISAL_BLOCK_INPUT_DONE` when it should have been left at `ISAL_BLOCK_NEW_HDR`.

Fixes #316