### PR TITLE
erasure_code/riscv: fix segment_fault when vlen > 128

### DIFF
--- a/erasure_code/riscv64/gf_2vect_dot_prod_rvv.S
+++ b/erasure_code/riscv64/gf_2vect_dot_prod_rvv.S
@@ -55,6 +55,7 @@
 #define x_tbl2 t4
 #define x_dest1 t5
 #define x_dest2 a7
+#define x_remain s0
 
 /* vectors */
 #define v_src v1
@@ -75,7 +76,10 @@ gf_2vect_dot_prod_rvv:
     li t6, 16
     blt x_len, t6, .return_fail
 
-    vsetvli a5, x0, e8, m1, ta, ma  /* Set vector length to maximum */
+    /* save callee-saved registers */
+    addi sp, sp, -8
+    sd s0, 0(sp)
+
     li x_pos, 0
     slli x_vec, x_vec, 3
 
@@ -85,6 +89,9 @@ gf_2vect_dot_prod_rvv:
 /* Loop 1: x_len, vector length */
 .Llooprvv_vl:
     bge x_pos, x_len, .return_pass
+
+    sub x_remain, x_len, x_pos
+    vsetvli a5, x_remain, e8, m1, ta, ma
 
     li x_vec_i, 0              /* clear x_vec_i */
     ld x_ptr, 0(x_src)         /* x_ptr: src base addr. */
@@ -107,6 +114,7 @@ gf_2vect_dot_prod_rvv:
     vand.vi v_src_lo, v_src, 0x0F
     vsrl.vi v_src_hi, v_src, 4
 
+    vsetivli zero, 16, e8, m1, ta, ma
     /* gf_tbl addr: (x_tbl + dest_idx * x_vec * 32) + src_vec_idx * 32 */
     /* load gf_table's */
     vle8.v v_gft1_lo, (x_tbl1)
@@ -118,6 +126,7 @@ gf_2vect_dot_prod_rvv:
     addi x_tbl2, x_tbl2, 16
     vle8.v v_gft2_hi, (x_tbl2)
     addi x_tbl2, x_tbl2, 16
+    vsetvli zero, a5, e8, m1, ta, ma
 
     /* calc for next */
     addi x_vec_i, x_vec_i, 8   /* move x_vec_i to next */
@@ -153,6 +162,8 @@ gf_2vect_dot_prod_rvv:
 /* end of Loop 1 */
 
 .return_pass:
+    ld s0, 0(sp)
+    addi sp, sp, 8
     li a0, 0
     ret
 

--- a/erasure_code/riscv64/gf_2vect_mad_rvv.S
+++ b/erasure_code/riscv64/gf_2vect_mad_rvv.S
@@ -53,6 +53,7 @@
 #define x_pos t0
 #define x_dest2 t1
 #define x_dest1 t2
+#define x_remain t5
 
 /* vectors */
 #define v_src v1
@@ -72,7 +73,7 @@ gf_2vect_mad_rvv:
     li t3, 16
     blt x_len, t3, .return_fail
 
-    vsetvli t4, x0, e8, m1, ta, ma
+    vsetivli zero, 16, e8, m1, ta, ma
 
     /* load table 1 */
     slli t3, x_vec_i, 5
@@ -99,6 +100,9 @@ gf_2vect_mad_rvv:
     j .return_pass
 
 .Lloop_body:
+    sub x_remain, x_len, x_pos
+    vsetvli t4, x_remain, e8, m1, ta, ma
+
     /* load src data */
     add t3, x_src, x_pos
     vle8.v v_src, (t3)

--- a/erasure_code/riscv64/gf_3vect_dot_prod_rvv.S
+++ b/erasure_code/riscv64/gf_3vect_dot_prod_rvv.S
@@ -57,6 +57,7 @@
 #define x_dest2 s1
 #define x_dest3 a5
 #define t_offset a6
+#define x_remain s2
 
 /* vectors */
 #define v_src v1
@@ -80,11 +81,11 @@ gf_3vect_dot_prod_rvv:
     blt x_len, t0, .return_fail
 
     /* save callee-saved registers */
