### PR TITLE
build: maintain compatibility with non-vector devices for riscv64

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ aarch64:
 * Assembler: gas v2.24 or later.
 * Compiler: gcc v4.7 or later.
 
+RISC-V 64:
+* Portable base functions:
+	* Supported by most C compilers.
+* For RISC-V Vector (RVV) support:
+	* Assembler: gas v2.39 or later.
+	* Compiler: gcc v12.1 or later.
+
 other:
 * Compiler: Portable base functions are available that build with most C compilers.
 

--- a/configure.ac
+++ b/configure.ac
@@ -57,7 +57,7 @@ case "${CPU}" in
 
 	riscv64)
 
-		AC_MSG_CHECKING([checking RVV support])
+		AC_MSG_CHECKING([whether compiler supports RISC-V Vector Extension (RVV)])
 		AC_COMPILE_IFELSE(
 			[AC_LANG_PROGRAM([], [
 				__asm__ volatile(
@@ -70,10 +70,6 @@ case "${CPU}" in
 			[AC_DEFINE([HAVE_RVV], [0], [Disable RVV instructions])
 			AM_CONDITIONAL([HAVE_RVV], [false]) rvv=no]
 		)
-		if test "x$rvv" = "xyes"; then
-			CFLAGS+=" -march=rv64gcv"
-			CCASFLAGS+=" -march=rv64gcv"
-		fi
 		AC_MSG_RESULT([$rvv])
 		;;
 

--- a/erasure_code/riscv64/gf_2vect_dot_prod_rvv.S
+++ b/erasure_code/riscv64/gf_2vect_dot_prod_rvv.S
@@ -31,6 +31,7 @@
 .text
 .align 2
 
+.option arch, +v
 .global gf_2vect_dot_prod_rvv
 .type gf_2vect_dot_prod_rvv, @function
 

--- a/erasure_code/riscv64/gf_2vect_mad_rvv.S
+++ b/erasure_code/riscv64/gf_2vect_mad_rvv.S
@@ -31,6 +31,7 @@
 .text
 .align 2
 
+.option arch, +v
 .global gf_2vect_mad_rvv
 .type gf_2vect_mad_rvv, @function
 

--- a/erasure_code/riscv64/gf_3vect_dot_prod_rvv.S
+++ b/erasure_code/riscv64/gf_3vect_dot_prod_rvv.S
@@ -31,6 +31,7 @@
 .text
 .align 2
 
+.option arch, +v
 .global gf_3vect_dot_prod_rvv
 .type gf_3vect_dot_prod_rvv, @function
 

--- a/erasure_code/riscv64/gf_3vect_mad_rvv.S
+++ b/erasure_code/riscv64/gf_3vect_mad_rvv.S
@@ -31,6 +31,7 @@
 .text
 .align 2
 
+.option arch, +v
 .global gf_3vect_mad_rvv
 .type gf_3vect_mad_rvv, @function
 

--- a/erasure_code/riscv64/gf_4vect_dot_prod_rvv.S
+++ b/erasure_code/riscv64/gf_4vect_dot_prod_rvv.S
@@ -31,6 +31,7 @@
 .text
 .align 2
 
+.option arch, +v
 .global gf_4vect_dot_prod_rvv
 .type gf_4vect_dot_prod_rvv, @function
 

--- a/erasure_code/riscv64/gf_4vect_mad_rvv.S
+++ b/erasure_code/riscv64/gf_4vect_mad_rvv.S
@@ -31,6 +31,7 @@
 .text
 .align 2
 
+.option arch, +v
 .global gf_4vect_mad_rvv
 .type gf_4vect_mad_rvv, @function
 

--- a/erasure_code/riscv64/gf_5vect_dot_prod_rvv.S
+++ b/erasure_code/riscv64/gf_5vect_dot_prod_rvv.S
@@ -31,6 +31,7 @@
 .text
 .align 2
 
+.option arch, +v
 .global gf_5vect_dot_prod_rvv
 .type gf_5vect_dot_prod_rvv, @function
 

--- a/erasure_code/riscv64/gf_5vect_mad_rvv.S
+++ b/erasure_code/riscv64/gf_5vect_mad_rvv.S
@@ -31,6 +31,7 @@
 .text
 .align 2
 
+.option arch, +v
 .global gf_5vect_mad_rvv
 .type gf_5vect_mad_rvv, @function
 

--- a/erasure_code/riscv64/gf_6vect_dot_prod_rvv.S
+++ b/erasure_code/riscv64/gf_6vect_dot_prod_rvv.S
@@ -31,6 +31,7 @@
 .text
 .align 2
 
+.option arch, +v
 .global gf_6vect_dot_prod_rvv
 .type gf_6vect_dot_prod_rvv, @function
 

--- a/erasure_code/riscv64/gf_6vect_mad_rvv.S
+++ b/erasure_code/riscv64/gf_6vect_mad_rvv.S
@@ -31,6 +31,7 @@
 .text
 .align 2
 
+.option arch, +v
 .global gf_6vect_mad_rvv
 .type gf_6vect_mad_rvv, @function
 

--- a/erasure_code/riscv64/gf_7vect_dot_prod_rvv.S
+++ b/erasure_code/riscv64/gf_7vect_dot_prod_rvv.S
@@ -31,6 +31,7 @@
 .text
 .align 2
 
+.option arch, +v
 .global gf_7vect_dot_prod_rvv
 .type gf_7vect_dot_prod_rvv, @function
 

--- a/erasure_code/riscv64/gf_vect_dot_prod_rvv.S
+++ b/erasure_code/riscv64/gf_vect_dot_prod_rvv.S
@@ -53,6 +53,7 @@
 #   v6: z_gft1_hi (high 8 bits of GF table)
 
 #if HAVE_RVV
+.option arch, +v
 .global gf_vect_dot_prod_rvv
 .type gf_vect_dot_prod_rvv, @function
 

--- a/erasure_code/riscv64/gf_vect_mad_rvv.S
+++ b/erasure_code/riscv64/gf_vect_mad_rvv.S
@@ -31,6 +31,7 @@
 .text
 .align 2
 
+.option arch, +v
 .global gf_vect_mad_rvv
 .type gf_vect_mad_rvv, @function
 

--- a/erasure_code/riscv64/gf_vect_mul_rvv.S
+++ b/erasure_code/riscv64/gf_vect_mul_rvv.S
@@ -31,6 +31,7 @@
 .text
 .align 2
 
+.option arch, +v
 .global gf_vect_mul_rvv
 .type gf_vect_mul_rvv, @function
 


### PR DESCRIPTION
When the compiler supports vector extensions, the -march option always enables vector by default. This causes illegal instruction errors on RISC-V CPU without vector support. 
It is sufficient to enable the vector extension by adding the `.option arch, +v` into all rvv assembly source files, it will be handle correctly by gas.

cc @sunyuechi 