### PR TITLE
ci: replace deprecated macOS-13 with macOS-15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-13  # x86_64
+          - macos-15-intel  # x86_64
           - macos-14  # arm64
         assembler:
           - nasm
@@ -51,7 +51,7 @@ jobs:
       - name: Build
         run: |
           ./autogen.sh
-          ./configure
+          ./configure --prefix ${HOME}/.local
           bash -c 'make -j $(nproc)'
       - name: Run tests
         run: bash tools/test_checks.sh


### PR DESCRIPTION
macOS-13 GitHub Action Runner image is now deprecated. Replace it with macOS-15 image instead.