-    addi sp, sp, -16
+    addi sp, sp, -24
     sd s0, 0(sp)
     sd s1, 8(sp)
+    sd s2, 16(sp)
 
-    vsetvli a7, x0, e8, m1, ta, ma  /* Set vector length to maximum */
     li x_pos, 0
     slli x_vec, x_vec, 3
 
@@ -96,6 +97,9 @@ gf_3vect_dot_prod_rvv:
 .Lloop_rvv_vl:
     /* check if we have processed all elements */
     bge x_pos, x_len, .return_pass
+
+    sub x_remain, x_len, x_pos
+    vsetvli a7, x_remain, e8, m1, ta, ma
 
     /* Clear destination vectors */
     vmv.v.i v_dest1, 0
@@ -121,6 +125,8 @@ gf_3vect_dot_prod_rvv:
     vand.vi v_src_lo, v_src, 0x0F
     vsrl.vi v_src_hi, v_src, 4
 
+    vsetivli zero, 16, e8, m1, ta, ma
+
     /* Load gf_table's */
     vle8.v v_gft1_lo, (x_tbl1)
     addi x_tbl1, x_tbl1, 16
@@ -130,17 +136,18 @@ gf_3vect_dot_prod_rvv:
     addi x_tbl2, x_tbl2, 16
     vle8.v v_gft2_hi, (x_tbl2)
     addi x_tbl2, x_tbl2, 16
+    vle8.v v_gft3_lo, (x_tbl3)
+    addi x_tbl3, x_tbl3, 16
+    vle8.v v_gft3_hi, (x_tbl3)
+    addi x_tbl3, x_tbl3, 16
+
+    vsetvli zero, a7, e8, m1, ta, ma
 
     /* Move to next source vector */
     addi x_vec_i, x_vec_i, 8
     add t0, x_src, x_vec_i
     ld x_ptr, 0(t0)
 
-    /* Load next gf_table's */
-    vle8.v v_gft3_lo, (x_tbl3)
-    addi x_tbl3, x_tbl3, 16
-    vle8.v v_gft3_hi, (x_tbl3)
-    addi x_tbl3, x_tbl3, 16
 
     /* dest 1 */
     vrgather.vv v26, v_gft1_lo, v_src_lo
@@ -177,7 +184,8 @@ gf_3vect_dot_prod_rvv:
 .return_pass:
     ld s0, 0(sp)
     ld s1, 8(sp)
-    addi sp, sp, 16
+    ld s2, 16(sp)
+    addi sp, sp, 24
 
     li a0, 0
     ret

--- a/erasure_code/riscv64/gf_3vect_mad_rvv.S
+++ b/erasure_code/riscv64/gf_3vect_mad_rvv.S
@@ -54,6 +54,7 @@
 #define x_dest1 t1
 #define x_dest2 t2
 #define x_dest3 t3
+#define x_remain a6
 
 /* vectors */
 #define v_src v1
@@ -76,7 +77,7 @@ gf_3vect_mad_rvv:
     li t4, 16
     blt x_len, t4, .return_fail
 
-    vsetvli t5, x0, e8, m1, ta, ma
+    vsetivli zero, 16, e8, m1, ta, ma
 
     /* Load table 1 */
     slli t4, x_vec_i, 5
@@ -112,6 +113,9 @@ gf_3vect_mad_rvv:
     j .return_pass
 
 .Lloop_body:
+    sub x_remain, x_len, x_pos
+    vsetvli t5, x_remain, e8, m1, ta, ma
+
     /* Load source data */
     add t6, x_src, x_pos
     vle8.v v_src, (t6)

--- a/erasure_code/riscv64/gf_4vect_dot_prod_rvv.S
+++ b/erasure_code/riscv64/gf_4vect_dot_prod_rvv.S
@@ -60,6 +60,7 @@
 #define x_dest3 s2
 #define x_dest4 s3
 #define t_offset a5
+#define x_remain s4
 
 /* vectors */
 #define v_src v1
@@ -86,13 +87,13 @@ gf_4vect_dot_prod_rvv:
     blt x_len, t0, .return_fail
 
 /* save callee-saved registers */
