### PR TITLE
Keep sub and jcc in sequence to enable macrofusion.

### DIFF
--- a/raid/pq_gen_avx2.asm
+++ b/raid/pq_gen_avx2.asm
@@ -135,7 +135,7 @@ func(pq_gen_avx2)
 	je	return_pass
 	test	len, (32-1)		;Check alignment of length
 	jnz	return_fail
-	mov	pos, 0
+	xor	DWORD(pos), DWORD(pos)
 	vmovdqa	xpoly, [poly]
 	vpxor	xzero, xzero, xzero
 	cmp	len, 96
@@ -146,7 +146,7 @@ len_aligned_32bytes:
 
 loop96:
 	mov	ptr, [arg2+vec*8] 	;Fetch last source pointer
-	mov	tmp, vec		;Set tmp to point back to last vector
+	lea	tmp, [vec-1]		;Set tmp to point back to last vector
 	XLDR	xs1, [ptr+pos]		;Preload last vector (source)
 	XLDR	xs2, [ptr+pos+32]	;Preload last vector (source)
 	XLDR	xs3, [ptr+pos+64]	;Preload last vector (source)
@@ -158,7 +158,6 @@ loop96:
 	vpxor	xq3, xq3, xq3		;q3 = 0
 
 next_vect:
-	sub	tmp, 1		  	;Inner loop for each source vector
 	mov 	ptr, [arg2+tmp*8] 	; get pointer to next vect
 	vpxor	xq1, xq1, xs1		; q1 ^= s1
 	vpxor	xq2, xq2, xs2		; q2 ^= s2
@@ -178,7 +177,8 @@ next_vect:
 	vpxor	xq1, xq1, xtmp1		; q1 = q1<<1 ^ poly_masked
 	vpxor	xq2, xq2, xtmp2		; q2 = q2<<1 ^ poly_masked
 	vpxor	xq3, xq3, xtmp3		; q3 = q3<<1 ^ poly_masked
-	jg	next_vect		; Loop for each vect except 0
+	sub	tmp, 1
+	jae	next_vect		; Loop for each vect except 0
 
 	mov	ptr, [arg2+8+vec*8]	;Get address of P parity vector
 	mov	tmp, [arg2+(2*8)+vec*8]	;Get address of Q parity vector
@@ -206,13 +206,12 @@ next_vect:
 
 loop32:
 	mov 	ptr, [arg2+vec*8] 	;Fetch last source pointer
-	mov	tmp, vec		;Set tmp to point back to last vector
+	lea	tmp, [vec-1]		;Set tmp to point back to last vector
 	XLDR	xs1, [ptr+pos]		;Preload last vector (source)
 	vpxor	xp1, xp1, xp1		;p = 0
 	vpxor	xq1, xq1, xq1		;q = 0
 
 next_vect32:
-	sub	tmp, 1		  	;Inner loop for each source vector
 	mov 	ptr, [arg2+tmp*8] 	; get pointer to next vect
 	vpxor	xq1, xq1, xs1		; q1 ^= s1
 	vpblendvb xtmp1, xzero, xpoly, xq1 ; xtmp1 = poly or 0x00
@@ -220,7 +219,8 @@ next_vect32:
 	vpaddb	xq1, xq1, xq1		; q = q<<1
 	vpxor	xq1, xq1, xtmp1		; q = q<<1 ^ poly_masked
 	XLDR	xs1, [ptr+pos]		; Get next vector (source data)
-	jg	next_vect32		; Loop for each vect except 0
+	sub	tmp, 1
+	jae	next_vect32		; Loop for each vect except 0
 
 	mov	ptr, [arg2+8+vec*8]	;Get address of P parity vector
 	mov	tmp, [arg2+(2*8)+vec*8]	;Get address of Q parity vector
@@ -234,7 +234,7 @@ next_vect32:
 
 
 return_pass:
-	mov	return, 0
+	xor	DWORD(return), DWORD(return)
 	FUNC_RESTORE
 	ret
 

--- a/raid/xor_gen_avx.asm
+++ b/raid/xor_gen_avx.asm
@@ -114,12 +114,11 @@ func(xor_gen_avx)
 
 len_aligned_128bytes:
 	sub	len, 128
-	mov	pos, 0
+	xor	DWORD(pos), DWORD(pos)
 
 loop128:
-	mov	tmp, vec		;Back to last vector
 	mov	tmp2, [arg2+vec*PS]	;Fetch last pointer in array
-	sub	tmp, 1			;Next vect
+	lea	tmp, [vec-1]		;Next vect
 	XLDR	ymm0, [tmp2+pos]	;Start with end of array in last vector
 	XLDR	ymm1, [tmp2+pos+32]	;Keep xor parity in xmm0-7
 	XLDR	ymm2, [tmp2+pos+(2*32)]
@@ -127,7 +126,6 @@ loop128:
 
 next_vect:
 	mov 	ptr, [arg2+tmp*PS]
-	sub	tmp, 1
 	XLDR	ymm4, [ptr+pos]		;Get next vector (source)
 	XLDR	ymm5, [ptr+pos+32]
 	XLDR	ymm6, [ptr+pos+(2*32)]
@@ -136,7 +134,8 @@ next_vect:
 	vxorpd	ymm1, ymm1, ymm5
 	vxorpd	ymm2, ymm2, ymm6
 	vxorpd	ymm3, ymm3, ymm7
-	jge	next_vect		;Loop for each source
+	sub	tmp, 1
+	jae	next_vect		;Loop for each source
 
 	mov	ptr, [arg2+PS+vec*PS]	;Address of parity vector
 	XSTR	[ptr+pos], ymm0		;Write parity xor vector
@@ -149,7 +148,7 @@ next_vect:
 
 return_pass:
 	FUNC_RESTORE
-	mov	return, 0
+	xor	DWORD(return), DWORD(return)
 	ret
 
 

--- a/raid/xor_gen_avx512.asm
+++ b/raid/xor_gen_avx512.asm
@@ -113,23 +113,22 @@ func(xor_gen_avx512)
 
 len_aligned_128bytes:
 	sub	len, 128
-	mov	pos, 0
+	xor	DWORD(pos), DWORD(pos)
 
 loop128:
-	mov	tmp, vec		;Back to last vector
 	mov	tmp2, [arg2+vec*PS]	;Fetch last pointer in array
-	sub	tmp, 1			;Next vect
+	lea	tmp, [vec-1]		;Next vect
 	XLDR	zmm0, [tmp2+pos]	;Start with end of array in last vector
 	XLDR	zmm1, [tmp2+pos+64]	;Keep xor parity in xmm0-7
 
 next_vect:
 	mov 	ptr, [arg2+tmp*PS]
-	sub	tmp, 1
 	XLDR	zmm4, [ptr+pos]		;Get next vector (source)
 	XLDR	zmm5, [ptr+pos+64]
 	vpxorq	zmm0, zmm0, zmm4	;Add to xor parity
 	vpxorq	zmm1, zmm1, zmm5
-	jge	next_vect		;Loop for each source
+	sub	tmp, 1
+	jae	next_vect		;Loop for each source
 
 	mov	ptr, [arg2+PS+vec*PS]	;Address of parity vector
 	XSTR	[ptr+pos], zmm0		;Write parity xor vector
@@ -140,7 +139,7 @@ next_vect:
 
 return_pass:
 	FUNC_RESTORE
-	mov	return, 0
+	xor	DWORD(return), DWORD(return)
 	ret
 
 


### PR DESCRIPTION
As we talked in the other pull request, this is the "lite" version. Only enabling macrofusion for loops and setting registers to zero in the right way.