### PR TITLE
Make programs optional

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -43,7 +43,9 @@ include crc/Makefile.am
 include igzip/Makefile.am
 include tests/fuzz/Makefile.am
 include examples/ec/Makefile.am
+if HAVE_PROGRAMS
 include programs/Makefile.am
+endif
 include mem/Makefile.am
 include misc/Makefile.am
 

--- a/configure.ac
+++ b/configure.ac
@@ -152,6 +152,11 @@ AS_IF([test "x$enable_debug" = "xyes"], [
         AC_DEFINE(ENABLE_DEBUG, [1], [Debug messages.])
 ])
 
+AC_ARG_ENABLE([programs],
+	AS_HELP_STRING([--enable-programs], [build test programs @<:@default=disabled@:>@]),
+	[], [enable_programs=no])
+AM_CONDITIONAL([HAVE_PROGRAMS], [test "x$enable_programs" != "xno"])
+
 # If this build is for x86, look for nasm
 if test x"$is_x86" = x"yes"; then
   AC_MSG_CHECKING([whether Intel CET is enabled])


### PR DESCRIPTION
When building as a library the programs are optional, and especially the 'igzip' binary insists on building the man page with 'help2man'. But installing an additional application just to build a man page for a program which is never used in the first place is a bit of an overkill.
So add a new feature 'programs' to enable building of programs if requested, and disable them otherwise.