-    addi sp, sp, -32
+    addi sp, sp, -40
     sd s0, 0(sp)
     sd s1, 8(sp)
     sd s2, 16(sp)
     sd s3, 24(sp)
+    sd s4, 32(sp)
 
-    vsetvli t0, x0, e8, m1, ta, ma
     li x_pos, 0
 
     slli x_vec, x_vec, 3
@@ -107,6 +108,9 @@ gf_4vect_dot_prod_rvv:
 .Lloop_rvv_vl:
     /* check if we have processed all elements */
     bge x_pos, x_len, .return_pass
+
+    sub x_remain, x_len, x_pos
+    vsetvli t0, x_remain, e8, m1, ta, ma
 
     /* Clear destination vectors */
     vmv.v.i v_dest1, 0
@@ -136,6 +140,7 @@ gf_4vect_dot_prod_rvv:
     vand.vi v_src_lo, v_src, 0x0F
     vsrl.vi v_src_hi, v_src, 4
 
+    vsetivli zero, 16, e8, m1, ta, ma
     /* Load gf_table's */
     vle8.v v_gft1_lo, (x_tbl1)
     addi x_tbl1, x_tbl1, 16
@@ -146,21 +151,22 @@ gf_4vect_dot_prod_rvv:
     vle8.v v_gft2_hi, (x_tbl2)
     addi x_tbl2, x_tbl2, 16
 
-    /* Move to next source vector */
-    addi x_vec_i, x_vec_i, 8
-    add a6, x_src, x_vec_i
-    ld x_ptr, 0(a6)
-
     /* Load next gf_table's */
     vle8.v v_gft3_lo, (x_tbl3)
     addi x_tbl3, x_tbl3, 16
     vle8.v v_gft3_hi, (x_tbl3)
     addi x_tbl3, x_tbl3, 16
-
     vle8.v v_gft4_lo, (x_tbl4)
     addi x_tbl4, x_tbl4, 16
     vle8.v v_gft4_hi, (x_tbl4)
     addi x_tbl4, x_tbl4, 16
+
+    vsetvli zero, t0, e8, m1, ta, ma
+
+    /* Move to next source vector */
+    addi x_vec_i, x_vec_i, 8
+    add a6, x_src, x_vec_i
+    ld x_ptr, 0(a6)
 
     /* dest 1 */
     vrgather.vv v26, v_gft1_lo, v_src_lo
@@ -208,7 +214,8 @@ gf_4vect_dot_prod_rvv:
     ld s1, 8(sp)
     ld s2, 16(sp)
     ld s3, 24(sp)
-    addi sp, sp, 32
+    ld s4, 32(sp)
+    addi sp, sp, 40
     li a0, 0
     ret
 

--- a/erasure_code/riscv64/gf_4vect_mad_rvv.S
+++ b/erasure_code/riscv64/gf_4vect_mad_rvv.S
@@ -55,6 +55,7 @@
 #define x_dest2	t2
 #define x_dest3	t3
 #define x_dest4	t4
+#define x_remain a6
 
 /* vectors */
 #define v_src v1
@@ -80,7 +81,7 @@ gf_4vect_mad_rvv:
 	li	t5, 16
 	blt	x_len, t5, .return_fail
 
-	vsetvli	t6, x0, e8, m1, ta, ma
+	vsetivli zero, 16, e8, m1, ta, ma
 
 	/* load table 1 */
 	slli	t5, x_vec_i, 5
@@ -122,6 +123,9 @@ gf_4vect_mad_rvv:
 	blt	x_pos, x_len, .Lloop_body
 	j	.return_pass
 .Lloop_body:
+    sub x_remain, x_len, x_pos
+    vsetvli t6, x_remain, e8, m1, ta, ma
+
 	/* load src data */
         add t5, x_src, x_pos
 	vle8.v	v_src, (t5)

--- a/erasure_code/riscv64/gf_5vect_dot_prod_rvv.S
+++ b/erasure_code/riscv64/gf_5vect_dot_prod_rvv.S
@@ -61,6 +61,7 @@
 #define x_dest3 s3
 #define x_dest4 s4
 #define x_dest5 s5
