### PR TITLE
crc: avoid VPTERNLOGQ on Hygon in crc32_iscsi_by16_10

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -132,6 +132,18 @@ case "${CPU}" in
 
 esac
 
+# Special configuration for Hygon
+AC_MSG_CHECKING([if Hygon CPU])
+if grep -q "HygonGenuine" /proc/cpuinfo 2>/dev/null ; then
+  is_hygon=yes
+else
+  is_hygon=no
+fi
+AC_MSG_RESULT([$is_hygon])
+AS_IF([test "x$is_hygon" = "xyes"], [
+  AC_DEFINE_UNQUOTED([NO_VPTERNLOGQ], [1], [Disable VPTERNLOGQ instruction.])
+])
+
 # Options
 AC_ARG_ENABLE([debug],
         AS_HELP_STRING([--enable-debug], [enable debug messages @<:@default=disabled@:>@]),

--- a/crc/crc32_iscsi_by16_10.asm
+++ b/crc/crc32_iscsi_by16_10.asm
@@ -80,6 +80,17 @@ section .text
 	%xdefine	arg1_low32 edx
 %endif
 
+%ifdef NO_VPTERNLOGQ
+%macro vpternlogq 4
+%if %4 == 0x96
+	vpxorq		%1, %1, %2
+	vpxorq		%1, %1, %3
+%else
+	vpternlogq	%1, %2, %3, %4	; fallback
+%endif
+%endmacro
+%endif
+
 align 64
 mk_global FUNCTION_NAME, function
 FUNCTION_NAME:


### PR DESCRIPTION
Disable VPTERNLOGQ instruction in `crc32_iscsi_by16_10` on Hygon CPU.

Using VPTERNLOGQ in this case leads to an uarch bottleneck on current Hygon CPU and does not perform ideally. So we would like to use VPXORQ instead. This will leads to ~53.5% speedup according to `make perf` :

| | original bandwidth (MB/s) | opt | speedup|
| -- | -- | -- | -- |
| Hygon | 49643.52 | 76193.92 | 53.5% |

Modification only takes effect on Hygon CPU, based on the result of cpuinfo check.