+#define x_remain s6
 
 /* vectors */
 #define v_src v1
@@ -88,15 +89,15 @@ gf_5vect_dot_prod_rvv:
     blt x_len, t0, .return_fail
 
     /* save s0-s4 */
-    addi sp, sp, -48
+    addi sp, sp, -56
     sd s0, 0(sp)
     sd s1, 8(sp)
     sd s2, 16(sp)
     sd s3, 24(sp)
     sd s4, 32(sp)
     sd s5, 40(sp)
+    sd s6, 48(sp)
 
-    vsetvli a5, x0, e8, m1, ta, ma
     /* Initialize position */
     li x_pos, 0
 
@@ -110,6 +111,9 @@ gf_5vect_dot_prod_rvv:
 /* Loop 1: x_len, vector length */
 .Llooprvv_vl:
     bge x_pos, x_len, .return_pass
+
+    sub x_remain, x_len, x_pos
+    vsetvli a5, x_remain, e8, m1, ta, ma
 
     /* Clear destination vectors */
     vmv.v.i v_dest1, 0
@@ -140,6 +144,7 @@ gf_5vect_dot_prod_rvv:
     vand.vi v_src_lo, v_src, 0x0F
     vsrl.vi v_src_hi, v_src, 4
 
+    vsetivli zero, 16, e8, m1, ta, ma
     /* Load gf_table's */
     vle8.v v_gft1_lo, (x_tbl1)
     addi x_tbl1, x_tbl1, 16
@@ -150,6 +155,7 @@ gf_5vect_dot_prod_rvv:
     addi x_tbl2, x_tbl2, 16
     vle8.v v_gft2_hi, (x_tbl2)
     addi x_tbl2, x_tbl2, 16
+    vsetvli zero, a5, e8, m1, ta, ma
 
     /* Move to next source vector */
     addi x_vec_i, x_vec_i, 1
@@ -160,6 +166,7 @@ gf_5vect_dot_prod_rvv:
     vxor.vv v_dest1, v_dest1, v26
     vxor.vv v_dest1, v_dest1, v27
 
+    vsetivli zero, 16, e8, m1, ta, ma
     /* Load more gf_table's */
     vle8.v v_gft3_lo, (x_tbl3)
     addi x_tbl3, x_tbl3, 16
@@ -170,6 +177,14 @@ gf_5vect_dot_prod_rvv:
     addi x_tbl4, x_tbl4, 16
     vle8.v v_gft4_hi, (x_tbl4)
     addi x_tbl4, x_tbl4, 16
+
+    /* Load more gf_table's */
+    vle8.v v_gft5_lo, (x_tbl5)
+    addi x_tbl5, x_tbl5, 16
+    vle8.v v_gft5_hi, (x_tbl5)
+    addi x_tbl5, x_tbl5, 16
+
+    vsetvli zero, a5, e8, m1, ta, ma
 
     /* dest 2 */
     vrgather.vv v26, v_gft2_lo, v_src_lo
@@ -182,12 +197,6 @@ gf_5vect_dot_prod_rvv:
     vrgather.vv v27, v_gft3_hi, v_src_hi
     vxor.vv v_dest3, v_dest3, v26
     vxor.vv v_dest3, v_dest3, v27
-
-    /* Load more gf_table's */
-    vle8.v v_gft5_lo, (x_tbl5)
-    addi x_tbl5, x_tbl5, 16
-    vle8.v v_gft5_hi, (x_tbl5)
-    addi x_tbl5, x_tbl5, 16
 
     /* dest 4 */
     vrgather.vv v26, v_gft4_lo, v_src_lo
@@ -229,7 +238,8 @@ gf_5vect_dot_prod_rvv:
     ld s3, 24(sp)
     ld s4, 32(sp)
     ld s5, 40(sp)
-    addi sp, sp, 48
+    ld s6, 48(sp)
+    addi sp, sp, 56
 
     li a0, 0
     ret

--- a/erasure_code/riscv64/gf_5vect_mad_rvv.S
+++ b/erasure_code/riscv64/gf_5vect_mad_rvv.S
@@ -56,6 +56,7 @@
 #define x_dest3 t3
 #define x_dest4 t4
 #define x_dest5 t5
+#define x_remain s0
 
 /* vectors */
 #define v_src v1
@@ -84,7 +85,11 @@ gf_5vect_mad_rvv:
     li t6, 16
     blt x_len, t6, .return_fail
 
-    vsetvli a7, x0, e8, m1, ta, ma
+    /* save callee-saved registers */
+    addi sp, sp, -8
+    sd s0, 0(sp)
+
+    vsetivli zero, 16, e8, m1, ta, ma
 
     /* Load table 1 */
     slli a6, x_vec_i, 5
@@ -136,6 +141,9 @@ gf_5vect_mad_rvv:
     j .return_pass
 
 .Lloop_body:
+    sub x_remain, x_len, x_pos
+    vsetvli a7, x_remain, e8, m1, ta, ma
+
     /* Load source data */
     add t6, x_src, x_pos
     vle8.v v_src, (t6)
@@ -205,6 +213,10 @@ gf_5vect_mad_rvv:
     j .Llooprvv_vl
 
 .return_pass:
+    /* restore callee-saved registers */
+    ld s0, 0(sp)
+    addi sp, sp, 8
+
     li w_ret, 0
     ret
 

--- a/erasure_code/riscv64/gf_6vect_dot_prod_rvv.S
+++ b/erasure_code/riscv64/gf_6vect_dot_prod_rvv.S
@@ -62,6 +62,7 @@
 #define x_dest4 s5  /* dest pointer 4  t12  -- x28 */
 #define x_dest5 s6  /* dest pointer 5 */
 #define x_dest6 s7  /* dest pointer 6 */
+#define x_remain s8
 
 /* vector registers */
 #define v_src v1     /* source vector */
@@ -92,7 +93,7 @@ gf_6vect_dot_prod_rvv:
     blt x_len, t0, .return_fail
 
     /* save callee-saved registers */
-    addi sp, sp, -64
+    addi sp, sp, -72
     sd s0, 0(sp)
     sd s1, 8(sp)
     sd s2, 16(sp)
@@ -101,9 +102,9 @@ gf_6vect_dot_prod_rvv:
     sd s5, 40(sp)
     sd s6, 48(sp)
     sd s7, 56(sp)
+    sd s8, 64(sp)
 
     li t0, 0x0F
-    vsetvli a5, x0, e8, m1, ta, ma
 
     /* initialize position */
     li x_pos, 0
@@ -121,6 +122,9 @@ gf_6vect_dot_prod_rvv:
 .Llooprvv_vl:
     /* check if we have processed all elements */
     bge x_pos, x_len, .return_pass
+
+    sub x_remain, x_len, x_pos
+    vsetvli a5, x_remain, e8, m1, ta, ma
 
     /* initialize vector loop counter */
     li x_vec_i, 0
@@ -155,6 +159,7 @@ gf_6vect_dot_prod_rvv:
     vand.vi v_src_lo, v_src, 0x0F
     vsrl.vi v_src_hi, v_src, 4
 
+    vsetivli zero, 16, e8, m1, ta, ma
     /* load gf_table's */
     vle8.v v_gft1_lo, (x_tbl1)
     addi x_tbl1, x_tbl1, 16
@@ -190,6 +195,7 @@ gf_6vect_dot_prod_rvv:
     addi x_tbl6, x_tbl6, 16
     vle8.v v_gft6_hi, (x_tbl6)
     addi x_tbl6, x_tbl6, 16
+    vsetvli zero, a5, e8, m1, ta, ma
 
     /* dest 1 */
     vrgather.vv v26, v_gft1_lo, v_src_lo
@@ -259,7 +265,8 @@ gf_6vect_dot_prod_rvv:
     ld s5, 40(sp)
     ld s6, 48(sp)
     ld s7, 56(sp)
-    addi sp, sp, 64
+    ld s8, 64(sp)
+    addi sp, sp, 72
 
     li a0, 0
     ret

--- a/erasure_code/riscv64/gf_6vect_mad_rvv.S
+++ b/erasure_code/riscv64/gf_6vect_mad_rvv.S
@@ -57,6 +57,7 @@
 #define x_dest4 t4
 #define x_dest5 t5
 #define x_dest6 t6
+#define x_remain s0
 
 /* vectors */
 #define v_src v1
@@ -90,9 +91,10 @@ gf_6vect_mad_rvv:
 
    /* save callee-saved registers */
     addi sp, sp, -16
-    sd s8, 0(sp)
+    sd s0, 0(sp)
+    sd s8, 8(sp)
 
-    vsetvli a6, x0, e8, m1, ta, ma
+    vsetivli zero, 16, e8, m1, ta, ma
 
     /* Load table 1 */
     slli s8, x_vec_i, 5
@@ -151,6 +153,9 @@ gf_6vect_mad_rvv:
     j .return_pass
 
 .Lloop_body:
+    sub x_remain, x_len, x_pos
+    vsetvli a6, x_remain, e8, m1, ta, ma
+
     /* Load source data */
     add a7, x_src, x_pos
     vle8.v v_src, (a7)
@@ -229,7 +234,8 @@ gf_6vect_mad_rvv:
     j .Llooprvv_vl
 
 .return_pass:
-    ld s8, 0(sp)
+    ld s0, 0(sp)
+    ld s8, 8(sp)
     addi sp, sp, 16
 
     li w_ret, 0

--- a/erasure_code/riscv64/gf_7vect_dot_prod_rvv.S
+++ b/erasure_code/riscv64/gf_7vect_dot_prod_rvv.S
@@ -66,6 +66,7 @@
 #define x_dest5 s5
 #define x_dest6 s6
 #define x_dest7 s7
+#define x_remain s9
 
 /* vectors */
 #define v_src v1
@@ -101,7 +102,7 @@ gf_7vect_dot_prod_rvv:
     blt x_len, t0, .return_fail
 
     /* save callee-saved registers */
-    addi sp, sp, -80
+    addi sp, sp, -88
     sd s0, 0(sp)
     sd s1, 8(sp)
     sd s2, 16(sp)
@@ -111,8 +112,8 @@ gf_7vect_dot_prod_rvv:
     sd s6, 48(sp)
     sd s7, 56(sp)
     sd s8, 64(sp)
+    sd s9, 72(sp)
 
-    vsetvli t0, x0, e8, m1, ta, ma
     /* initialize position */
     li x_pos, 0
 
@@ -129,6 +130,9 @@ gf_7vect_dot_prod_rvv:
 .Llooprvv_vl:
     /* check if we have processed all elements */
     bge x_pos, x_len, .return_pass
+
+    sub x_remain, x_len, x_pos
+    vsetvli t0, x_remain, e8, m1, ta, ma
 
     /* initialize vector loop counter */
     li x_vec_i, 0
@@ -169,6 +173,7 @@ gf_7vect_dot_prod_rvv:
     vand.vi v_src_lo, v_src, 0x0F
     vsrl.vi v_src_hi, v_src, 4
 
+    vsetivli zero, 16, e8, m1, ta, ma
     /* load gf_table's */
     vle8.v v_gft1_lo, (x_tbl1)
     addi x_tbl1, x_tbl1, 16
@@ -204,6 +209,7 @@ gf_7vect_dot_prod_rvv:
     addi x_tbl7, x_tbl7, 16
     vle8.v v_gft7_hi, (x_tbl7)
     addi x_tbl7, x_tbl7, 16
+    vsetvli zero, t0, e8, m1, ta, ma
 
     /* dest 1 */
     vrgather.vv v26, v_gft1_lo, v_src_lo
@@ -283,7 +289,8 @@ gf_7vect_dot_prod_rvv:
     ld s6, 48(sp)
     ld s7, 56(sp)
     ld s8, 64(sp)
-    addi sp, sp, 80
+    ld s9, 72(sp)
+    addi sp, sp, 88
 
     /* Return success */
     li a0, 0

--- a/erasure_code/riscv64/gf_vect_dot_prod_rvv.S
+++ b/erasure_code/riscv64/gf_vect_dot_prod_rvv.S
@@ -62,7 +62,6 @@ gf_vect_dot_prod_rvv:
     li t4, 16
     blt a0, t4, .return_fail
 
-    vsetvli t5, zero, e8, m1, ta, ma  # Set vector length to maximum
     # Initialize pos = 0
     li t2, 0
 
@@ -72,6 +71,9 @@ gf_vect_dot_prod_rvv:
 .Llooprvv_vl:
     # Check if pos >= len
     bge t2, a0, .return_pass
+
+    sub a5, a0, t2
+    vsetvli t5, a5, e8, m1, ta, ma
 
     # Clear z_dest
     vmv.v.i v4, 0
@@ -94,11 +96,13 @@ gf_vect_dot_prod_rvv:
     # Increment vec_i
     addi t0, t0, 8
 
+    vsetivli zero, 16, e8, m1, ta, ma
     # Load GF table (low and high)
     vle8.v v5, (t3)           # Load low 8 bits of GF table
     addi t3, t3, 16           # Move to next GF table entry
     vle8.v v6, (t3)           # Load high 8 bits of GF table
     addi t3, t3, 16           # Move to next GF table entry
+    vsetvli zero, t5, e8, m1, ta, ma
 
     # Split src into low and high 4 bits
     vand.vi v2, v1, 0x0F      # z_src_lo = z_src & z_mask0f
@@ -120,7 +124,7 @@ gf_vect_dot_prod_rvv:
     add a4, a4, t5           # Move dest pointer to next position
 
     # Increment pos
-    add t2, t2, t5           # pos += 16 (vector length)
+    add t2, t2, t5           # pos += vlenB (vector length)
 
     j .Llooprvv_vl
 

--- a/erasure_code/riscv64/gf_vect_mad_rvv.S
+++ b/erasure_code/riscv64/gf_vect_mad_rvv.S
@@ -50,6 +50,7 @@
 
 /* local variables */
 #define x_pos t0
+#define x_remain t3
 
 /* vectors */
 #define v_src v1
@@ -66,7 +67,7 @@ gf_vect_mad_rvv:
     li t1, 16
     blt x_len, t1, .return_fail
 
-    vsetvli t2, x0, e8, m1, ta, ma
+    vsetivli zero, 16, e8, m1, ta, ma
 
     /* x_tbl += x_vec_i * 2^5 */
     slli t1, x_vec_i, 5
@@ -80,6 +81,9 @@ gf_vect_mad_rvv:
     li x_pos, 0
 
 .Lloop_rvv_vl:
+    sub x_remain, x_len, x_pos
+    vsetvli t2, x_remain, e8, m1, ta, ma
+
     /* load src data */
     vle8.v v_src, (x_src)
 

--- a/erasure_code/riscv64/gf_vect_mul_rvv.S
+++ b/erasure_code/riscv64/gf_vect_mul_rvv.S
@@ -52,6 +52,7 @@
 #define x_tbl a1
 #define x_src a2
 #define x_dest a3
+#define x_remain a4
 
 /* Vector registers */
 #define v_src v1
@@ -68,7 +69,7 @@ gf_vect_mul_rvv:
     andi x_tmp, x_len, 0x1F
     bnez x_tmp, .return_fail
 
-    vsetvli t6, x0, e8, m1, ta, ma
+    vsetivli zero, 16, e8, m1, ta, ma
 
     /* Load pre-calculated constants into v_gft1_lo and v_gft1_hi */
     vle8.v v_gft1_lo, (x_tbl)
@@ -79,6 +80,9 @@ gf_vect_mul_rvv:
     li x_pos, 0
 
 .Llooprvv_vl:
+    sub x_remain, x_len, x_pos
+    vsetvli t6, x_remain, e8, m1, ta, ma
+
     /* Load source data into v_src */
     add x_ptr, x_src, x_pos
     vle8.v v_src, (x_ptr)


### PR DESCRIPTION
Current erasure_code will throw a segmentation fault when vector length is greater than 128, use this path to fix it.