### PR TITLE
feat(crc): optimize crc32_iscsi with SVE2 fusion and improved PMULL path

### DIFF
--- a/crc/aarch64/Makefile.am
+++ b/crc/aarch64/Makefile.am
@@ -50,6 +50,9 @@ lsrc_aarch64 += \
 	crc/aarch64/crc32_iscsi_refl_pmull.S \
 	crc/aarch64/crc32_gzip_refl_pmull.S \
 	crc/aarch64/crc32_iscsi_3crc_fold.S \
+	crc/aarch64/crc32_iscsi_p8c10.S \
+	crc/aarch64/crc32_iscsi_p8c10_clmul_const.S \
+	crc/aarch64/crc32_iscsi_x6.S \
 	crc/aarch64/crc32_gzip_refl_3crc_fold.S \
 	crc/aarch64/crc32_iscsi_crc_ext.S \
 	crc/aarch64/crc32_gzip_refl_crc_ext.S \

--- a/crc/aarch64/crc32_iscsi_p8c10.S
+++ b/crc/aarch64/crc32_iscsi_p8c10.S
@@ -1,0 +1,711 @@
+/**************************************************************
+  Copyright (c) 2026 Huawei Technologies Co., Ltd.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Huawei Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+.arch armv8.5-a+crc+sha3+sve2-aes
+.file "crc32_iscsi_p8c10.S"
+.text
+.align 4
+.global crc32_iscsi_fusion_p8_c10_asm
+.type   crc32_iscsi_fusion_p8_c10_asm, %function
+
+.set stack_size,        160
+.set blk_size,          416   //the block_size corresponding to p8c10 is 8*32 + 10*16 = 416B
+.set pmull_blk_size,    256
+.set crc_parallels,     10
+.set max_blk_num,       1260
+
+.macro  push_stack
+        stp     d8,  d9,  [sp, -stack_size]!
+		stp     d10, d11, [sp, 16]
+		stp     d12, d13, [sp, 32]
+		stp     d14, d15, [sp, 48]
+		stp     x19, x20, [sp, 64]
+		stp     x21, x22, [sp, 80]
+		stp     x23, x24, [sp, 96]
+		stp     x25, x26, [sp, 112]
+		stp     x27, x28, [sp, 128]
+		stp     x29, x30, [sp, 144]
+.endm
+
+.macro  pop_stack
+		ldp     d10, d11, [sp, 16]
+		ldp     d12, d13, [sp, 32]
+		ldp     d14, d15, [sp, 48]
+		ldp     x19, x20, [sp, 64]
+		ldp     x21, x22, [sp, 80]
+		ldp     x23, x24, [sp, 96]
+		ldp     x25, x26, [sp, 112]
+		ldp     x27, x28, [sp, 128]
+		ldp     x29, x30, [sp, 144]
+		ldp     d8,  d9,  [sp], stack_size
+.endm
+
+    buffer0 .req    x0
+    len     .req    w1
+    len_x   .req    x1
+    crc0    .req    w2
+    crc0_x  .req    x2
+    blk_num .req    w3
+    klen    .req    w19
+    klen_x  .req    x19
+    bufferN .req    x4
+    tmp_x   .req    x30
+    tmp_w   .req    w30
+    const_addr  .req    x30
+    shifts_offset   .req    w19
+    shifts_offset_x .req    x19
+
+    crc1    .req    w5
+    crc1_x  .req    x5
+    crc2    .req    w6
+    crc2_x  .req    x6
+    crc3    .req    w7
+    crc3_x  .req    x7
+    crc4    .req    w8
+    crc5    .req    w9
+    crc6    .req    w10
+    crc7    .req    w11
+    crc8    .req    w26
+    crc9    .req    w27
+
+    buffer1 .req    x12
+    buffer2 .req    x13
+    buffer3 .req    x14
+    buffer4 .req    x15
+    buffer5 .req    x16
+    buffer6 .req    x17
+    buffer7 .req    x18
+    buffer8 .req    x28
+    buffer9 .req    x29
+
+    data0   .req    x20
+    data0_w .req    w20
+    data1   .req    x21
+    data2   .req    x22
+    data3   .req    x23
+    data4   .req    x24
+    data5   .req    x25
+
+    xnmodp_stack    .req    x12
+    xnmodp_n        .req    x13
+    xnmodp_n_w      .req    w13
+    xnmodp_tmp      .req    x14
+    xnmodp_tmp_w    .req    w14
+    xnmodp_acc      .req    w15
+    xnmodp_acc_x    .req    x15
+    xnmodp_y        .req    x16
+    xnmodp_vec_q    .req    q30
+    xnmodp_vec_v    .req    v30
+    xnmodp_vec_d    .req    d30
+
+    k_96B   .req    x12
+    k_64B   .req    x13
+    k_32B   .req    x14
+
+    mul_r0  .req    x15
+    mul_r1  .req    x16
+    mul_r2  .req    x17
+
+.macro xnmodp_func  n_reg, result_s
+    mov xnmodp_stack, #-2
+.Lxnmodp_compress_large_index_\@:
+    cmp \n_reg,#191
+    b.ls .Lxnmodp_compress_large_index_end_\@
+
+    and xnmodp_tmp, \n_reg, #1
+    lsl xnmodp_stack, xnmodp_stack, #1
+    add xnmodp_stack, xnmodp_stack, xnmodp_tmp
+
+    lsr \n_reg, \n_reg, #1
+    sub \n_reg, \n_reg, #16
+    b   .Lxnmodp_compress_large_index_\@
+.Lxnmodp_compress_large_index_end_\@:
+    mvn xnmodp_stack, xnmodp_stack
+
+    and xnmodp_tmp, \n_reg, #31
+    mov xnmodp_acc, #0x80000000
+    lsr xnmodp_acc, xnmodp_acc, xnmodp_tmp_w
+
+    // n >>= 5
+    lsr \n_reg, \n_reg, #5
+
+.Lxnmodp_32bit_fold_\@:
+    cbz \n_reg, .Lxnmodp_32bit_fold_end_\@
+    crc32cw xnmodp_acc, xnmodp_acc, wzr
+    sub \n_reg, \n_reg, #1
+    b   .Lxnmodp_32bit_fold_\@
+
+.Lxnmodp_32bit_fold_end_\@:
+.Lxnmodp_left_fold_\@:
+    and     \n_reg, xnmodp_stack, #1            //low = stack & 1
+    lsr     xnmodp_stack, xnmodp_stack, #1      //stack >>=1
+    //  Check the loop condition (whether the original stack is 0)
+    cbz     xnmodp_stack, .Lxnmodp_left_fold_end_\@
+.Lxnmodp_left_fold_body_\@:
+    fmov    xnmodp_vec_d, xnmodp_acc_x          //vec_d = acc (As a 64-bit value)
+    pmull   xnmodp_vec_v.8h, xnmodp_vec_v.8b, xnmodp_vec_v.8b  //v0 = x * x(Polynomial multiplication)
+    fmov    xnmodp_y, xnmodp_vec_d              //x0 = y (Extract the lower 64 bits)
+    lsl     xnmodp_y, xnmodp_y, \n_reg          //x0 = y << low
+    crc32cx xnmodp_acc, wzr, xnmodp_y           //w22 = crc32cd(0, y << low)
+
+    b .Lxnmodp_left_fold_\@
+.Lxnmodp_left_fold_end_\@:
+    // return acc
+    fmov    \result_s, xnmodp_acc
+.endm
+
+crc32_iscsi_fusion_p8_c10_asm:
+    push_stack
+    cmp len, blk_size       //if len < blk_size
+    blt .Ltail_less_blk_size
+    movz tmp_w, blk_size
+    udiv blk_num, len, tmp_w        //blk_num = len / blk_size
+    lsl  klen, blk_num, #4          //klen = blk_num * 16
+    mov  tmp_x, crc_parallels
+    mul  tmp_x, klen_x, tmp_x       //offset = blk_num * 16 * 10
+    add  bufferN, buffer0, tmp_x    //bufferN = buffer0 + offset, buffer0 is the first address of the input buffer
+
+    ptrue   p0.b, all
+    ld1d    z0.d, p0/z, [bufferN] 
+    ld1d    z1.d, p0/z, [bufferN, #1, mul vl]  //vl: current sve vector length(bytes)
+    ld1d    z2.d, p0/z, [bufferN, #2, mul vl]
+    ld1d    z3.d, p0/z, [bufferN, #3, mul vl]
+
+    ld1d    z4.d, p0/z, [bufferN, #4, mul vl]
+    ld1d    z5.d, p0/z, [bufferN, #5, mul vl]
+    ld1d    z6.d, p0/z, [bufferN, #6, mul vl]
+    ld1d    z7.d, p0/z, [bufferN, #7, mul vl]
+
+    // the start address of each subsequent scalar channel is the address of the previous bufferx + klen
+    add     buffer1, buffer0, klen_x
+    add     buffer2, buffer1, klen_x
+    add     buffer3, buffer2, klen_x
+    add     buffer4, buffer3, klen_x
+    add     buffer5, buffer4, klen_x
+    add     buffer6, buffer5, klen_x
+    add     buffer7, buffer6, klen_x
+    add     buffer8, buffer7, klen_x
+    add     buffer9, buffer8, klen_x
+
+    adrp    const_addr, .Lp2048_symbol
+    add     const_addr, const_addr, :lo12:.Lp2048_symbol
+    ld1d    z16.d,  p0/z,  [const_addr]     // acceleration constant for the vector procesing part
+
+    add bufferN, bufferN, pmull_blk_size
+    sub len, len, blk_size
+
+    mov crc1, #0
+    mov crc2, #0
+    mov crc3, #0
+    mov crc4, #0
+    mov crc5, #0
+    mov crc6, #0
+    mov crc7, #0
+    mov crc8, #0
+    mov crc9, #0
+
+.Lloop_main:
+    cmp len, blk_size
+    b.lt .Lvector_processing_part_fold
+
+    ldp data0, data1, [buffer0]
+    ldp data2, data3, [buffer1]
+    ldp data4, data5, [buffer2]
+
+    crc32cx crc0, crc0, data0  //assembly instruction corresponding to the __crc32cd() intrinsic func is crc32cx
+    crc32cx crc1, crc1, data2
+    crc32cx crc2, crc2, data4
+
+    crc32cx crc0, crc0, data1
+    crc32cx crc1, crc1, data3
+    crc32cx crc2, crc2, data5
+
+    ldp data0, data1, [buffer3]
+    ldp data2, data3, [buffer4]
+    ldp data4, data5, [buffer5]
+
+    crc32cx crc3, crc3, data0
+    crc32cx crc4, crc4, data2
+    crc32cx crc5, crc5, data4
+
+    crc32cx crc3, crc3, data1
+    crc32cx crc4, crc4, data3
+    crc32cx crc5, crc5, data5
+
+    /*
+     *[Key: scalar-vector hybridization] Interleave crc32cx with pmullt/pmullb instructions,
+     *and insert as many scalar calculations as possible between slower vector calculations.
+     */
+    pmullt  z17.q, z0.d, z16.d
+    pmullb  z0.q,  z0.d, z16.d
+    pmullt  z18.q, z1.d, z16.d
+    pmullb  z1.q,  z1.d, z16.d
+    pmullt  z19.q, z2.d, z16.d
+    pmullb  z2.q,  z2.d, z16.d
+    pmullt  z20.q, z3.d, z16.d
+    pmullb  z3.q,  z3.d, z16.d
+
+    ldp data0, data1, [buffer6]
+    ldp data2, data3, [buffer7]
+    ldp data4, data5, [buffer8]
+
+    crc32cx crc6, crc6, data0
+    crc32cx crc7, crc7, data2
+    crc32cx crc8, crc8, data4
+    crc32cx crc6, crc6, data1
+    crc32cx crc7, crc7, data3
+    crc32cx crc8, crc8, data5
+
+    ldp data0, data1, [buffer9]
+    crc32cx crc9, crc9, data0
+    crc32cx crc9, crc9, data1
+
+    pmullt  z21.q, z4.d, z16.d
+    pmullb  z4.q,  z4.d, z16.d
+    pmullt  z22.q, z5.d, z16.d
+    pmullb  z5.q,  z5.d, z16.d
+    pmullt  z23.q, z6.d, z16.d
+    pmullb  z6.q,  z6.d, z16.d
+    pmullt  z24.q, z7.d, z16.d
+    pmullb  z7.q,  z7.d, z16.d
+
+    ld1d    z8.d, p0/z, [bufferN] 
+    ld1d    z9.d, p0/z, [bufferN, #1, mul VL]  
+    ld1d    z10.d, p0/z, [bufferN, #2, mul VL]
+    ld1d    z11.d, p0/z, [bufferN, #3, mul VL]
+    ld1d    z12.d, p0/z, [bufferN, #4, mul VL]
+    ld1d    z13.d, p0/z, [bufferN, #5, mul VL]
+    ld1d    z14.d, p0/z, [bufferN, #6, mul VL]
+    ld1d    z15.d, p0/z, [bufferN, #7, mul VL]
+
+    add     bufferN, bufferN, pmull_blk_size
+
+    add     buffer0, buffer0, #16
+    add     buffer1, buffer1, #16
+    add     buffer2, buffer2, #16
+    add     buffer3, buffer3, #16
+    add     buffer4, buffer4, #16
+    add     buffer5, buffer5, #16
+    add     buffer6, buffer6, #16
+    add     buffer7, buffer7, #16
+    add     buffer8, buffer8, #16
+    add     buffer9, buffer9, #16
+
+    sub     len, len, blk_size
+
+    eor3    z0.d, z0.d, z17.d, z8.d
+    eor3    z1.d, z1.d, z18.d, z9.d
+    eor3    z2.d, z2.d, z19.d, z10.d
+    eor3    z3.d, z3.d, z20.d, z11.d
+
+    eor3    z4.d, z4.d, z21.d, z12.d
+    eor3    z5.d, z5.d, z22.d, z13.d
+    eor3    z6.d, z6.d, z23.d, z14.d
+    eor3    z7.d, z7.d, z24.d, z15.d
+
+    b .Lloop_main
+.Lvector_processing_part_fold:
+    adrp    const_addr, .Lp1024
+    add     const_addr, const_addr, :lo12:.Lp1024
+    ld1d    z16.d, p0/z, [const_addr]   //x0 = svld1_u64(pg, p4)
+
+    adrp    const_addr, .Lp512
+    add     const_addr, const_addr, :lo12:.Lp512
+    ld1d    z17.d, p0/z, [const_addr]   //x00 = svld1_u64(pg, p3)
+
+    adrp    const_addr, .Lp256
+    add     const_addr, const_addr, :lo12:.Lp256
+    ld1d    z18.d, p0/z, [const_addr]   //x000 = svld1_u64(pg, p2)
+    
+    //Group 1: x1(z0) treatment
+    pmullt z20.q, z0.d, z16.d
+    pmullb z0.q,  z0.d, z16.d
+    eor3   z0.d, z0.d, z20.d, z4.d
+
+    //Group 2: x2(z1) treatment
+    pmullt z21.q, z1.d, z16.d
+    pmullb z1.q,  z1.d, z16.d
+    eor3   z1.d, z1.d, z21.d, z5.d
+
+    //Group 3: x3(z2) treatment
+    pmullt z22.q, z2.d, z16.d
+    pmullb z2.q,  z2.d, z16.d
+    eor3   z2.d, z2.d, z22.d, z6.d
+
+    //Group 4: x4(z3) treatment
+    pmullt z23.q, z3.d, z16.d
+    pmullb z3.q,  z3.d, z16.d
+    eor3   z3.d, z3.d, z23.d, z7.d
+
+    //Group 5: x1(z0)  and x00(z17) treatments
+    pmullt z24.q, z0.d, z17.d
+    pmullb z0.q,  z0.d, z17.d
+    eor3   z0.d, z0.d, z24.d, z2.d
+
+    //Group 6: x2(z1) and x00(z17) treatments
+    pmullt z25.q, z1.d, z17.d
+    pmullb z1.q,  z1.d, z17.d
+    eor3   z1.d, z1.d, z25.d, z3.d
+
+    //Group 7: x1(z0) and x000(z18) treatments
+    pmullt z26.q, z0.d, z18.d
+    pmullb z0.q,  z0.d, z18.d
+    eor3   z0.d, z0.d, z26.d, z1.d
+
+    // extract_sve256_to_neon
+    sub     sp, sp, #32
+    st1d    {z0.d}, p0, [sp]
+    ldr     q0, [sp]
+    ldr     q1, [sp, #16]
+    add     sp, sp, #32
+
+    //crc32_fold_256b_to_128b
+    adrp    const_addr, .Lp128
+    ldr     q3, [const_addr, :lo12:.Lp128]
+
+    pmull2  v4.1q, v3.2d, v0.2d
+    pmull   v5.1q, v3.1d, v0.1d
+    eor3    v0.16b, v1.16b, v4.16b, v5.16b
+
+    //crc32c final
+    ldp data0, data1, [buffer0]
+    ldp data2, data3, [buffer1]
+    ldp data4, data5, [buffer2]
+
+    crc32cx crc0, crc0, data0
+    crc32cx crc1, crc1, data2
+    crc32cx crc2, crc2, data4
+    crc32cx crc0, crc0, data1
+    crc32cx crc1, crc1, data3
+    crc32cx crc2, crc2, data5
+
+    ldp data0, data1, [buffer3]
+    ldp data2, data3, [buffer4]
+    ldp data4, data5, [buffer5]
+
+    crc32cx crc3, crc3, data0
+    crc32cx crc4, crc4, data2
+    crc32cx crc5, crc5, data4
+    crc32cx crc3, crc3, data1
+    crc32cx crc4, crc4, data3
+    crc32cx crc5, crc5, data5
+
+    ldp data0, data1, [buffer6]
+    ldp data2, data3, [buffer7]
+    ldp data4, data5, [buffer8]
+
+    crc32cx crc6, crc6, data0
+    crc32cx crc7, crc7, data2
+    crc32cx crc8, crc8, data4
+    crc32cx crc6, crc6, data1
+    crc32cx crc7, crc7, data3
+    crc32cx crc8, crc8, data5
+
+    ldp data0, data1, [buffer9]
+    crc32cx crc9, crc9, data0
+    crc32cx crc9, crc9, data1
+
+    cmp blk_num, max_blk_num
+    bgt .Lxnmodp_cal
+    adrp    const_addr, :got:crc32_iscsi_p8c10_clmul_const //acceleration constant for the scalar processing part
+    ldr     const_addr, [const_addr, #:got_lo12:crc32_iscsi_p8c10_clmul_const]
+    mov     shifts_offset, #40
+    mul     shifts_offset, shifts_offset, blk_num
+    add     const_addr, const_addr, shifts_offset_x
+
+    ldp     s10, s12, [const_addr, #0]
+    ldp     s14, s16, [const_addr, #8]
+    ldp     s18, s20, [const_addr, #16]
+    ldp     s22, s24, [const_addr, #24]
+    ldp     s26, s28, [const_addr, #32]
+
+.Lscalar_processing_part_fold:
+    fmov    s11, crc0
+    pmull   v2.1q, v10.1d, v11.1d
+
+    fmov    s13, crc1
+    pmull   v3.1q, v12.1d, v13.1d
+
+    fmov    s15, crc2
+    pmull   v4.1q, v14.1d, v15.1d
+
+    fmov    s17, crc3
+    pmull   v5.1q, v16.1d, v17.1d
+
+    fmov    s19, crc4
+    pmull   v6.1q, v18.1d, v19.1d
+
+    fmov    s21, crc5
+    pmull   v7.1q, v20.1d, v21.1d
+
+    fmov    s23, crc6
+    pmull   v8.1q, v22.1d, v23.1d
+
+    fmov    s25, crc7
+    pmull   v9.1q, v24.1d, v25.1d
+
+    fmov    s27, crc8
+    pmull   v10.1q, v26.1d, v27.1d
+
+    fmov    s29, crc9
+    pmull   v11.1q, v28.1d, v29.1d
+
+    eor3    v2.16b, v2.16b, v3.16b, v4.16b
+    eor3    v5.16b, v5.16b, v6.16b, v7.16b
+    eor3    v8.16b, v8.16b, v9.16b, v10.16b
+    eor3    v2.16b, v2.16b, v5.16b, v8.16b
+    eor     v2.16b, v2.16b, v11.16b
+
+    //Reduce
+    fmov    data0, d2
+    fmov    data1, d0
+    crc32cx crc0, wzr, data1
+    mov     data2, v0.d[1]
+    eor     data0, data0, data2
+    crc32cx crc0, crc0, data0
+
+    mov     buffer0, bufferN
+.Ltail_less_blk_size:
+    cmp     len, #0
+    beq     .Ldone
+    movz    k_96B, #0xce53, lsl #0
+    movk    k_96B, #0x0715, lsl #16
+    fmov    d3, k_96B
+
+    movz    k_64B, #0xddf8, lsl #0
+    movk    k_64B, #0x9e4a, lsl #16
+    fmov    d4, k_64B
+
+    movz    k_32B, #0xc28e, lsl #0
+    movk    k_32B, #0xba4f, lsl #16
+    fmov    d5, k_32B
+.L_tail_main_loop:
+    cmp     len,#128
+    b.lt    .L_tail_32
+    mov     crc1, #0
+    mov     crc2, #0
+    mov     crc3, #0
+
+    ldr     data0, [buffer0, #0]
+    ldr     data1, [buffer0, #32]
+    ldr     data2, [buffer0, #64]
+    ldr     data3, [buffer0, #96]
+
+    crc32cx crc0, crc0, data0
+    crc32cx crc1, crc1, data1
+    crc32cx crc2, crc2, data2
+    crc32cx crc3, crc3, data3
+
+    ldr     data0, [buffer0, #8]
+    ldr     data1, [buffer0, #40]
+    ldr     data2, [buffer0, #72]
+    ldr     data3, [buffer0,#104]
+
+    crc32cx crc0, crc0, data0
+    crc32cx crc1, crc1, data1
+    crc32cx crc2, crc2, data2
+    crc32cx crc3, crc3, data3
+
+    ldr     data0, [buffer0, #16]
+    ldr     data1, [buffer0, #48]
+    ldr     data2, [buffer0, #80]
+    ldr     data3, [buffer0,#112]
+
+    crc32cx crc0, crc0, data0
+    crc32cx crc1, crc1, data1
+    crc32cx crc2, crc2, data2
+    crc32cx crc3, crc3, data3
+
+    ldr     data0, [buffer0, #24]
+    ldr     data1, [buffer0, #56]
+    ldr     data2, [buffer0, #88]
+    ldr     data3, [buffer0,#120]
+
+    crc32cx crc0, crc0, data0
+    crc32cx crc1, crc1, data1
+    crc32cx crc2, crc2, data2
+    crc32cx crc3, crc3, data3
+
+    fmov    d6, crc0_x
+    fmov    d7, crc1_x
+    fmov    d8, crc2_x
+
+    pmull   v6.1q, v6.1d, v3.1d
+    pmull   v7.1q, v7.1d, v4.1d
+    pmull   v8.1q, v8.1d, v5.1d
+
+    fmov    mul_r0, d6
+    fmov    mul_r1, d7
+    fmov    mul_r2, d8
+
+    crc32cx crc0, wzr, mul_r0
+    crc32cx crc1, wzr, mul_r1
+    crc32cx crc2, wzr, mul_r2
+
+    eor     crc0, crc0, crc1
+    eor     crc0, crc0, crc2
+    eor     crc0, crc0, crc3
+
+    add     buffer0, buffer0,#128
+    sub     len, len,#128
+    b   .L_tail_main_loop
+.L_tail_32:
+    cmp len, #32
+    b.lt    .L_tail_8
+
+    add     buffer1, buffer0, #16
+    ldp     data0, data1, [buffer0]
+    ldp     data2, data3, [buffer1]
+
+    crc32cx crc0, crc0, data0
+    crc32cx crc0, crc0, data1
+    crc32cx crc0, crc0, data2
+    crc32cx crc0, crc0, data3
+
+    add     buffer0, buffer0, #32
+    sub     len, len, #32
+    b .L_tail_32
+
+.L_tail_8:
+    cmp len, #8
+    b.lt    .L_tail_4
+
+    ldr     data0, [buffer0], #8
+    crc32cx crc0, crc0, data0
+    sub     len, len, #8
+    b .L_tail_8
+
+.L_tail_4:
+    tbz     len, #2, .L_tail_2
+    ldr     data0_w, [buffer0], #4
+    crc32cw crc0, crc0, data0_w
+
+.L_tail_2:
+    tbz      len, #1, .L_tail_1
+    ldrh     data0_w, [buffer0], #2
+    crc32ch  crc0, crc0, data0_w
+
+.L_tail_1:
+    tbz      len, #0, .Ldone
+    ldrb     data0_w, [buffer0]
+    crc32cb  crc0, crc0, data0_w
+
+.Ldone:
+    mov w0, crc0
+    pop_stack
+    ret
+
+.Lxnmodp_cal:
+    mov tmp_x, -33
+
+    mov xnmodp_n_w, 3200
+    smaddl x0, blk_num, xnmodp_n_w, tmp_x
+    xnmodp_func x0, s10
+
+    mov xnmodp_n_w, 3072
+    smaddl x0, blk_num, xnmodp_n_w, tmp_x
+    xnmodp_func x0, s12
+
+    mov xnmodp_n_w, 2944
+    smaddl x0, blk_num, xnmodp_n_w, tmp_x
+    xnmodp_func x0, s14
+
+    mov xnmodp_n_w, 2816
+    smaddl x0, blk_num, xnmodp_n_w, tmp_x
+    xnmodp_func x0, s16
+
+    mov xnmodp_n_w, 2688
+    smaddl x0, blk_num, xnmodp_n_w, tmp_x
+    xnmodp_func x0, s18
+
+    mov xnmodp_n_w, 2560
+    smaddl x0, blk_num, xnmodp_n_w, tmp_x
+    xnmodp_func x0, s20
+
+    mov xnmodp_n_w, 2432
+    smaddl x0, blk_num, xnmodp_n_w, tmp_x
+    xnmodp_func x0, s22
+
+    mov xnmodp_n_w, 2304
+    smaddl x0, blk_num, xnmodp_n_w, tmp_x
+    xnmodp_func x0, s24
+
+    mov xnmodp_n_w, 2176
+    smaddl x0, blk_num, xnmodp_n_w, tmp_x
+    xnmodp_func x0, s26
+
+    mov xnmodp_n_w, 2048
+    smaddl x0, blk_num, xnmodp_n_w, tmp_x
+    xnmodp_func x0, s28
+
+    b .Lscalar_processing_part_fold
+    .size   crc32_iscsi_fusion_p8_c10_asm, .-crc32_iscsi_fusion_p8_c10_asm
+
+    .section    .rodata
+    .align      4
+    .set        .Lp2048_symbol,. + 0
+    .type       .Lp2048, %object
+    .size       .Lp2048, 32
+.Lp2048:
+	.word 0xdcb17aa4  // x^2079 mod P_crc32c(x) = 0xdcb17aa4
+    .word 0x00000000
+    .word 0xb9e02b86  // x^2015 mod P_crc32c(x) = 0xb9e02b86
+    .word 0x00000000
+    .word 0xdcb17aa4
+    .word 0x00000000
+    .word 0xb9e02b86
+    .word 0x00000000
+
+    .type   .Lp1024, %object
+    .size   .Lp1024, 32
+.Lp1024:
+    .word 0x6992cea2, 0x00000000, 0x0d3b6092, 0x00000000  // x^1055 mod P_crc32c(x) = 0x6992cea2
+    .word 0x6992cea2, 0x00000000, 0x0d3b6092, 0x00000000  // x^991 mod P_crc32c(x) = 0x0d3b6092
+
+    .type   .Lp512, %object
+    .size   .Lp512, 32
+.Lp512:
+    .word 0x740eef02, 0x00000000, 0x9e4addf8, 0x00000000  // x^543 mod P_crc32c(x) = 0x740eef02
+    .word 0x740eef02, 0x00000000, 0x9e4addf8, 0x00000000  // x^479 mod P_crc32c(x) = 0x9e4addf8
+
+    .type   .Lp256, %object
+    .size   .Lp256, 32
+.Lp256:
+    .word 0x3da6d0cb, 0x00000000, 0xba4fc28e, 0x00000000  // x^287 mod P_crc32c(x) = 0x3da6d0cb
+    .word 0x3da6d0cb, 0x00000000, 0xba4fc28e, 0x00000000  // x^223 mod P_crc32c(x) = 0xba4fc28e
+
+    .type   .Lp128, %object
+    .size   .Lp128, 16
+.Lp128:
+    .quad   0x00000000f20c0dfe  // x^159 mod P_crc32c(x) = 0xf20c0dfe
+    .quad   0x00000000493c7d27  // x^95 mod P_crc32c(x) = 0x493c7d27
+
+
+
+

--- a/crc/aarch64/crc32_iscsi_p8c10_clmul_const.S
+++ b/crc/aarch64/crc32_iscsi_p8c10_clmul_const.S
@@ -1,0 +1,15796 @@
+/**************************************************************
+  Copyright (c) 2026 Huawei Technologies Co., Ltd.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Huawei Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+.file   "crc32_iscsi_p8c10_clmul_const.S"
+
+.section    .rodata
+.align  4
+.global crc32_iscsi_p8c10_clmul_const
+.type   crc32_iscsi_p8c10_clmul_const, %object
+.size   crc32_iscsi_p8c10_clmul_const, 50400
+crc32_iscsi_p8c10_clmul_const:
+    .word   0xc619809d      // placeholder, invalid data
+    .word   0xd270f1a2      // placeholder, invalid data
+    .word   0x61d82e56      // placeholder, invalid data
+    .word   0xce7f39f4      // placeholder, invalid data
+    .word   0xa60ce07b      // placeholder, invalid data
+    .word   0xbac2fd7b      // placeholder, invalid data
+    .word   0x78d9ccb7      // placeholder, invalid data
+    .word   0xb6dd949b      // placeholder, invalid data
+    .word   0x18b33a4e      // placeholder, invalid data
+    .word   0xb9e02b86      // placeholder, invalid data
+    
+    .word   0xc619809d
+    .word   0xd270f1a2
+    .word   0x61d82e56
+    .word   0xce7f39f4
+    .word   0xa60ce07b
+    .word   0xbac2fd7b
+    .word   0x78d9ccb7
+    .word   0xb6dd949b
+
+
+    .word   0x18b33a4e
+    .word   0xb9e02b86
+    .word   0x167d312
+    .word   0xd7a4825c
+    .word   0xb0cd4768
+    .word   0xe6fc4e6a
+    .word   0xcec3662e
+    .word   0x6b749fb2
+
+
+    .word   0x93a5f730
+    .word   0x271d9844
+    .word   0x10746f3c
+    .word   0xdd7e3b0c
+    .word   0xa90fd27a
+    .word   0x86d8e4d2
+    .word   0xa2b73df1
+    .word   0x6f345e45
+
+
+    .word   0xe0ac139e
+    .word   0x3771e98f
+    .word   0x57a3d037
+    .word   0x98d8d9cb
+    .word   0xf6076544
+    .word   0xd7a4825c
+    .word   0x2664fd8b
+    .word   0x9ef68d35
+
+
+    .word   0x6d9a4957
+    .word   0xd813b325
+    .word   0xc9c8b782
+    .word   0xdd66cbbb
+    .word   0xb3af077a
+    .word   0x86d8e4d2
+    .word   0xff0dba97
+    .word   0x170076fa
+
+
+    .word   0xa563905d
+    .word   0xf48642e9
+    .word   0x59f229bc
+    .word   0x17f27698
+    .word   0x135c83fd
+    .word   0x2664fd8b
+    .word   0x995a5724
+    .word   0x2342001e
+
+
+    .word   0x3f70cc6f
+    .word   0xdd66cbbb
+    .word   0xd6c3a807
+    .word   0xbedc6ba1
+    .word   0xe0cdcf86
+    .word   0x21ac5ef
+    .word   0x45cddf4e
+    .word   0xf48642e9
+
+
+    .word   0xded288f8
+    .word   0xbcf5f6
+    .word   0x2ee03b2
+    .word   0x9ef68d35
+    .word   0x60bf0a6a
+    .word   0x889774e1
+    .word   0xd8ecc578
+    .word   0x94eb256e
+
+
+    .word   0xcd1526a
+    .word   0xdefba41c
+    .word   0xe8310afa
+    .word   0x45cddf4e
+    .word   0xc4584f5c
+    .word   0xaa7c7ad5
+    .word   0xf8448640
+    .word   0x359674f7
+
+
+    .word   0xc00df280
+    .word   0x8515c07f
+    .word   0x889774e1
+    .word   0x22c3799f
+    .word   0x63d097e9
+    .word   0xbedc6ba1
+    .word   0xcbbe4ee1
+    .word   0xa51b6135
+
+
+    .word   0x997157e1
+    .word   0x7f47463d
+    .word   0x533e308d
+    .word   0x1c2cce0a
+    .word   0x47972100
+    .word   0x465a4eee
+    .word   0x8a074012
+    .word   0xb3a6da94
+
+
+    .word   0x1d31175f
+    .word   0xbedc6ba1
+    .word   0xcecfcd43
+    .word   0x23d5e7e5
+    .word   0xd1a9427c
+    .word   0x4ac726eb
+    .word   0xaeb3e622
+    .word   0xf8448640
+
+
+    .word   0x51aeef66
+    .word   0x465a4eee
+    .word   0x5aa1f3cf
+    .word   0x22c3799f
+    .word   0xfb3bb2c8
+    .word   0x195bc82d
+    .word   0xd0c6d7c9
+    .word   0x1495d20d
+
+
+    .word   0x93f3319c
+    .word   0x4ac726eb
+    .word   0x604d6e09
+    .word   0x1c2cce0a
+    .word   0x712e86
+    .word   0x8515c07f
+    .word   0xf6e6d69e
+    .word   0x5bb964
+
+
+    .word   0x4a9d4498
+    .word   0x195bc82d
+    .word   0x24e6fe8f
+    .word   0x23d5e7e5
+    .word   0x4ce8bfe5
+    .word   0x7f47463d
+    .word   0x95ffd7dc
+    .word   0x359674f7
+
+
+    .word   0x60bced33
+    .word   0x87d07ae0
+    .word   0x8653215c
+    .word   0x1b93589c
+    .word   0x6737eead
+    .word   0xc4cedd32
+    .word   0x96309b0f
+    .word   0xf22fd3e2
+
+
+    .word   0x529295e6
+    .word   0x5f0e0438
+    .word   0x71cc89e8
+    .word   0xe0126b2
+    .word   0xeb75a090
+    .word   0xe1a468d0
+    .word   0x871bd30
+    .word   0x4de20a7c
+
+
+    .word   0x23912612
+    .word   0x24e6fe8f
+    .word   0x6664d9c1
+    .word   0x96a1f19b
+    .word   0x734fe0e4
+    .word   0x6bce9345
+    .word   0x618e0996
+    .word   0x7959fe2a
+
+
+    .word   0xab819fbb
+    .word   0xf6e6d69e
+    .word   0x32a8058
+    .word   0xf36d84e2
+    .word   0xcf067065
+    .word   0x23d5e7e5
+    .word   0xdbf6533d
+    .word   0xb9d68d49
+
+
+    .word   0x66c774dd
+    .word   0xe3e0d8bf
+    .word   0xe0126b2
+    .word   0xca110698
+    .word   0x1ad321bc
+    .word   0x5bb964
+    .word   0xcfeff4b3
+    .word   0x82f89c77
+
+
+    .word   0xf94b6383
+    .word   0xfab852fc
+    .word   0xe7cf465
+    .word   0xd51c8fe7
+    .word   0x734c4743
+    .word   0xfa0f2bd0
+    .word   0x3e18bd99
+    .word   0x60165873
+
+
+    .word   0x28198362
+    .word   0xcfeff4b3
+    .word   0xe917069f
+    .word   0x60867a83
+    .word   0xc8cb3d4d
+    .word   0x1136e0c6
+    .word   0x50e1223d
+    .word   0x6bce9345
+
+
+    .word   0x79d95f64
+    .word   0x480e7e4d
+    .word   0x60165873
+    .word   0x5bb964
+    .word   0xa934549e
+    .word   0xa0bd36d3
+    .word   0xf46a66c0
+    .word   0x78475c4c
+
+
+    .word   0x206b5112
+    .word   0xc6e71129
+    .word   0xd33280db
+    .word   0x79d95f64
+    .word   0x3e18bd99
+    .word   0x1ad321bc
+    .word   0xe12e0a15
+    .word   0xf7ac8f1f
+
+
+    .word   0x6dad97a6
+    .word   0xfa96021e
+    .word   0xfc160434
+    .word   0xdbf6533d
+    .word   0xc6e71129
+    .word   0x6bce9345
+    .word   0xfa0f2bd0
+    .word   0xca110698
+
+
+    .word   0x2b8f4465
+    .word   0xd33a036c
+    .word   0x2083964f
+    .word   0x7fa16459
+    .word   0xb16216c4
+    .word   0xfc160434
+    .word   0x206b5112
+    .word   0x50e1223d
+
+
+    .word   0x734c4743
+    .word   0xe0126b2
+    .word   0x51a9b983
+    .word   0x221dcce
+    .word   0x2eb46705
+    .word   0x7e7697a7
+    .word   0x7fa16459
+    .word   0xfa96021e
+
+
+    .word   0x78475c4c
+    .word   0x1136e0c6
+    .word   0xd51c8fe7
+    .word   0xe3e0d8bf
+    .word   0xd293ac2c
+    .word   0x1bfa871f
+    .word   0xa6a88db1
+    .word   0x2eb46705
+
+
+    .word   0x2083964f
+    .word   0x6dad97a6
+    .word   0xf46a66c0
+    .word   0xc8cb3d4d
+    .word   0xe7cf465
+    .word   0x66c774dd
+    .word   0xf1808fd4
+    .word   0x6bde96db
+
+
+    .word   0x1bfa871f
+    .word   0x221dcce
+    .word   0xd33a036c
+    .word   0xf7ac8f1f
+    .word   0xa0bd36d3
+    .word   0x60867a83
+    .word   0xfab852fc
+    .word   0xb9d68d49
+
+
+    .word   0xeebd4cf6
+    .word   0xf1808fd4
+    .word   0xd293ac2c
+    .word   0x51a9b983
+    .word   0x2b8f4465
+    .word   0xe12e0a15
+    .word   0xa934549e
+    .word   0xe917069f
+
+
+    .word   0xf94b6383
+    .word   0xdbf6533d
+    .word   0xb530ab45
+    .word   0x999b9ee5
+    .word   0x26eb381f
+    .word   0xa1e289e0
+    .word   0xed63d02d
+    .word   0xad630641
+
+
+    .word   0x531607cd
+    .word   0xef93fc47
+    .word   0x73a2eb15
+    .word   0x51c0477e
+    .word   0x932fdc7f
+    .word   0xb6337728
+    .word   0x638dec4b
+    .word   0x3df47b02
+
+
+    .word   0x9af81e88
+    .word   0xdd4b4a66
+    .word   0xa4faae37
+    .word   0x5c0446ae
+    .word   0xc1465383
+    .word   0x60867a83
+    .word   0x4c61f1ee
+    .word   0x57e82916
+
+
+    .word   0x8e3cdda4
+    .word   0xda4e15d9
+    .word   0x6ab17535
+    .word   0xe22abd82
+    .word   0xfe71c1f7
+    .word   0xd33a036c
+    .word   0x6f157c58
+    .word   0xa9232e2b
+
+
+    .word   0xd538db6d
+    .word   0x78a42dd7
+    .word   0x10b2ee53
+    .word   0x7b83ad45
+    .word   0xd761f8da
+    .word   0xdba7506a
+    .word   0x8e3ebcb6
+    .word   0xcc5eeafe
+
+
+    .word   0xe91a75db
+    .word   0x11e2d681
+    .word   0x73cca6b7
+    .word   0xf8489afc
+    .word   0x6c08076e
+    .word   0xe83d9de6
+    .word   0x670677cf
+    .word   0xf1808fd4
+
+
+    .word   0xca7b4457
+    .word   0xdd4b4a66
+    .word   0xfd1e6f18
+    .word   0xf7ac8f1f
+    .word   0x6d3bab56
+    .word   0x361dcba9
+    .word   0x55b9d733
+    .word   0x562cc096
+
+
+    .word   0xd2c0eed
+    .word   0xbca448b9
+    .word   0x180d9039
+    .word   0x6e8aee1f
+    .word   0x8ada9f16
+    .word   0xf11494b6
+    .word   0xef30292f
+    .word   0xc1f19ee1
+
+
+    .word   0x9090f94c
+    .word   0x2deb01bb
+    .word   0x57e82916
+    .word   0xe2f1a204
+    .word   0xd14029f1
+    .word   0x6bde96db
+    .word   0x7e3dc353
+    .word   0x54a86326
+
+
+    .word   0x35f0759c
+    .word   0x53a16e16
+    .word   0xfa2a87d7
+    .word   0x3369bc9f
+    .word   0x235ea573
+    .word   0xe83d9de6
+    .word   0xfb539ee9
+    .word   0x3df47b02
+
+
+    .word   0xcd846e4f
+    .word   0x221dcce
+    .word   0xd53652a7
+    .word   0x32aa6f06
+    .word   0xd37d52d6
+    .word   0x636ddf64
+    .word   0xac76b1e7
+    .word   0xc8774a7
+
+
+    .word   0x3afba905
+    .word   0x606dfba1
+    .word   0x991dbde0
+    .word   0x7e3dc353
+    .word   0xfdfd25f6
+    .word   0x1a983b69
+    .word   0xb94a60b0
+    .word   0x4b7708c5
+
+
+    .word   0xceda5177
+    .word   0x4c61f1ee
+    .word   0x9967dd9a
+    .word   0x670677cf
+    .word   0x40de0a72
+    .word   0xe22abd82
+    .word   0x652ba80
+    .word   0x7bf67404
+
+
+    .word   0xa649b1ff
+    .word   0x53a16e16
+    .word   0x5e7068e2
+    .word   0xf8489afc
+    .word   0x344c1875
+    .word   0xb6337728
+    .word   0x606dfba1
+    .word   0x6bde96db
+
+
+    .word   0x605c2780
+    .word   0x6d11e994
+    .word   0x9b02f3bf
+    .word   0xca67c7b5
+    .word   0xa00f1f17
+    .word   0x2d1501cb
+    .word   0xee83c5d4
+    .word   0x308846f5
+
+
+    .word   0x5d9e5e03
+    .word   0xb70a476d
+    .word   0x624f0691
+    .word   0xa9ff8077
+    .word   0x9e9bad3c
+    .word   0x9e0f1f01
+    .word   0x353a41e0
+    .word   0x678d4ec0
+
+
+    .word   0x7544282e
+    .word   0x344c1875
+    .word   0x3afba905
+    .word   0xd14029f1
+    .word   0xfb8e39c3
+    .word   0x1125b7e2
+    .word   0x5db94b29
+    .word   0x9cda2ea3
+
+
+    .word   0x5e1cc86a
+    .word   0x7cfd7add
+    .word   0x312d8c85
+    .word   0xa7c73379
+    .word   0xbc349b2d
+    .word   0x999b9ee5
+    .word   0x3b9b9a4f
+    .word   0x278840ed
+
+
+    .word   0x2a3dbf03
+    .word   0x40b6a02a
+    .word   0x1a983b69
+    .word   0xef30292f
+    .word   0x678d4ec0
+    .word   0xf8489afc
+    .word   0xc8774a7
+    .word   0xe2f1a204
+
+
+    .word   0xff0a85a6
+    .word   0x64f6f081
+    .word   0x9808559e
+    .word   0x8f95bc61
+    .word   0x6722d0d6
+    .word   0x1193579f
+    .word   0x5009a70f
+    .word   0x326f4908
+
+
+    .word   0xcc43d239
+    .word   0x3a60900b
+    .word   0xfdba47f1
+    .word   0xef755994
+    .word   0xb12d49ac
+    .word   0x34a41c00
+    .word   0xda04e539
+    .word   0x1a983b69
+
+
+    .word   0x353a41e0
+    .word   0x5e7068e2
+    .word   0xac76b1e7
+    .word   0x57e82916
+    .word   0x9aa409eb
+    .word   0x3d0fab62
+    .word   0x1484aa2c
+    .word   0x7c1b6aa5
+
+
+    .word   0x687ed121
+    .word   0x9b191cc6
+    .word   0x21b27aff
+    .word   0xa9534861
+    .word   0x6e10c383
+    .word   0xeab08786
+    .word   0xc2687ef7
+    .word   0x1afcdd4d
+
+
+    .word   0x63b80166
+    .word   0xd305130d
+    .word   0x34a41c00
+    .word   0x40b6a02a
+    .word   0x9e0f1f01
+    .word   0x53a16e16
+    .word   0x636ddf64
+    .word   0x2deb01bb
+
+
+    .word   0x133a190e
+    .word   0xa25ef6e5
+    .word   0x969efaf9
+    .word   0x72ccc510
+    .word   0x57118e1d
+    .word   0x652ba80
+    .word   0x7275c15d
+    .word   0x1dd1ab47
+
+
+    .word   0xac1b88d3
+    .word   0xf8489afc
+    .word   0xb0d097c
+    .word   0x38440e75
+    .word   0xedb298fc
+    .word   0x63b80166
+    .word   0xb12d49ac
+    .word   0x2a3dbf03
+
+
+    .word   0x9e9bad3c
+    .word   0xa649b1ff
+    .word   0xd37d52d6
+    .word   0x9090f94c
+    .word   0xcee184fc
+    .word   0x8467a6a5
+    .word   0x8310055b
+    .word   0xf8481b6a
+
+
+    .word   0x7fd2ce89
+    .word   0x16a00021
+    .word   0x89477fae
+    .word   0x28654999
+    .word   0x36aabdc7
+    .word   0x5d878436
+    .word   0x1e1653d4
+    .word   0xdfea38fc
+
+
+    .word   0x38440e75
+    .word   0x1afcdd4d
+    .word   0xef755994
+    .word   0x278840ed
+    .word   0xa9ff8077
+    .word   0x7bf67404
+    .word   0x32aa6f06
+    .word   0xc1f19ee1
+
+
+    .word   0xda63aae4
+    .word   0x3f059dcf
+    .word   0x77c9eb8a
+    .word   0x3bae5711
+    .word   0x3ca161f7
+    .word   0x23f832c6
+    .word   0x2f00bc4a
+    .word   0xda04e539
+
+
+    .word   0x7dd192f5
+    .word   0xc16cbe2e
+    .word   0xb4d47c50
+    .word   0x1e1653d4
+    .word   0xb0d097c
+    .word   0xc2687ef7
+    .word   0xfdba47f1
+    .word   0x3b9b9a4f
+
+
+    .word   0x624f0691
+    .word   0x652ba80
+    .word   0xd53652a7
+    .word   0xef30292f
+    .word   0xa0a063da
+    .word   0x3b2afea
+    .word   0x82cd77d7
+    .word   0xd5c2006e
+
+
+    .word   0x712e7e8a
+    .word   0xa5ac2348
+    .word   0x368bd350
+    .word   0x580315c1
+    .word   0xaeddb50e
+    .word   0x32aa6f06
+    .word   0xb6b60b9c
+    .word   0xcdbb03f9
+
+
+    .word   0xda090154
+    .word   0x5211183f
+    .word   0xff1cbe44
+    .word   0xba14e742
+    .word   0x2475815a
+    .word   0x1125b7e2
+    .word   0xf4a0d5fb
+    .word   0xba687f9f
+
+
+    .word   0xe901ad71
+    .word   0x373326ad
+    .word   0x9da08a89
+    .word   0xc8e95e0f
+    .word   0x650ef9ac
+    .word   0x802c1ff
+    .word   0x328e095f
+    .word   0xaf28b4a1
+
+
+    .word   0xde621d3a
+    .word   0xfab9fb8c
+    .word   0x7dc697e8
+    .word   0xed62e6ae
+    .word   0xaa4a7da6
+    .word   0xa617f4c3
+    .word   0x12852f1
+    .word   0xa25ef6e5
+
+
+    .word   0x6fa5495a
+    .word   0x5664260e
+    .word   0x580315c1
+    .word   0x7bf67404
+    .word   0x7e6cf1a9
+    .word   0x5af4fd4
+    .word   0xbf543b6f
+    .word   0xc71fb794
+
+
+    .word   0x15164ac5
+    .word   0xc2687ef7
+    .word   0x20cee0ca
+    .word   0x72ccc510
+    .word   0xefbb8d22
+    .word   0x40b6a02a
+    .word   0x90c54a5c
+    .word   0xce7e63bb
+
+
+    .word   0x4c053c59
+    .word   0x916f0f21
+    .word   0x3f059dcf
+    .word   0x3f8d877
+    .word   0xeceffb9f
+    .word   0xef755994
+    .word   0xac78d1e3
+    .word   0x1994f83a
+
+
+    .word   0x9f68311a
+    .word   0x92b325a6
+    .word   0xc15b5054
+    .word   0xd6e25267
+    .word   0xe5fb8e79
+    .word   0xf1658334
+    .word   0xa83ecfe5
+    .word   0x6fa5495a
+
+
+    .word   0x368bd350
+    .word   0xa9ff8077
+    .word   0x2242ba27
+    .word   0xc9a2191f
+    .word   0xcd01c406
+    .word   0x41afada9
+    .word   0x294b3b13
+    .word   0xa25c109d
+
+
+    .word   0xfe6e1775
+    .word   0xd5750f4
+    .word   0x8b4be151
+    .word   0x72e26a0b
+    .word   0xb08eb2fc
+    .word   0x12a6c4f9
+    .word   0xec1aae5a
+    .word   0xb56ac09
+
+
+    .word   0x8259e44c
+    .word   0x426caac4
+    .word   0x870276ef
+    .word   0xf8efef0f
+    .word   0x37d273e5
+    .word   0x351af13d
+    .word   0x736cf29b
+    .word   0x460f957b
+
+
+    .word   0xa7a92bde
+    .word   0x5af4fd4
+    .word   0xfd6bc41b
+    .word   0x1e1653d4
+    .word   0xf1658334
+    .word   0xa25ef6e5
+    .word   0xa5ac2348
+    .word   0x278840ed
+
+
+    .word   0x924f7d6b
+    .word   0x10f93c8b
+    .word   0xd740b8a9
+    .word   0x3508cf4b
+    .word   0x8ed561df
+    .word   0x48030a08
+    .word   0x9950bdd
+    .word   0x2533fa11
+
+
+    .word   0x5c59e710
+    .word   0xd438fed
+    .word   0xe70c8366
+    .word   0x19a12a1b
+    .word   0xfc2270aa
+    .word   0x40ca35e7
+    .word   0xe7d73e3c
+    .word   0x61c9c995
+
+
+    .word   0x3645b6b
+    .word   0xf4e2108f
+    .word   0x63012ef5
+    .word   0xe620257d
+    .word   0xee1f3862
+    .word   0x24226733
+    .word   0x30bfe869
+    .word   0xb7003da5
+
+
+    .word   0xd0a94b9
+    .word   0xfd6bc41b
+    .word   0xe5fb8e79
+    .word   0x12852f1
+    .word   0x712e7e8a
+    .word   0xef755994
+    .word   0x621cc3d9
+    .word   0x6a173fa1
+
+
+    .word   0x520a5eab
+    .word   0x1a77140a
+    .word   0xce7e63bb
+    .word   0x68bfa742
+    .word   0xa30c5b8d
+    .word   0xdfea38fc
+    .word   0x7620891b
+    .word   0x1dc403cc
+
+
+    .word   0xc5a85468
+    .word   0x4480d945
+    .word   0xc6ef898f
+    .word   0x5fd271b0
+    .word   0x99ab0371
+    .word   0xb6b60b9c
+    .word   0x9c214c21
+    .word   0xb90bac07
+
+
+    .word   0xae895394
+    .word   0xba14e742
+    .word   0x6146b401
+    .word   0xe511176c
+    .word   0x5333820d
+    .word   0x35a80761
+    .word   0xb7003da5
+    .word   0x5af4fd4
+
+
+    .word   0xd6e25267
+    .word   0xa617f4c3
+    .word   0xd5c2006e
+    .word   0x1afcdd4d
+    .word   0x6e0e4bec
+    .word   0x96f9122
+    .word   0x5061b6a1
+    .word   0xb8353103
+
+
+    .word   0xad9c797c
+    .word   0x833b4f11
+    .word   0x202054e4
+    .word   0xf140259a
+    .word   0x1f308d
+    .word   0x4e2e9efc
+    .word   0x10368bd1
+    .word   0xab855c16
+
+
+    .word   0x49ecc32
+    .word   0x55755180
+    .word   0x3026685e
+    .word   0xecce298e
+    .word   0xfe9f2c20
+    .word   0x3b2afea
+    .word   0xe85295a3
+    .word   0x7620891b
+
+
+    .word   0x17a314fd
+    .word   0x2c826b89
+    .word   0x73a446a
+    .word   0x5333820d
+    .word   0x30bfe869
+    .word   0xa7a92bde
+    .word   0xc15b5054
+    .word   0xaa4a7da6
+
+
+    .word   0x82cd77d7
+    .word   0x38440e75
+    .word   0xe56694e3
+    .word   0x6b663660
+    .word   0xe02a754d
+    .word   0x93fd4bfc
+    .word   0xf8930d94
+    .word   0x90c54a5c
+
+
+    .word   0x762935da
+    .word   0xfd6bc41b
+    .word   0xf76c8a25
+    .word   0x3f8d877
+    .word   0xa1edbf15
+    .word   0xf81a958a
+    .word   0x3cc76ca5
+    .word   0x78cfbc2b
+
+
+    .word   0x1dc6bf44
+    .word   0xfa76aefd
+    .word   0xde32b253
+    .word   0x6771f06c
+    .word   0x96128fe4
+    .word   0x654e1b32
+    .word   0xf6cd9e0e
+    .word   0x8a822e60
+
+
+    .word   0x2c826b89
+    .word   0xe511176c
+    .word   0x24226733
+    .word   0x460f957b
+    .word   0x92b325a6
+    .word   0xed62e6ae
+    .word   0x3b2afea
+    .word   0xdfea38fc
+
+
+    .word   0x344bc23b
+    .word   0x82f7b51f
+    .word   0x4f948ff3
+    .word   0xb40fdceb
+    .word   0xffbbc39e
+    .word   0xed6ff822
+    .word   0x455bf7c0
+    .word   0x510c2d78
+
+
+    .word   0x69b3d756
+    .word   0xdefe731
+    .word   0x47de84c4
+    .word   0x5370607d
+    .word   0x16ecc543
+    .word   0x1e637330
+    .word   0x4dcc7d13
+    .word   0xfe7713ab
+
+
+    .word   0xe43388fd
+    .word   0x42accdee
+    .word   0xc96e8b87
+    .word   0x3af9e2cb
+    .word   0x54c3a27
+    .word   0xf6cd9e0e
+    .word   0x17a314fd
+    .word   0x6146b401
+
+
+    .word   0xee1f3862
+    .word   0x736cf29b
+    .word   0x9f68311a
+    .word   0x7dc697e8
+    .word   0xa0a063da
+    .word   0x1e1653d4
+    .word   0x2438686b
+    .word   0x8817e599
+
+
+    .word   0xf714e1a0
+    .word   0x3b0d9847
+    .word   0xd193175d
+    .word   0xf8f85c4c
+    .word   0x64c41653
+    .word   0x92b325a6
+    .word   0xfe9f2c20
+    .word   0xa30c5b8d
+
+
+    .word   0x7237cc47
+    .word   0x4cf2741a
+    .word   0xfb6b2d08
+    .word   0x70969746
+    .word   0xa03630c8
+    .word   0x93fd4bfc
+    .word   0xca1b5a8f
+    .word   0xb7003da5
+
+
+    .word   0xafb3f8d5
+    .word   0x916f0f21
+    .word   0x8fc34de8
+    .word   0x5bebc969
+    .word   0x9163bdee
+    .word   0x9a0e77f0
+    .word   0x3f3f482f
+    .word   0x4480d945
+
+
+    .word   0x69ae1e81
+    .word   0x9bdd7d74
+    .word   0x4888c18b
+    .word   0xcdbb03f9
+    .word   0x791ef78
+    .word   0x38c006ca
+    .word   0xc69dfa90
+    .word   0x230903c6
+
+
+    .word   0x3ea51d59
+    .word   0xfd58573f
+    .word   0xad76a913
+    .word   0xc69866be
+    .word   0x2337e6a9
+    .word   0x2c5a1ef5
+    .word   0x2196534c
+    .word   0xd2d0a674
+
+
+    .word   0xc6f63182
+    .word   0x370ba98c
+    .word   0x6b663660
+    .word   0x621cc3d9
+    .word   0xf8f85c4c
+    .word   0x460f957b
+    .word   0xecce298e
+    .word   0x68bfa742
+
+
+    .word   0x72789cb6
+    .word   0xb9b5458e
+    .word   0x35cdc852
+    .word   0xaa8f1ea6
+    .word   0xb5c18327
+    .word   0x1a0136a7
+    .word   0x47549653
+    .word   0xa60ceebc
+
+
+    .word   0x91dca658
+    .word   0xed62e6ae
+    .word   0x4bfb160e
+    .word   0xa5b34a34
+    .word   0xd271395d
+    .word   0xdb0e4887
+    .word   0xfb33f3af
+    .word   0xeb93e6c9
+
+
+    .word   0x285c34b1
+    .word   0x5b443d2
+    .word   0xeb7a073d
+    .word   0x17715b2e
+    .word   0x6713765a
+    .word   0x8842ee57
+    .word   0xfb70ea0
+    .word   0xe4b6571
+
+
+    .word   0x82f95dcf
+    .word   0x845be24e
+    .word   0x1b74c6a1
+    .word   0xc09278a6
+    .word   0xf18395e5
+    .word   0x7f1291d5
+    .word   0xeb02ddf5
+    .word   0xb49ccf02
+
+
+    .word   0x494620a3
+    .word   0x4cf2741a
+    .word   0x1262fed3
+    .word   0x6b663660
+    .word   0xd193175d
+    .word   0x24226733
+    .word   0x3026685e
+    .word   0xce7e63bb
+
+
+    .word   0x93490e5e
+    .word   0x8a24fa06
+    .word   0x9aa4588f
+    .word   0x68eadc2d
+    .word   0x561920d0
+    .word   0x10368bd1
+    .word   0x3237102d
+    .word   0x3128f4ef
+
+
+    .word   0x26114d69
+    .word   0xecce298e
+    .word   0x624b901e
+    .word   0x9e57a0fe
+    .word   0xb3dcfcb3
+    .word   0x8c76b7e3
+    .word   0xd980b58d
+    .word   0x7713b44d
+
+
+    .word   0x653f7d7c
+    .word   0xe871d807
+    .word   0xbfd3b74
+    .word   0xae9cd6f4
+    .word   0xe60d06a7
+    .word   0x51da797e
+    .word   0x4f2f7bb5
+    .word   0xb67ff735
+
+
+    .word   0x9688448
+    .word   0xd69de54d
+    .word   0xac32236d
+    .word   0x4452d34c
+    .word   0xd274e3a6
+    .word   0xc9a2191f
+    .word   0xb6a6332e
+    .word   0x6727202c
+
+
+    .word   0xae509f36
+    .word   0x78d9379d
+    .word   0x4cf2741a
+    .word   0x370ba98c
+    .word   0x3b0d9847
+    .word   0xe511176c
+    .word   0x55755180
+    .word   0x1a77140a
+
+
+    .word   0xb7676b9e
+    .word   0x6604c8fe
+    .word   0xfc41eb34
+    .word   0xe914931e
+    .word   0xb2eb07e4
+    .word   0x964d5954
+    .word   0xe47edf33
+    .word   0x54006c90
+
+
+    .word   0x8d153db5
+    .word   0x9a99094f
+    .word   0x22163d6d
+    .word   0xb8f04a14
+    .word   0x3d7ed741
+    .word   0x616cddb4
+    .word   0xc39d1e5
+    .word   0xf6cd9e0e
+
+
+    .word   0x6068eb6f
+    .word   0x1a0136a7
+    .word   0x3128f4ef
+    .word   0x460f957b
+    .word   0xe08b8052
+    .word   0x95786847
+    .word   0x3d7ccd84
+    .word   0xa4ab2df2
+
+
+    .word   0xd6994ebd
+    .word   0x75111e66
+    .word   0x13a096cf
+    .word   0x3f3f482f
+    .word   0x1b70c2b9
+    .word   0x91aa2224
+    .word   0x13429a06
+    .word   0xb32f2521
+
+
+    .word   0x762aedda
+    .word   0xae509f36
+    .word   0x494620a3
+    .word   0xc6f63182
+    .word   0xf714e1a0
+    .word   0x2c826b89
+    .word   0x49ecc32
+    .word   0x520a5eab
+
+
+    .word   0x7f61a3c4
+    .word   0xbddb02ee
+    .word   0x437242dd
+    .word   0xad5fc63f
+    .word   0x2291488e
+    .word   0xfe2355a1
+    .word   0x429bcfa6
+    .word   0xb64c0b7b
+
+
+    .word   0x73f9eecc
+    .word   0x19a12a1b
+    .word   0x6905f3a8
+    .word   0x68317ab4
+    .word   0x1057cf58
+    .word   0x29b134a7
+    .word   0x3cf4a533
+    .word   0x36438f6b
+
+
+    .word   0x36e81107
+    .word   0xcd4e5f88
+    .word   0x9077eca
+    .word   0x26f67961
+    .word   0xc12124cf
+    .word   0x8e2a42c0
+    .word   0x193cce98
+    .word   0xcc7ab42b
+
+
+    .word   0x3fc5bffc
+    .word   0x2438686b
+    .word   0x529ca544
+    .word   0x6068eb6f
+    .word   0x3237102d
+    .word   0xf8f85c4c
+    .word   0xab5b4d5b
+    .word   0xa400fc17
+
+
+    .word   0xb32f2521
+    .word   0x6727202c
+    .word   0xb49ccf02
+    .word   0xd2d0a674
+    .word   0x8817e599
+    .word   0x8a822e60
+    .word   0xab855c16
+    .word   0x6a173fa1
+
+
+    .word   0xd84cbe66
+    .word   0xfebc33a8
+    .word   0x753b50f4
+    .word   0xf9c7f58d
+    .word   0xd3108773
+    .word   0x9baa347
+    .word   0x269f91b5
+    .word   0x1429e38
+
+
+    .word   0x3d4a975
+    .word   0xa6cef9c5
+    .word   0xf65735e8
+    .word   0xa2e90469
+    .word   0xcc3b2f38
+    .word   0xfc50e399
+    .word   0x36d2fba3
+    .word   0x946a6a0a
+
+
+    .word   0xdc2b3aaf
+    .word   0x1262fed3
+    .word   0x62eceb37
+    .word   0x674a17c4
+    .word   0xf7f3a372
+    .word   0x330a4a3f
+    .word   0xfd5a50a6
+    .word   0xf5879b4b
+
+
+    .word   0x5393f71e
+    .word   0x616cddb4
+    .word   0xd35e3aec
+    .word   0xaa8f1ea6
+    .word   0x1c2c47d3
+    .word   0xe511176c
+    .word   0xdd8b2b45
+    .word   0xab5b4d5b
+
+
+    .word   0x13429a06
+    .word   0xb6a6332e
+    .word   0xeb02ddf5
+    .word   0x2196534c
+    .word   0x2438686b
+    .word   0xf6cd9e0e
+    .word   0x10368bd1
+    .word   0x621cc3d9
+
+
+    .word   0x6fea7709
+    .word   0x12b088c6
+    .word   0xe37e69dd
+    .word   0x752661af
+    .word   0xfddabce2
+    .word   0x7fc5879f
+    .word   0x153dad66
+    .word   0x9e9d6ba6
+
+
+    .word   0x759023bf
+    .word   0xce3bb9a9
+    .word   0x580ab526
+    .word   0xe638ec12
+    .word   0x8fb63e24
+    .word   0xc51c831a
+    .word   0xfb12927f
+    .word   0x8a24fa06
+
+
+    .word   0xa7e52ee5
+    .word   0x3b8ad53
+    .word   0xfaea57cb
+    .word   0xab855c16
+    .word   0x73fdce53
+    .word   0xd288859
+    .word   0xf98c3267
+    .word   0xd3429b73
+
+
+    .word   0xce20bc93
+    .word   0x7c662803
+    .word   0xbef03cb9
+    .word   0x10e6684e
+    .word   0xf6fe8ce0
+    .word   0x548e71b7
+    .word   0xb47a413f
+    .word   0x5698f98e
+
+
+    .word   0xfb2ebf94
+    .word   0xd91afde4
+    .word   0x95786847
+    .word   0xf18b2c6d
+    .word   0x9067a873
+    .word   0x5bebc969
+    .word   0xf4da04c6
+    .word   0xa095b905
+
+
+    .word   0x56b6d976
+    .word   0x36445ff2
+    .word   0xbe19d0b3
+    .word   0xf17e7c45
+    .word   0x54269d06
+    .word   0xeb02ddf5
+    .word   0x3fc5bffc
+    .word   0xc39d1e5
+
+
+    .word   0x561920d0
+    .word   0x6b663660
+    .word   0x49e7034d
+    .word   0x504575ea
+    .word   0x9bf0a2d3
+    .word   0xcc51dfd0
+    .word   0x2710c11
+    .word   0xe2ebe9a
+
+
+    .word   0x66c5f160
+    .word   0x97018b70
+    .word   0x579f28cc
+    .word   0x887732ed
+    .word   0xa74484fa
+    .word   0xb89440d3
+    .word   0xff389ed0
+    .word   0x6ca253ac
+
+
+    .word   0x4f4d9d5d
+    .word   0x549a5ad7
+    .word   0x1b339736
+    .word   0xae442e5f
+    .word   0x263abf83
+    .word   0xd5a313cd
+    .word   0x18db9b71
+    .word   0x9a623a99
+
+
+    .word   0x9b28c794
+    .word   0x330a4a3f
+    .word   0x412f3360
+    .word   0xb8f04a14
+    .word   0x86f76f08
+    .word   0xb9b5458e
+    .word   0x3b8ad53
+    .word   0x8a822e60
+
+
+    .word   0xed51555a
+    .word   0xc085c213
+    .word   0x94c996a6
+    .word   0x8e0aa742
+    .word   0x281c634e
+    .word   0xbb87a44d
+    .word   0xd8579548
+    .word   0x4253baa0
+
+
+    .word   0xfda3e3a1
+    .word   0x2f8b379d
+    .word   0x43577a6
+    .word   0x870fb66c
+    .word   0x918e4d65
+    .word   0x9622c0f2
+    .word   0xf17e7c45
+    .word   0xb6a6332e
+
+
+    .word   0xcc7ab42b
+    .word   0x616cddb4
+    .word   0x68eadc2d
+    .word   0x370ba98c
+    .word   0x1583d226
+    .word   0x20811ffd
+    .word   0x66af2074
+    .word   0xa4060cc0
+
+
+    .word   0x5bc20c58
+    .word   0x18fb473
+    .word   0x8862d573
+    .word   0xb81e69c7
+    .word   0x92739fb0
+    .word   0x5370607d
+    .word   0x690b61ce
+    .word   0x5a77415b
+
+
+    .word   0x559531dd
+    .word   0xd57a2584
+    .word   0xa2e90469
+    .word   0x495fb700
+    .word   0x4cd49d0b
+    .word   0xb49ccf02
+    .word   0xe2d761a0
+    .word   0xd435f26
+
+
+    .word   0x146ca2bb
+    .word   0xc75de780
+    .word   0xb1f2c627
+    .word   0x8f202a9f
+    .word   0x2acf9849
+    .word   0x53b3f85e
+    .word   0x7ee73a8
+    .word   0xbb376544
+
+
+    .word   0xe09dd6c9
+    .word   0xa008a754
+    .word   0xf4a0974
+    .word   0x12427e70
+    .word   0x5db8b859
+    .word   0x501051b6
+    .word   0x7269b807
+    .word   0x8e2a42c0
+
+
+    .word   0xde71d5b2
+    .word   0x86f76f08
+    .word   0xa7e52ee5
+    .word   0x8817e599
+    .word   0xd1c05790
+    .word   0x49547bdf
+    .word   0x9f855285
+    .word   0x918e4d65
+
+
+    .word   0xbe19d0b3
+    .word   0x13429a06
+    .word   0x193cce98
+    .word   0x3d7ed741
+    .word   0x9aa4588f
+    .word   0xc6f63182
+    .word   0x98d35ebb
+    .word   0xd878dfca
+
+
+    .word   0x82046f03
+    .word   0xc4a5ae26
+    .word   0xddfb7551
+    .word   0xa2a511ee
+    .word   0x43afaff
+    .word   0x51da797e
+    .word   0x9445eea8
+    .word   0x98a95d92
+
+
+    .word   0x565dc4e5
+    .word   0x3fae2057
+    .word   0xe18ba196
+    .word   0xfee53a94
+    .word   0x4203402e
+    .word   0x60b5da4a
+    .word   0x5b41d80a
+    .word   0xdc799c29
+
+
+    .word   0x6fe81bdf
+    .word   0x5bebc969
+    .word   0x62860cd6
+    .word   0x7750df41
+    .word   0x470491ae
+    .word   0xafba594b
+    .word   0x36e6db18
+    .word   0xfb15dd13
+
+
+    .word   0xc8609622
+    .word   0x6bd39ba9
+    .word   0xba4de2d7
+    .word   0xf9ed6640
+    .word   0x7d4f6861
+    .word   0x133922c5
+    .word   0xb9f54002
+    .word   0x6c004d76
+
+
+    .word   0xc8c253fd
+    .word   0x498d46df
+    .word   0xc458ad6
+    .word   0xfb12927f
+    .word   0x800f48bb
+    .word   0xe2d761a0
+    .word   0x667eef4e
+    .word   0x86515b41
+
+
+    .word   0x49547bdf
+    .word   0x870fb66c
+    .word   0x36445ff2
+    .word   0xab5b4d5b
+    .word   0x8e2a42c0
+    .word   0xb8f04a14
+    .word   0x8a24fa06
+    .word   0xd2d0a674
+
+
+    .word   0x5f2e0b4e
+    .word   0x6c528ce
+    .word   0x50b683bc
+    .word   0x56ff1898
+    .word   0xe7603e9f
+    .word   0x9622c0f2
+    .word   0x9e29b704
+    .word   0xf5879b4b
+
+
+    .word   0x73190986
+    .word   0x78d9379d
+    .word   0x54494c74
+    .word   0x161a34a0
+    .word   0xdc6bb897
+    .word   0x77f4d015
+    .word   0x116b67ef
+    .word   0xefdf3d8e
+
+
+    .word   0xb0d43e61
+    .word   0x8becb4d4
+    .word   0x2c1b9c17
+    .word   0x356f938a
+    .word   0x6b7d0577
+    .word   0x44ec00b2
+    .word   0xb4a500fb
+    .word   0x3ae0e67c
+
+
+    .word   0xd99b4577
+    .word   0x76d23a33
+    .word   0x823f7e94
+    .word   0x43ceddc7
+    .word   0x4605a2fb
+    .word   0xa5b34a34
+    .word   0x40d42952
+    .word   0xdcb69997
+
+
+    .word   0xf2c65798
+    .word   0x2f2e10e0
+    .word   0x5eeba69c
+    .word   0x83fba4a5
+    .word   0xf55893f3
+    .word   0xbddb02ee
+    .word   0x2d548127
+    .word   0x30a53002
+
+
+    .word   0x6102dbe5
+    .word   0x667eef4e
+    .word   0xd1c05790
+    .word   0x43577a6
+    .word   0x56b6d976
+    .word   0xdd8b2b45
+    .word   0xc12124cf
+    .word   0x22163d6d
+
+
+    .word   0x93490e5e
+    .word   0x2196534c
+    .word   0x97f5cb97
+    .word   0x4acf5617
+    .word   0x111bb074
+    .word   0xfd166662
+    .word   0x28d0acac
+    .word   0x36445ff2
+
+
+    .word   0x7269b807
+    .word   0x412f3360
+    .word   0xfb12927f
+    .word   0xb49ccf02
+    .word   0xc8b1e790
+    .word   0xaf8f040d
+    .word   0xf2970133
+    .word   0xad1d34d9
+
+
+    .word   0x9300c15f
+    .word   0x6dc88d13
+    .word   0xec0ea4e4
+    .word   0xf9b020ef
+    .word   0x4f92dccf
+    .word   0xf2faa416
+    .word   0x46a87d1a
+    .word   0x51e9168b
+
+
+    .word   0x1a83efaa
+    .word   0x84c8538e
+    .word   0x5a77415b
+    .word   0xc71795dd
+    .word   0xd0042cf3
+    .word   0xa400fc17
+    .word   0x679a5d8
+    .word   0x5ae703ab
+
+
+    .word   0x922a8fcf
+    .word   0x9de1a35a
+    .word   0xca0cf4bb
+    .word   0xfecaf6fa
+    .word   0x6f27ed5b
+    .word   0xcbb1ba1c
+    .word   0x187c53af
+    .word   0xe9e8d5b5
+
+
+    .word   0x38802b43
+    .word   0x9e57a0fe
+    .word   0xdbdb0205
+    .word   0xd8b96c21
+    .word   0xb75306bc
+    .word   0x1979e129
+    .word   0x4e9e1255
+    .word   0xb47a413f
+
+
+    .word   0x9daf1568
+    .word   0x60b5da4a
+    .word   0xc50bd96b
+    .word   0xf18b2c6d
+    .word   0xc1955808
+    .word   0xcbfbbb15
+    .word   0x9e33d9e
+    .word   0xaa90f4fa
+
+
+    .word   0x87720821
+    .word   0x737f6957
+    .word   0x9a71f932
+    .word   0x41c5163c
+    .word   0xc32b6979
+    .word   0x3eaf1806
+    .word   0x40b7c3e8
+    .word   0xc0c9e2f1
+
+
+    .word   0x700bf290
+    .word   0x6c528ce
+    .word   0xfd166662
+    .word   0x870fb66c
+    .word   0x501051b6
+    .word   0x330a4a3f
+    .word   0xc51c831a
+    .word   0x6727202c
+
+
+    .word   0x554c50ff
+    .word   0xf2652278
+    .word   0x9fd30b37
+    .word   0xcf1a738c
+    .word   0x32274e59
+    .word   0xfe47001b
+    .word   0x24330c04
+    .word   0x7269b807
+
+
+    .word   0xc458ad6
+    .word   0x4cd49d0b
+    .word   0x61e545dd
+    .word   0x82e1dbd5
+    .word   0xda9b3433
+    .word   0xdb66a70a
+    .word   0xcfb8828
+    .word   0x17dd1158
+
+
+    .word   0xe9013cfd
+    .word   0xe104ac48
+    .word   0x344d8e28
+    .word   0xfffc65e6
+    .word   0x2e94534b
+    .word   0x71e6c63
+    .word   0xe0157c5f
+    .word   0xc9718fa6
+
+
+    .word   0x40d0d276
+    .word   0x18db9b71
+    .word   0x9c4f6eb6
+    .word   0xfca199b1
+    .word   0x40cf0699
+    .word   0xb8f04a14
+    .word   0xf8f1f4b1
+    .word   0x63c9eceb
+
+
+    .word   0xfe8437d3
+    .word   0x93fa1fed
+    .word   0x133922c5
+    .word   0x1ce791e0
+    .word   0xe7a0ef14
+    .word   0xe638ec12
+    .word   0x5063360b
+    .word   0x679a5d8
+
+
+    .word   0x64dd6006
+    .word   0x6b90f498
+    .word   0xfc010612
+    .word   0x56b49100
+    .word   0x931ad4d4
+    .word   0x870e3996
+    .word   0xd958c40a
+    .word   0xf97eebd3
+
+
+    .word   0xb339c220
+    .word   0xad2678ab
+    .word   0x6b02c057
+    .word   0xae227839
+    .word   0xc47e779f
+    .word   0x700bf290
+    .word   0x111bb074
+    .word   0x49547bdf
+
+
+    .word   0x5db8b859
+    .word   0x9b28c794
+    .word   0x8fb63e24
+    .word   0xb32f2521
+    .word   0x62ca89f2
+    .word   0xd9e53a83
+    .word   0xea73a546
+    .word   0xa4dfdf36
+
+
+    .word   0x44a24274
+    .word   0xfd95ded1
+    .word   0x60eb5092
+    .word   0x2d811cd7
+    .word   0x5a88365e
+    .word   0x4728c057
+    .word   0x22838f1f
+    .word   0x9ad7dfa3
+
+
+    .word   0xebbe292d
+    .word   0x947d5854
+    .word   0xe87aa3ed
+    .word   0x690b61ce
+    .word   0xfe47001b
+    .word   0x36445ff2
+    .word   0x498d46df
+    .word   0x495fb700
+
+
+    .word   0x7e01342
+    .word   0x8f5e220e
+    .word   0x3bfa34f4
+    .word   0xc442dbb4
+    .word   0xb8ca42b9
+    .word   0x9faa3620
+    .word   0xb4669afd
+    .word   0x2b26f9d2
+
+
+    .word   0xbe2fab2
+    .word   0x68317ab4
+    .word   0xfa5cdbad
+    .word   0x8fd0e4a1
+    .word   0xbe95f632
+    .word   0x7f16bc7b
+    .word   0x607f2e77
+    .word   0x5b9e81ef
+
+
+    .word   0xac22adff
+    .word   0xe4bb9e9c
+    .word   0x7fdac1c3
+    .word   0x35cf9878
+    .word   0x1e7eaa4c
+    .word   0xdadd2e14
+    .word   0xb594c2a6
+    .word   0x536dcaf5
+
+
+    .word   0xe1bbee7f
+    .word   0x1979e129
+    .word   0x5f3410ce
+    .word   0xfee53a94
+    .word   0x593e9f72
+    .word   0xd91afde4
+    .word   0xf10dfee8
+    .word   0xe9a2d62b
+
+
+    .word   0xae227839
+    .word   0xc0c9e2f1
+    .word   0x4acf5617
+    .word   0x86515b41
+    .word   0x12427e70
+    .word   0x9a623a99
+    .word   0xe638ec12
+    .word   0xa400fc17
+
+
+    .word   0xf4822a32
+    .word   0x13b934a5
+    .word   0x13349e00
+    .word   0x1b5dcd91
+    .word   0xb3e573f3
+    .word   0x98d35ebb
+    .word   0x4098e9dd
+    .word   0x5019cb61
+
+
+    .word   0x1ed27429
+    .word   0xa2a511ee
+    .word   0xc213bdd0
+    .word   0x92c76cb0
+    .word   0xe1561c41
+    .word   0xd0ad8ec1
+    .word   0x407c4eba
+    .word   0xa5c88809
+
+
+    .word   0xff19ce2c
+    .word   0x39905430
+    .word   0x2d7476c3
+    .word   0x5fecce89
+    .word   0x712ad93e
+    .word   0xd3aba221
+    .word   0x16140abd
+    .word   0xb80dbfb
+
+
+    .word   0xbb0396ea
+    .word   0xe87aa3ed
+    .word   0x32274e59
+    .word   0x28d0acac
+    .word   0xc8c253fd
+    .word   0xa2e90469
+    .word   0xcc12d1b9
+    .word   0x1db58554
+
+
+    .word   0x8bcaf17b
+    .word   0xf3789239
+    .word   0x40471895
+    .word   0x26103c1f
+    .word   0xf1928b43
+    .word   0x20811ffd
+    .word   0x987c1eb6
+    .word   0xd9c6b2
+
+
+    .word   0xccaf6916
+    .word   0xc684a1cf
+    .word   0xb1e18c74
+    .word   0x6702c9b
+    .word   0x8d9a9811
+    .word   0xbdea803d
+    .word   0x6d82eb48
+    .word   0x3a464992
+
+
+    .word   0x71bbc24b
+    .word   0xfbc3e490
+    .word   0x33157409
+    .word   0xf10dfee8
+    .word   0x6b02c057
+    .word   0x40b7c3e8
+    .word   0x97f5cb97
+    .word   0x667eef4e
+
+
+    .word   0xf4a0974
+    .word   0x18db9b71
+    .word   0x580ab526
+    .word   0xab5b4d5b
+    .word   0x9bd4f3d2
+    .word   0x2ff151b8
+    .word   0x2f8ec7ef
+    .word   0x19970e2d
+
+
+    .word   0x4e0dcd8a
+    .word   0x5e9d3389
+    .word   0x753970bc
+    .word   0x9ebab348
+    .word   0x247d28da
+    .word   0xd00cfced
+    .word   0x429f809a
+    .word   0x62ac10fd
+
+
+    .word   0x224df9d9
+    .word   0x79013d60
+    .word   0xf2652278
+    .word   0xc72bc191
+    .word   0x6033ac5e
+    .word   0x12427e70
+    .word   0xe7a0ef14
+    .word   0xd0042cf3
+
+
+    .word   0x4a01e0d8
+    .word   0x6021ed07
+    .word   0x582a75db
+    .word   0x1a80dd9b
+    .word   0xd4062d7f
+    .word   0x65b9808
+    .word   0xedbf59fa
+    .word   0xbb434934
+
+
+    .word   0xf019d09b
+    .word   0xe638ec12
+    .word   0x19cec24d
+    .word   0xe392ef48
+    .word   0xfe2b9912
+    .word   0x7e745937
+    .word   0xb80dbfb
+    .word   0x947d5854
+
+
+    .word   0xcf1a738c
+    .word   0xfd166662
+    .word   0x6c004d76
+    .word   0xd57a2584
+    .word   0x43265e55
+    .word   0xdc514d13
+    .word   0xdb6827af
+    .word   0xc65d51f8
+
+
+    .word   0x1f3e4180
+    .word   0x40d42952
+    .word   0x7ca2877
+    .word   0x826fa8c6
+    .word   0xa405e19
+    .word   0x83fba4a5
+    .word   0x3a3727aa
+    .word   0x571254cb
+
+
+    .word   0xdaf3878b
+    .word   0xdadd2e14
+    .word   0xa5a05be2
+    .word   0xd8b96c21
+    .word   0x2c4dbcba
+    .word   0x3fae2057
+    .word   0xdc5f8d33
+    .word   0x5698f98e
+
+
+    .word   0xb78c0e7c
+    .word   0xc7b6f0c2
+    .word   0x56717bab
+    .word   0x590cb173
+    .word   0x17139d38
+    .word   0x99d21f84
+    .word   0xabd49c84
+    .word   0xea0716c3
+
+
+    .word   0x60e80d60
+    .word   0xd67b1a8c
+    .word   0x5dcfeace
+    .word   0xd2299c81
+    .word   0x13ab8104
+    .word   0xf213b180
+    .word   0x687e7218
+    .word   0xd8af67d4
+
+
+    .word   0xbae8d91f
+    .word   0xfc49716c
+    .word   0x488ab49c
+    .word   0xa0867222
+    .word   0x63a760c5
+    .word   0x399042b9
+    .word   0x7cca54b
+    .word   0xc05336d9
+
+
+    .word   0xcd737f0a
+    .word   0x562ef79f
+    .word   0x83b9e9d2
+    .word   0xd36e32e7
+    .word   0x9b5bba7d
+    .word   0x504575ea
+    .word   0xcc81f730
+    .word   0x8f619e7d
+
+
+    .word   0x52ba3e65
+    .word   0x883cf98a
+    .word   0x9ad7dfa3
+    .word   0x46a87d1a
+    .word   0xc72bc191
+    .word   0x86515b41
+    .word   0x1ce791e0
+    .word   0xc71795dd
+
+
+    .word   0x1ff68212
+    .word   0x493ce709
+    .word   0xb6854bfe
+    .word   0xfe2b9912
+    .word   0x16140abd
+    .word   0xebbe292d
+    .word   0x9fd30b37
+    .word   0x111bb074
+
+
+    .word   0xb9f54002
+    .word   0x559531dd
+    .word   0x58c9adcb
+    .word   0x3526878e
+    .word   0x52e4c04e
+    .word   0x2a6ca24f
+    .word   0x114c3252
+    .word   0x71e6c63
+
+
+    .word   0xaff4bae3
+    .word   0xb88531ae
+    .word   0xbb434934
+    .word   0x9a623a99
+    .word   0x8b136e64
+    .word   0xbd9f10f
+    .word   0x38a6df0e
+    .word   0x486b3695
+
+
+    .word   0xffeaa885
+    .word   0xbb8bcf5d
+    .word   0x21fc21d5
+    .word   0x1d90caf7
+    .word   0x4e82a2c6
+    .word   0x55360b5
+    .word   0xc67bdf55
+    .word   0x8a5d2341
+
+
+    .word   0x61ce517b
+    .word   0x2f5772ea
+    .word   0x4ff12527
+    .word   0x6fdc02c2
+    .word   0x499c2253
+    .word   0x44ec00b2
+    .word   0x28596d71
+    .word   0xf887e6bf
+
+
+    .word   0x1b928896
+    .word   0xfaa07c87
+    .word   0x91e8c716
+    .word   0x2166101d
+    .word   0x32a606d1
+    .word   0x40b7c3e8
+    .word   0xd2aec547
+    .word   0xc9718fa6
+
+
+    .word   0x3b0af6e8
+    .word   0x870fb66c
+    .word   0x5cc579d8
+    .word   0x89285e3e
+    .word   0x8da9ccec
+    .word   0xabe405a3
+    .word   0x73fa8cab
+    .word   0x6f6fff92
+
+
+    .word   0xaeecf5c7
+    .word   0x6b6d5bd1
+    .word   0xb84e5f91
+    .word   0xc5e3754c
+    .word   0x3f507d3e
+    .word   0xe066f37d
+    .word   0x43f1d0c5
+    .word   0x1da7eca7
+
+
+    .word   0xc8aed80d
+    .word   0x7056e418
+    .word   0xef87e65b
+    .word   0xeaeee493
+    .word   0x1b170f2f
+    .word   0x607f37a7
+    .word   0x8bd47db
+    .word   0x610abaf7
+
+
+    .word   0x493ce709
+    .word   0xe392ef48
+    .word   0xd3aba221
+    .word   0x9ad7dfa3
+    .word   0xf2652278
+    .word   0x4acf5617
+    .word   0x133922c5
+    .word   0x5a77415b
+
+
+    .word   0x5315e95b
+    .word   0x97246aa0
+    .word   0x65bee479
+    .word   0x25861494
+    .word   0xa4c0ebd2
+    .word   0x6d09b85a
+    .word   0x90585b10
+    .word   0x7930c606
+
+
+    .word   0xacb6695f
+    .word   0x24e1842a
+    .word   0xdfb725e6
+    .word   0xfee19267
+    .word   0x8785c3bb
+    .word   0xed8ed45d
+    .word   0x2e72dcb4
+    .word   0xf8f1f4b1
+
+
+    .word   0x455c7c0e
+    .word   0x65b9808
+    .word   0xa4cd7f9
+    .word   0x1ce791e0
+    .word   0xc036e770
+    .word   0x15c54f4a
+    .word   0x25dbf27a
+    .word   0xabbad7ad
+
+
+    .word   0x55b029d
+    .word   0x560566f4
+    .word   0xc3dff90f
+    .word   0xaff4bae3
+    .word   0xedbf59fa
+    .word   0x12427e70
+    .word   0x3c05e1ab
+    .word   0xe4d88d54
+
+
+    .word   0x8bcd161
+    .word   0x133f1bc
+    .word   0xe55adf34
+    .word   0x207c1ce7
+    .word   0x9d191b49
+    .word   0x9de1a35a
+    .word   0xefbb7c68
+    .word   0x75bd5e6e
+
+
+    .word   0xccfe2c1c
+    .word   0x482f4853
+    .word   0x768231d6
+    .word   0xc0cd06f3
+    .word   0xde1e8de0
+    .word   0xff9d5c3
+    .word   0x143bddf
+    .word   0xaad1e54d
+
+
+    .word   0x1af83ccb
+    .word   0x28d05653
+    .word   0x398eaaef
+    .word   0x6b040e4b
+    .word   0x8976f570
+    .word   0x571a8c39
+    .word   0xd869b300
+    .word   0x13b934a5
+
+
+    .word   0x55ffd8b9
+    .word   0x5ed0e876
+    .word   0x3052620e
+    .word   0xd878dfca
+    .word   0xc30b442d
+    .word   0x8bd47db
+    .word   0x1ff68212
+    .word   0x19cec24d
+
+
+    .word   0x712ad93e
+    .word   0x22838f1f
+    .word   0x554c50ff
+    .word   0x97f5cb97
+    .word   0x7d4f6861
+    .word   0x690b61ce
+    .word   0x512235b8
+    .word   0xbf276fd1
+
+
+    .word   0x295f6377
+    .word   0x3ebea65a
+    .word   0xe392ef48
+    .word   0x883cf98a
+    .word   0x79013d60
+    .word   0xc0c9e2f1
+    .word   0x93fa1fed
+    .word   0x84c8538e
+
+
+    .word   0xe7eedd8a
+    .word   0x11f0ed80
+    .word   0xf0435880
+    .word   0x582f953b
+    .word   0xb720dfe3
+    .word   0xbed89417
+    .word   0x9a049fe1
+    .word   0x7d00083c
+
+
+    .word   0xe90b0aa8
+    .word   0x7750df41
+    .word   0x266141d3
+    .word   0x6dfc75a8
+    .word   0x4b837c9d
+    .word   0xb3c205b3
+    .word   0x446ba870
+    .word   0xb53d65d
+
+
+    .word   0x6dca6db3
+    .word   0x6e2b2ae9
+    .word   0x80197095
+    .word   0x9d722907
+    .word   0x76a44a44
+    .word   0x13a14b1a
+    .word   0xab991b18
+    .word   0x1944aa93
+
+
+    .word   0x41c12471
+    .word   0x8fa5fade
+    .word   0x15f13abc
+    .word   0x8148c6ef
+    .word   0x827d2911
+    .word   0x83462e8a
+    .word   0xa98ab575
+    .word   0xd8632ca0
+
+
+    .word   0x5c90a029
+    .word   0xfaa07c87
+    .word   0x6cbab7e8
+    .word   0xf10dfee8
+    .word   0x560566f4
+    .word   0x71e6c63
+    .word   0x65b9808
+    .word   0x86515b41
+
+
+    .word   0x4255edcd
+    .word   0x138e9846
+    .word   0x1f17d50b
+    .word   0x4ea1b0ba
+    .word   0x4250c5e6
+    .word   0x9735cd25
+    .word   0xb33c0729
+    .word   0xccb2f2d1
+
+
+    .word   0x7df17fb3
+    .word   0x3d5b7283
+    .word   0xbe0f3714
+    .word   0x6e836b90
+    .word   0x88f41ba5
+    .word   0x2631b399
+    .word   0x550742c6
+    .word   0xa9f005e3
+
+
+    .word   0x9bfa9c30
+    .word   0xa5a05be2
+    .word   0xf587933e
+    .word   0x5aab09bd
+    .word   0xec64a872
+    .word   0xad0fc6ac
+    .word   0x4bf97d70
+    .word   0xdcce22c7
+
+
+    .word   0x32c75025
+    .word   0xa6391fa5
+    .word   0x8f6ff684
+    .word   0x52505c21
+    .word   0x5c069d2d
+    .word   0x161a34a0
+    .word   0xb219d496
+    .word   0x707c7ce1
+
+
+    .word   0xd646a46a
+    .word   0x295f6377
+    .word   0x493ce709
+    .word   0x52ba3e65
+    .word   0x224df9d9
+    .word   0xae227839
+    .word   0xfe8437d3
+    .word   0x1a83efaa
+
+
+    .word   0xde297811
+    .word   0x26f20a46
+    .word   0x1727c38c
+    .word   0x7c121dc0
+    .word   0x65ffbfc
+    .word   0xcc12d1b9
+    .word   0x32cd67db
+    .word   0x1db7e27f
+
+
+    .word   0x8fdb1821
+    .word   0x26103c1f
+    .word   0x6327126d
+    .word   0xf62f4242
+    .word   0x191b7cc8
+    .word   0x95e967d5
+    .word   0x728b3375
+    .word   0xdc514d13
+
+
+    .word   0x60b3050c
+    .word   0x47fd2aef
+    .word   0xde6dc285
+    .word   0xdcb69997
+    .word   0x42234db1
+    .word   0xa34b9cd6
+    .word   0x50ed2b92
+    .word   0x95cdf1a8
+
+
+    .word   0xa73656be
+    .word   0xed8ed45d
+    .word   0x4000d88e
+    .word   0x1a80dd9b
+    .word   0x4cd42187
+    .word   0x93fa1fed
+    .word   0xf7e59a10
+    .word   0x16ac312c
+
+
+    .word   0xad6d671b
+    .word   0x21c8001e
+    .word   0xcdf5c0f9
+    .word   0x7d7d349a
+    .word   0xfd7770a4
+    .word   0x8f5e220e
+    .word   0x55cc2ceb
+    .word   0x6e0e8ed6
+
+
+    .word   0x8a522969
+    .word   0xc5ad3c96
+    .word   0x9226effc
+    .word   0x51d8ee39
+    .word   0x9c75191f
+    .word   0x6cbab7e8
+    .word   0x55b029d
+    .word   0x114c3252
+
+
+    .word   0xd4062d7f
+    .word   0x4acf5617
+    .word   0x31ee0298
+    .word   0x5a422a93
+    .word   0xabb9b291
+    .word   0xf286b289
+    .word   0xe25c66ae
+    .word   0x429f809a
+
+
+    .word   0x6c5ca5e6
+    .word   0x560566f4
+    .word   0x455c7c0e
+    .word   0xc72bc191
+    .word   0x97adad9c
+    .word   0x7c12745a
+    .word   0x57c98c70
+    .word   0xe336e089
+
+
+    .word   0xe9716550
+    .word   0x9fb26281
+    .word   0x113f9a91
+    .word   0xe2126d41
+    .word   0x853d1297
+    .word   0xf5625eb0
+    .word   0xd49f1d5d
+    .word   0x935f10a0
+
+
+    .word   0x707c7ce1
+    .word   0xbf276fd1
+    .word   0x610abaf7
+    .word   0x8f619e7d
+    .word   0x62ac10fd
+    .word   0xe9a2d62b
+    .word   0x63c9eceb
+    .word   0x51e9168b
+
+
+    .word   0xed0ed9ab
+    .word   0x522ebb4d
+    .word   0xbdf8c1c1
+    .word   0x8d64a2b5
+    .word   0xefc37e2e
+    .word   0x7e8f6b57
+    .word   0xac54941
+    .word   0xcca35ba0
+
+
+    .word   0xa79a0ae2
+    .word   0x84380f53
+    .word   0x61115f3a
+    .word   0x1472441a
+    .word   0x27dc5b43
+    .word   0x92437e04
+    .word   0xc826d80e
+    .word   0x3a1602f2
+
+
+    .word   0xaa3a949f
+    .word   0xbc7caf85
+    .word   0xc18a47b
+    .word   0xd33c5b58
+    .word   0x4d1b9507
+    .word   0x84ca46fc
+    .word   0xc9a3ba5
+    .word   0xaf4abb17
+
+
+    .word   0x31d38612
+    .word   0x3a3727aa
+    .word   0xf6a7a7c4
+    .word   0xae63e09e
+    .word   0x944d6758
+    .word   0xd8b96c21
+    .word   0x211fe214
+    .word   0x3d1afe35
+
+
+    .word   0x3c2b4be
+    .word   0x359e62ba
+    .word   0xa98a3a9a
+    .word   0x5aa6221a
+    .word   0xbd264c04
+    .word   0xd3aba221
+    .word   0xd8d62b90
+    .word   0xd24dbc50
+
+
+    .word   0x6acb60d2
+    .word   0x4ba87931
+    .word   0xbd050034
+    .word   0xed717c47
+    .word   0xf2fd37a0
+    .word   0x8dcd3226
+    .word   0x23e13d2a
+    .word   0xd444ed54
+
+
+    .word   0xb870426a
+    .word   0xa6f7849f
+    .word   0xd6728f3b
+    .word   0xb03a5a39
+    .word   0x7fcca7d0
+    .word   0x722ec1cf
+    .word   0x51d8ee39
+    .word   0xfaa07c87
+
+
+    .word   0xabbad7ad
+    .word   0x2a6ca24f
+    .word   0x1a80dd9b
+    .word   0xc0c9e2f1
+    .word   0x2857e962
+    .word   0xd8a93e56
+    .word   0x33dcecc7
+    .word   0xbc7019fa
+
+
+    .word   0xfabebd97
+    .word   0x8b629757
+    .word   0xdd81467e
+    .word   0x2b537af3
+    .word   0xa6ea0873
+    .word   0xcea88f72
+    .word   0x580f8557
+    .word   0xd49f1d5d
+
+
+    .word   0xb219d496
+    .word   0x512235b8
+    .word   0x8bd47db
+    .word   0xcc81f730
+    .word   0x429f809a
+    .word   0xf10dfee8
+    .word   0xf8f1f4b1
+    .word   0x46a87d1a
+
+
+    .word   0x9085ba94
+    .word   0xf33eead9
+    .word   0xd3502fba
+    .word   0xa66ac66e
+    .word   0xf904b14d
+    .word   0x3c6cc722
+    .word   0x3710c196
+    .word   0x37ad8467
+
+
+    .word   0xeabc1d6d
+    .word   0x82e1dbd5
+    .word   0x2a20c389
+    .word   0x3ac91322
+    .word   0x6ebca184
+    .word   0xac07d54c
+    .word   0x36ba0a03
+    .word   0x75c8eb0b
+
+
+    .word   0x10e8f88f
+    .word   0x86710fb7
+    .word   0x976f9953
+    .word   0x6b7981bc
+    .word   0xbf0d8618
+    .word   0x3489b918
+    .word   0xa7ea0ac2
+    .word   0x776f5422
+
+
+    .word   0xc4b525d7
+    .word   0xd9b37974
+    .word   0x9083f1ce
+    .word   0xd869b300
+    .word   0x56c11aa1
+    .word   0x6e3fb400
+    .word   0xd1442e1
+    .word   0xa8e9c4af
+
+
+    .word   0x3702a43a
+    .word   0xa34b9cd6
+    .word   0x2d24eeb
+    .word   0xfee19267
+    .word   0xebca6ec9
+    .word   0x6021ed07
+    .word   0x92e3f5c1
+    .word   0x63c9eceb
+
+
+    .word   0x559c201b
+    .word   0xfc23b623
+    .word   0xb5cc2774
+    .word   0xcf6c0eeb
+    .word   0xf509901f
+    .word   0xc67bdf55
+    .word   0x38d6b1b9
+    .word   0x32754a12
+
+
+    .word   0xc1663a03
+    .word   0x6fdc02c2
+    .word   0x33afdb76
+    .word   0x78390531
+    .word   0xb28bd15d
+    .word   0x90fe0270
+    .word   0x1a3b2c0f
+    .word   0x1f27a7b9
+
+
+    .word   0x84be7671
+    .word   0xb676441
+    .word   0x1a7673fa
+    .word   0xc0302956
+    .word   0x98566d31
+    .word   0x972f1fc6
+    .word   0xc7d5be97
+    .word   0x7fcca7d0
+
+
+    .word   0x9226effc
+    .word   0x5c90a029
+    .word   0x25dbf27a
+    .word   0x52e4c04e
+    .word   0x582a75db
+    .word   0xae227839
+    .word   0x8b5003c4
+    .word   0x1e373473
+
+
+    .word   0x8bdf245c
+    .word   0xbc5b10dd
+    .word   0x6e836b90
+    .word   0x7d6e477e
+    .word   0xf2e60e59
+    .word   0x571254cb
+    .word   0x1a98784c
+    .word   0x139f7c52
+
+
+    .word   0x74a92f69
+    .word   0xd48d6ce
+    .word   0x76a0ff11
+    .word   0x23cf47f5
+    .word   0xd8e9745c
+    .word   0xf286b289
+    .word   0x1dcbcc9c
+    .word   0xabbad7ad
+
+
+    .word   0x4000d88e
+    .word   0x79013d60
+    .word   0x68432e07
+    .word   0xf394e79a
+    .word   0x76674d20
+    .word   0xcdc49750
+    .word   0x5a7b1f2e
+    .word   0x8bd47db
+
+
+    .word   0xe25c66ae
+    .word   0x6cbab7e8
+    .word   0x2e72dcb4
+    .word   0x9ad7dfa3
+    .word   0x2d7d6692
+    .word   0x768a1fe8
+    .word   0x776b1447
+    .word   0xbe361740
+
+
+    .word   0x94898b31
+    .word   0x1a572891
+    .word   0x61d87124
+    .word   0x35d53cb2
+    .word   0x5b8a873d
+    .word   0x239e01c3
+    .word   0x8c25f34a
+    .word   0xa6edb8d9
+
+
+    .word   0x1e58a710
+    .word   0x4112a64
+    .word   0x37c5bab0
+    .word   0x9337a897
+    .word   0x93c1a8f4
+    .word   0x399042b9
+    .word   0x9082f171
+    .word   0x44b5dbe7
+
+
+    .word   0x116f3c7c
+    .word   0xa73e7ec8
+    .word   0x3c265491
+    .word   0x62945817
+    .word   0x668bc98f
+    .word   0xddeac2b9
+    .word   0xa4c6bcb9
+    .word   0xee77ab21
+
+
+    .word   0x15b49b3e
+    .word   0x8fd0e4a1
+    .word   0x9a854934
+    .word   0x693123b3
+    .word   0x9445e1d6
+    .word   0x9e5820f9
+    .word   0x6feb5ca8
+    .word   0x62a8c57
+
+
+    .word   0x37ad1a11
+    .word   0xfc819fd
+    .word   0x33902b0b
+    .word   0x2487fe11
+    .word   0x1be076fe
+    .word   0x7724c019
+    .word   0xb7bbf5b0
+    .word   0x78cbc8e3
+
+
+    .word   0x788d44d0
+    .word   0x3c05e1ab
+    .word   0x30588589
+    .word   0x1fc27d92
+    .word   0xad6ec3ef
+    .word   0x207c1ce7
+    .word   0x563e8299
+    .word   0xb2fef123
+
+
+    .word   0x972f1fc6
+    .word   0xb03a5a39
+    .word   0xc5ad3c96
+    .word   0xd8632ca0
+    .word   0x15c54f4a
+    .word   0x3526878e
+    .word   0x6021ed07
+    .word   0xe9a2d62b
+
+
+    .word   0x78e6e200
+    .word   0x619ab5b3
+    .word   0x20027a84
+    .word   0xd0dedbe7
+    .word   0xa69e5bd5
+    .word   0x1d1d7a3c
+    .word   0xfeec80bb
+    .word   0x728b3375
+
+
+    .word   0xe1495770
+    .word   0x2d583432
+    .word   0x1a236d1b
+    .word   0xa8c5ae07
+    .word   0x4a742c0b
+    .word   0xe83ce574
+    .word   0xce9c14ff
+    .word   0x2da3d87
+
+
+    .word   0x609e35e7
+    .word   0xa1f3c789
+    .word   0xdbe0889a
+    .word   0x10a7341b
+    .word   0x1b41c865
+    .word   0x1bc8f90
+    .word   0xd8634792
+    .word   0xc5701778
+
+
+    .word   0xc1ea0938
+    .word   0x4fbc875e
+    .word   0xaed5cf7a
+    .word   0xdbf508d2
+    .word   0x21e5480f
+    .word   0x92c76cb0
+    .word   0x80f8498d
+    .word   0xfd02210d
+
+
+    .word   0x4dc73c3
+    .word   0x95c206de
+    .word   0xcdc49750
+    .word   0x512235b8
+    .word   0xf286b289
+    .word   0xfaa07c87
+    .word   0xed8ed45d
+    .word   0x883cf98a
+
+
+    .word   0x5034389d
+    .word   0xe1718801
+    .word   0xce929793
+    .word   0xe0d75039
+    .word   0x31bf9a75
+    .word   0x5a4f28a5
+    .word   0xa2e2f14
+    .word   0xdbe91c01
+
+
+    .word   0x90b120b7
+    .word   0x1a98784c
+    .word   0x8d12ecc9
+    .word   0x8a234e0d
+    .word   0x2e1e35c4
+    .word   0x3866de5
+    .word   0xacbfc1ea
+    .word   0x26f20a46
+
+
+    .word   0xbdf5e0d8
+    .word   0x93d46640
+    .word   0x3b19f31c
+    .word   0x1db58554
+    .word   0x72cf1d6e
+    .word   0x953d5d26
+    .word   0xd823169d
+    .word   0xa287f565
+
+
+    .word   0xb58614fd
+    .word   0x962d0193
+    .word   0x9fa67366
+    .word   0x48492848
+    .word   0x9a3894df
+    .word   0x139ddf05
+    .word   0xef60c3e2
+    .word   0xb1fd6af0
+
+
+    .word   0xf696f008
+    .word   0x2528fe85
+    .word   0x3d1afe35
+    .word   0xbf61d49b
+    .word   0x77371f4c
+    .word   0x610abaf7
+    .word   0xdab01f9a
+    .word   0x21c03eff
+
+
+    .word   0xe7da5b64
+    .word   0x563e8299
+    .word   0x98566d31
+    .word   0xd6728f3b
+    .word   0x8a522969
+    .word   0xa98ab575
+    .word   0xc036e770
+    .word   0x58c9adcb
+
+
+    .word   0x4a01e0d8
+    .word   0xf10dfee8
+    .word   0xc1847cba
+    .word   0xc6e4a788
+    .word   0x136f5408
+    .word   0xfa08b3da
+    .word   0xeb46aa5f
+    .word   0xc090873e
+
+
+    .word   0xbdf06b72
+    .word   0xfa5f5d4b
+    .word   0x2c573358
+    .word   0x17b4b2d0
+    .word   0x400880b8
+    .word   0x2043a5a8
+    .word   0xb825324
+    .word   0x6bfe46bb
+
+
+    .word   0xd5fecf97
+    .word   0xb8b16d3
+    .word   0x1aa448c8
+    .word   0xad3eb891
+    .word   0x5c1d59a1
+    .word   0xb8845850
+    .word   0x926f749
+    .word   0xcd525174
+
+
+    .word   0x207c82e6
+    .word   0xd48d6ce
+    .word   0xfeec88c7
+    .word   0x5a422a93
+    .word   0x8279bd27
+    .word   0x15c54f4a
+    .word   0xebca6ec9
+    .word   0x62ac10fd
+
+
+    .word   0x38da98f9
+    .word   0xaf7fa14c
+    .word   0xf7d98f47
+    .word   0x63c9c2de
+    .word   0xba6f9d73
+    .word   0xd79a3dc
+    .word   0xfdb8f917
+    .word   0x222c860d
+
+
+    .word   0xf59337e7
+    .word   0x43483082
+    .word   0x3f657569
+    .word   0xbc639c47
+    .word   0x6f95812c
+    .word   0x4dc73c3
+    .word   0x76674d20
+    .word   0xb219d496
+
+
+    .word   0xabb9b291
+    .word   0x5c90a029
+    .word   0x8785c3bb
+    .word   0x52ba3e65
+    .word   0x8c16f329
+    .word   0x859b16bd
+    .word   0x66a644a1
+    .word   0x5a6407b6
+
+
+    .word   0x9c821ee5
+    .word   0xcdc49750
+    .word   0xd8e9745c
+    .word   0x51d8ee39
+    .word   0xa73656be
+    .word   0xe392ef48
+    .word   0xf65d241b
+    .word   0x729c6c34
+
+
+    .word   0x721edacf
+    .word   0xa818d2a0
+    .word   0x3489b918
+    .word   0x8eb7a86a
+    .word   0xd5503605
+    .word   0x6b040e4b
+    .word   0x29cae9c7
+    .word   0xc6fd2e4b
+
+
+    .word   0xfe00a26d
+    .word   0x2bd0be99
+    .word   0x37d054b7
+    .word   0x8f43a09d
+    .word   0x8f1b0b40
+    .word   0x619b77b6
+    .word   0xeca10d44
+    .word   0xeca13908
+
+
+    .word   0x3aef145f
+    .word   0x102fbf8e
+    .word   0x2f27087a
+    .word   0x301abff8
+    .word   0xc0428ea2
+    .word   0x5d345dc
+    .word   0x6d1ad911
+    .word   0x84ca46fc
+
+
+    .word   0x5896da94
+    .word   0x69d6cdf7
+    .word   0xdbe91c01
+    .word   0x571254cb
+    .word   0x2d2e037a
+    .word   0xa89809c2
+    .word   0xdc1af42d
+    .word   0x9be320e4
+
+
+    .word   0xa8c5bfd6
+    .word   0xf7e59a10
+    .word   0xf4fc9b0e
+    .word   0x27a4b1f3
+    .word   0x8f613315
+    .word   0x7d7d349a
+    .word   0x29e100a3
+    .word   0x5469e046
+
+
+    .word   0x1b9b9223
+    .word   0x8f186c77
+    .word   0x5e41d968
+    .word   0xf6f3cf04
+    .word   0xb90a80b0
+    .word   0x11f0ed80
+    .word   0xa24932c0
+    .word   0xbf3aaf1b
+
+
+    .word   0x475dcd80
+    .word   0xbdcc57b8
+    .word   0xa54d9cf1
+    .word   0x9012edbf
+    .word   0xafc6af7f
+    .word   0x8335b073
+    .word   0x3e539a88
+    .word   0x79f6582
+
+
+    .word   0xd8479a7
+    .word   0xd2299c81
+    .word   0x733cb242
+    .word   0x9b29b91b
+    .word   0x8e7964df
+    .word   0x4ddf9e8c
+    .word   0x74642902
+    .word   0x216ad7e5
+
+
+    .word   0x24750d75
+    .word   0x2d24eeb
+    .word   0xe18d880e
+    .word   0xdab01f9a
+    .word   0x7b3a5efc
+    .word   0x7dac54ff
+    .word   0x25007529
+    .word   0x505ffe48
+
+
+    .word   0x95e2f495
+    .word   0x9ece01e2
+    .word   0xc34453ad
+    .word   0xc3e0a749
+    .word   0x6b8f7a8b
+    .word   0xf4053ca0
+    .word   0x3c9d6cd1
+    .word   0x90746d6
+
+
+    .word   0xbc639c47
+    .word   0xfd02210d
+    .word   0xf394e79a
+    .word   0xd49f1d5d
+    .word   0x5a422a93
+    .word   0xd8632ca0
+    .word   0xfee19267
+    .word   0x8f619e7d
+
+
+    .word   0x43b45dfd
+    .word   0x4629ae53
+    .word   0xd7c2eb2d
+    .word   0xe0072fc0
+    .word   0xd01d8c92
+    .word   0xf28f7854
+    .word   0x735a188e
+    .word   0xff2f7212
+
+
+    .word   0xfe3608c7
+    .word   0x8b220422
+    .word   0xa8004cb9
+    .word   0x456f2ee7
+    .word   0xcf3f683a
+    .word   0xc526be50
+    .word   0x5a6407b6
+    .word   0x95c206de
+
+
+    .word   0x23cf47f5
+    .word   0x722ec1cf
+    .word   0x95cdf1a8
+    .word   0x3ebea65a
+    .word   0x77cbff4d
+    .word   0x2f816cbd
+    .word   0x9b409ac8
+    .word   0xd555aee3
+
+
+    .word   0x17094327
+    .word   0x30e4d185
+    .word   0x80416fd7
+    .word   0xce29ff51
+    .word   0x4a13ec5c
+    .word   0x3526878e
+    .word   0x4f552d35
+    .word   0x31eeccbd
+
+
+    .word   0x9fc34e7c
+    .word   0x7559dd9
+    .word   0x4581b0ba
+    .word   0xc1d60f1f
+    .word   0x5b46185e
+    .word   0xad0fc6ac
+    .word   0xead442a9
+    .word   0x60c6a2
+
+
+    .word   0x1c5a7c8a
+    .word   0xec86a1ee
+    .word   0xcb36556a
+    .word   0x1536171b
+    .word   0xa1139133
+    .word   0x211fe214
+    .word   0x1be68094
+    .word   0x5a7b1f2e
+
+
+    .word   0x78886a0e
+    .word   0x5aa6221a
+    .word   0x3392de35
+    .word   0xd209ed73
+    .word   0x7ffbe7da
+    .word   0x48748930
+    .word   0x3def0e1d
+    .word   0xfc23b623
+
+
+    .word   0x6d82f1fe
+    .word   0x68b07381
+    .word   0x69ff8f63
+    .word   0x8a5d2341
+    .word   0xe8d531d
+    .word   0x4529ee29
+    .word   0x37331380
+    .word   0xcca2df80
+
+
+    .word   0x51e03fbf
+    .word   0xe9e8a0d1
+    .word   0x15abfba3
+    .word   0x5896da94
+    .word   0xa2e2f14
+    .word   0xf2e60e59
+    .word   0x3f88c33e
+    .word   0x1db7b09a
+
+
+    .word   0x2d915021
+    .word   0x864375a3
+    .word   0x619ab5b3
+    .word   0x98cfb994
+    .word   0x275da5c9
+    .word   0xf62f4242
+    .word   0xb9bb54bc
+    .word   0xa122782b
+
+
+    .word   0x9597351e
+    .word   0x272157e4
+    .word   0xba8de71d
+    .word   0x139b4ca6
+    .word   0xd7b42143
+    .word   0xdb559502
+    .word   0x53890aff
+    .word   0x4e939a7a
+
+
+    .word   0x61b35c5b
+    .word   0x89285e3e
+    .word   0xe2a1d63e
+    .word   0x3c9d6cd1
+    .word   0x3f657569
+    .word   0x80f8498d
+    .word   0x68432e07
+    .word   0x580f8557
+
+
+    .word   0x31ee0298
+    .word   0xa98ab575
+    .word   0xdfb725e6
+    .word   0xcc81f730
+    .word   0xc1bb7fc2
+    .word   0x7e1c9292
+    .word   0x6fdbb2bc
+    .word   0xdc900bf4
+
+
+    .word   0xb0f79e82
+    .word   0x2b0de214
+    .word   0x104f397f
+    .word   0x182097a4
+    .word   0xaaf59991
+    .word   0x15bf91b4
+    .word   0x7cd59793
+    .word   0xb33f3b75
+
+
+    .word   0x7382ec1f
+    .word   0x859b16bd
+    .word   0x723681d0
+    .word   0xf394e79a
+    .word   0xfeec88c7
+    .word   0xc5ad3c96
+    .word   0x2d24eeb
+    .word   0x610abaf7
+
+
+    .word   0x2eca26be
+    .word   0xe808d17b
+    .word   0xc21af706
+    .word   0xcf3f683a
+    .word   0x66a644a1
+    .word   0x4dc73c3
+    .word   0x76a0ff11
+    .word   0x7fcca7d0
+
+
+    .word   0x50ed2b92
+    .word   0x295f6377
+    .word   0x58c6f2fd
+    .word   0x2f9d3e5a
+    .word   0x4d8bea88
+    .word   0xaadc756e
+    .word   0xbb74ecd2
+    .word   0xe9ee4d6
+
+
+    .word   0xbfef70f9
+    .word   0x21859d70
+    .word   0xca73e501
+    .word   0xacf24901
+    .word   0x1e1d78e9
+    .word   0xb2292ede
+    .word   0x95048c68
+    .word   0xc986bb0
+
+
+    .word   0x50c96adf
+    .word   0xd1442e1
+    .word   0x9905d541
+    .word   0x704dd543
+    .word   0x93905fdf
+    .word   0xfee19267
+    .word   0xb65cf982
+    .word   0xec132bea
+
+
+    .word   0xd4536cb
+    .word   0x4df55b09
+    .word   0xb1fd6af0
+    .word   0xa0535a61
+    .word   0x2749d607
+    .word   0x935f10a0
+    .word   0x2056bbf3
+    .word   0xc5013a36
+
+
+    .word   0xc3b2c49a
+    .word   0xe8509ab6
+    .word   0xf387da65
+    .word   0x9ecc81d2
+    .word   0x55c19270
+    .word   0x860f080d
+    .word   0x922a80f6
+    .word   0x81c3d4c7
+
+
+    .word   0x2e488897
+    .word   0x141fe81e
+    .word   0x7e7a868
+    .word   0xd1a8d5fd
+    .word   0xc724a395
+    .word   0x8f038b63
+    .word   0x64944725
+    .word   0x7724c019
+
+
+    .word   0xc7754d45
+    .word   0x2df5b017
+    .word   0x4a7dee18
+    .word   0xe4d88d54
+    .word   0x2bb1fb12
+    .word   0xc614fbf5
+    .word   0x18ab2d5f
+    .word   0xfd72047f
+
+
+    .word   0xa9c8b895
+    .word   0x4d47843b
+    .word   0xe546287f
+    .word   0xacbfc1ea
+    .word   0x3df1e154
+    .word   0x1bc4c1f1
+    .word   0x61898e1a
+    .word   0x9bf3d076
+
+
+    .word   0x3e385e99
+    .word   0x62daced1
+    .word   0x7634a69e
+    .word   0x8b5003c4
+    .word   0xe9e8a0d1
+    .word   0x84ca46fc
+    .word   0x5a4f28a5
+    .word   0x7d6e477e
+
+
+    .word   0x3ccd60d2
+    .word   0xdc0a0b58
+    .word   0xce9c3981
+    .word   0x4c4cf1db
+    .word   0x127a55e4
+    .word   0xaaa26de5
+    .word   0x3cc2cb85
+    .word   0xda4cf281
+
+
+    .word   0xd96dc128
+    .word   0x6b040e4b
+    .word   0xb7b5d520
+    .word   0x6b0e0e8b
+    .word   0x377826f8
+    .word   0xe5618819
+    .word   0xf1518c96
+    .word   0x4143dba6
+
+
+    .word   0xf91859d6
+    .word   0x9967fab4
+    .word   0x13c509f5
+    .word   0x95c9ac89
+    .word   0x97a9c66
+    .word   0x571a4815
+    .word   0xd9353116
+    .word   0xada544b4
+
+
+    .word   0x10664e33
+    .word   0x938f06c9
+    .word   0x3c3a855f
+    .word   0x438428af
+    .word   0x51a5574
+    .word   0x5e3c1b95
+    .word   0x1f1dff88
+    .word   0x18f13987
+
+
+    .word   0xe808d17b
+    .word   0x456f2ee7
+    .word   0x859b16bd
+    .word   0xfd02210d
+    .word   0xd48d6ce
+    .word   0xb03a5a39
+    .word   0xa34b9cd6
+    .word   0xbf276fd1
+
+
+    .word   0x4286aa28
+    .word   0x2d490f4d
+    .word   0x928ef6c5
+    .word   0xbb80ee5f
+    .word   0x35bd0c75
+    .word   0x8c25f34a
+    .word   0x60814ceb
+    .word   0x8aef8955
+
+
+    .word   0x2a4b3dd0
+    .word   0x9337a897
+    .word   0x965999bc
+    .word   0xe90b3c4c
+    .word   0xe87ebc95
+    .word   0x5768c1ca
+    .word   0xfe1da6a6
+    .word   0xcf0fd7da
+
+
+    .word   0x2fd9a9d0
+    .word   0xfeec88c7
+    .word   0x24750d75
+    .word   0x77371f4c
+    .word   0xc2830580
+    .word   0x86073aab
+    .word   0xe424b84c
+    .word   0x694fb53b
+
+
+    .word   0x411a7385
+    .word   0x8f7d4fdc
+    .word   0x2765adf0
+    .word   0x77da8a51
+    .word   0xa0a9040c
+    .word   0x6dfc75a8
+    .word   0x20e5de8a
+    .word   0x6bab4942
+
+
+    .word   0xc0acdf72
+    .word   0xc8bce30
+    .word   0xc7fe07b8
+    .word   0x24feb98f
+    .word   0x4d56a8aa
+    .word   0xf33eead9
+    .word   0x115de49a
+    .word   0x9188129c
+
+
+    .word   0x5a13951b
+    .word   0xc297e78f
+    .word   0x884c3f87
+    .word   0xe4747c63
+    .word   0xb57b76ea
+    .word   0xc4cdb04e
+    .word   0x40d784bd
+    .word   0xd4adb174
+
+
+    .word   0x4ff8c841
+    .word   0x13bebc38
+    .word   0xc60efe13
+    .word   0xeb931f6
+    .word   0x9caef48f
+    .word   0xf5487191
+    .word   0xc49c6382
+    .word   0x563e8299
+
+
+    .word   0xe660475a
+    .word   0x30e4d185
+    .word   0x704dd543
+    .word   0xd8632ca0
+    .word   0x825a260
+    .word   0x4bfd4685
+    .word   0xf1fae904
+    .word   0x758f304f
+
+
+    .word   0xf5209176
+    .word   0xd22bb107
+    .word   0x51abb62b
+    .word   0x48ee3562
+    .word   0x4e1211ce
+    .word   0xd38eb39d
+    .word   0x949d105f
+    .word   0xecdb73ba
+
+
+    .word   0x67de3a60
+    .word   0x8d7e1d8c
+    .word   0x9b29b91b
+    .word   0xf7df91af
+    .word   0x8a67c62f
+    .word   0xa8e9c4af
+    .word   0x72a2e49a
+    .word   0x2056bbf3
+
+
+    .word   0x98b64caf
+    .word   0x75de740c
+    .word   0x260b41c8
+    .word   0xf70260b6
+    .word   0xf4834e4c
+    .word   0x7634a69e
+    .word   0x51e03fbf
+    .word   0x6d1ad911
+
+
+    .word   0x31bf9a75
+    .word   0x6e836b90
+    .word   0xaf0cde04
+    .word   0xbf4077a7
+    .word   0x42a4fa1e
+    .word   0x6694bdaa
+    .word   0xd10a1731
+    .word   0x94c98b3a
+
+
+    .word   0x72dcc5ac
+    .word   0x1785986d
+    .word   0xcbb8caeb
+    .word   0xad0d1c72
+    .word   0xfdf29daa
+    .word   0x1f1dff88
+    .word   0x2eca26be
+    .word   0xa8004cb9
+
+
+    .word   0x8c16f329
+    .word   0x80f8498d
+    .word   0x74a92f69
+    .word   0xd6728f3b
+    .word   0x42234db1
+    .word   0x512235b8
+    .word   0xaea575c1
+    .word   0x2ae8fd3b
+
+
+    .word   0x32617574
+    .word   0xe808d17b
+    .word   0x7382ec1f
+    .word   0xbc639c47
+    .word   0x207c82e6
+    .word   0x972f1fc6
+    .word   0x3702a43a
+    .word   0x707c7ce1
+
+
+    .word   0x5b4df19d
+    .word   0xcfab49f1
+    .word   0x8b9a6a9e
+    .word   0x6cba0b7c
+    .word   0xac025356
+    .word   0x2db56f7b
+    .word   0xe186b32f
+    .word   0x1cbb5c3f
+
+
+    .word   0xef9c8e8e
+    .word   0xc5288995
+    .word   0x227a6e1f
+    .word   0x24f000df
+    .word   0xb60c4f7
+    .word   0x34205034
+    .word   0xe51b6f71
+    .word   0xdaedfc5f
+
+
+    .word   0x77866a35
+    .word   0x9a6b311f
+    .word   0xdef57c5a
+    .word   0xe7b71f55
+    .word   0x9872c443
+    .word   0x888397fd
+    .word   0x6a9939f7
+    .word   0xd36aa823
+
+
+    .word   0x269c022a
+    .word   0x9fbf2991
+    .word   0x754fb355
+    .word   0xff5b5072
+    .word   0x86e148c
+    .word   0xf62f4242
+    .word   0xd2daa140
+    .word   0xfbd112b7
+
+
+    .word   0x8241efc5
+    .word   0x9176eafc
+    .word   0xec86a1ee
+    .word   0xef60c3e2
+    .word   0xcf0fd7da
+    .word   0xf394e79a
+    .word   0x216ad7e5
+    .word   0xbf61d49b
+
+
+    .word   0xfcd7470b
+    .word   0x42a7ece3
+    .word   0x19f705fe
+    .word   0x9791eafa
+    .word   0x1c82d04c
+    .word   0x8b04be8b
+    .word   0xbd1b1f2e
+    .word   0x3f8c44a0
+
+
+    .word   0xf7e99ae9
+    .word   0x7f38975c
+    .word   0x93661a6a
+    .word   0xdd592a63
+    .word   0x7c3372c3
+    .word   0x85e1e3a8
+    .word   0x35615231
+    .word   0xa89809c2
+
+
+    .word   0x78816385
+    .word   0x47dc358e
+    .word   0xba9b8de6
+    .word   0x16ac312c
+    .word   0xa0e82650
+    .word   0xa31b6c54
+    .word   0x344d53d1
+    .word   0x609bbf46
+
+
+    .word   0xfe3a1938
+    .word   0x4c1715c7
+    .word   0xd6894e4c
+    .word   0x1753697c
+    .word   0xeb9dbd11
+    .word   0xcac66625
+    .word   0x99d67667
+    .word   0xc05686c0
+
+
+    .word   0x52f7e087
+    .word   0x8dc6f84d
+    .word   0x590b695c
+    .word   0x76f4b23b
+    .word   0x88bbd514
+    .word   0xa73e7ec8
+    .word   0xa3d97e96
+    .word   0x8734c
+
+
+    .word   0xe68f542d
+    .word   0x15bc0aef
+    .word   0x71982638
+    .word   0x6adc9fe4
+    .word   0xd138fc30
+    .word   0x926f749
+    .word   0x9574066e
+    .word   0xe660475a
+
+
+    .word   0x9905d541
+    .word   0x5a422a93
+    .word   0x6726c13f
+    .word   0xef1f1229
+    .word   0xa317b6b4
+    .word   0x2c212782
+    .word   0xf70260b6
+    .word   0x62daced1
+
+
+    .word   0xcca2df80
+    .word   0x5d345dc
+    .word   0xe0d75039
+    .word   0xbc5b10dd
+    .word   0x96301ae8
+    .word   0x5a77be76
+    .word   0xc3c43b6b
+    .word   0xe78e0121
+
+
+    .word   0x4032540f
+    .word   0x444db00c
+    .word   0xe1ce790d
+    .word   0x3def0e1d
+    .word   0x6e4f8306
+    .word   0xbec83143
+    .word   0xad276726
+    .word   0x7dc994be
+
+
+    .word   0x2ae8fd3b
+    .word   0x18f13987
+    .word   0xb33f3b75
+    .word   0x90746d6
+    .word   0xcd525174
+    .word   0xb2fef123
+    .word   0xa8e9c4af
+    .word   0x935f10a0
+
+
+    .word   0xe1be15ca
+    .word   0x922f3cdc
+    .word   0xbfee5d32
+    .word   0xb2fb0ad7
+    .word   0xa545b836
+    .word   0xe6659ed9
+    .word   0x557313bf
+    .word   0x5781d2f5
+
+
+    .word   0xc3f3a010
+    .word   0x72a2e49a
+    .word   0x571c373c
+    .word   0x2f1f6e50
+    .word   0xe05a451
+    .word   0xd8f34a1e
+    .word   0x7d07b5e9
+    .word   0xf65d241b
+
+
+    .word   0x397b61a5
+    .word   0xaaa26de5
+    .word   0x743178b1
+    .word   0x8eb7a86a
+    .word   0xa63e889a
+    .word   0x4e830b5d
+    .word   0xa75f9732
+    .word   0x6581f56b
+
+
+    .word   0xcb447f2a
+    .word   0x204fd115
+    .word   0x96af046
+    .word   0xd166defd
+    .word   0xed690010
+    .word   0x1472441a
+    .word   0x5c5bd850
+    .word   0x13657293
+
+
+    .word   0xe1c63979
+    .word   0x810e8f86
+    .word   0x6637f816
+    .word   0xdc8ec6b1
+    .word   0xd5943748
+    .word   0x1bc8f90
+    .word   0x1df1772e
+    .word   0xf911db61
+
+
+    .word   0xca59500e
+    .word   0x4a94dd8
+    .word   0x4d7ac1b3
+    .word   0xdea7c7d0
+    .word   0x2ba0485d
+    .word   0x1926f8aa
+    .word   0xcf06794d
+    .word   0xb5006c05
+
+
+    .word   0x88413d12
+    .word   0xdd040b97
+    .word   0x6b897cdb
+    .word   0x23211b8b
+    .word   0x13ee0d43
+    .word   0xefd7fc9f
+    .word   0x757ade5d
+    .word   0xec86a1ee
+
+
+    .word   0xfe1da6a6
+    .word   0x723681d0
+    .word   0x74642902
+    .word   0x3d1afe35
+    .word   0xa78c7d0e
+    .word   0x8ea8039
+    .word   0x671fe524
+    .word   0x20f0c39a
+
+
+    .word   0xb7d01193
+    .word   0x29e100a3
+    .word   0x21a18083
+    .word   0xc9d007ef
+    .word   0xfac679fa
+    .word   0xf6f3cf04
+    .word   0xc4ae1965
+    .word   0x81836f9a
+
+
+    .word   0x288927eb
+    .word   0xfa0d4e14
+    .word   0xc614fbf5
+    .word   0x9b9c3ef1
+    .word   0xfe9a1d2b
+    .word   0x8a234e0d
+    .word   0x132bab3b
+    .word   0x38a6fa48
+
+
+    .word   0xccaeeb4b
+    .word   0xd554238e
+    .word   0xe3aa925b
+    .word   0x663b92c8
+    .word   0x2ced1c94
+    .word   0xf5487191
+    .word   0xbf877dd8
+    .word   0xd555aee3
+
+
+    .word   0x660f0d50
+    .word   0xb03a5a39
+    .word   0x6fd2f484
+    .word   0x26f4047d
+    .word   0xbfe37956
+    .word   0x74aa111c
+    .word   0xd0c1fb
+    .word   0x739fad19
+
+
+    .word   0x355fcd74
+    .word   0x3b37b67e
+    .word   0x23cacbc1
+    .word   0x5dc53939
+    .word   0xf9996632
+    .word   0x9ae29b88
+    .word   0xa6de4f4b
+    .word   0xa317b6b4
+
+
+    .word   0x260b41c8
+    .word   0x3e385e99
+    .word   0x37331380
+    .word   0xc0428ea2
+    .word   0xce929793
+    .word   0x8bdf245c
+    .word   0x3dff52a8
+    .word   0xad276726
+
+
+    .word   0xaea575c1
+    .word   0x1f1dff88
+    .word   0x7cd59793
+    .word   0x3c9d6cd1
+    .word   0x926f749
+    .word   0x563e8299
+    .word   0xd1442e1
+    .word   0xd49f1d5d
+
+
+    .word   0x8bb2bc9
+    .word   0xe585161d
+    .word   0xb4a42474
+    .word   0xc3606a46
+    .word   0x36f79834
+    .word   0x23f9a116
+    .word   0x489d036
+    .word   0x64944725
+
+
+    .word   0xbca325c1
+    .word   0x40415d2
+    .word   0x78ddaa76
+    .word   0xfe2a7889
+    .word   0x3404642d
+    .word   0x3daec373
+    .word   0xd96090c0
+    .word   0x3dd478ed
+
+
+    .word   0x3ae0e594
+    .word   0x25adc607
+    .word   0x77561402
+    .word   0xdbe58112
+    .word   0xa4d2947a
+    .word   0x6e824391
+    .word   0xeed8409
+    .word   0x51a3a725
+
+
+    .word   0x506c50ea
+    .word   0x9bbed623
+    .word   0x2661f222
+    .word   0x718923f4
+    .word   0x6e3bed04
+    .word   0x3ac91322
+    .word   0xc6adc9c6
+    .word   0x46633f7d
+
+
+    .word   0x3af542b9
+    .word   0xd488c91f
+    .word   0xe90b3c4c
+    .word   0xac1c84be
+    .word   0x1813d411
+    .word   0xcd525174
+    .word   0x8a67c62f
+    .word   0x2749d607
+
+
+    .word   0x72a8acfa
+    .word   0x31337ea
+    .word   0x121bc9b9
+    .word   0xcba5ee1b
+    .word   0xa55765a0
+    .word   0x4f552d35
+    .word   0x7164bf2f
+    .word   0xb16e9dce
+
+
+    .word   0x43d46eec
+    .word   0xc1d60f1f
+    .word   0xb05f65e4
+    .word   0x1061d2d
+    .word   0xd7fc46e2
+    .word   0x455cdfd5
+    .word   0x685fb890
+    .word   0xb2292ede
+
+
+    .word   0x1b854205
+    .word   0x27f36142
+    .word   0x5781d2f5
+    .word   0xa8e9c4af
+    .word   0xb08e68c4
+    .word   0x27abe153
+    .word   0x171f4c2
+    .word   0x57538493
+
+
+    .word   0xd06ba1d4
+    .word   0xe35eaab9
+    .word   0x182d35c8
+    .word   0x29f1fa6d
+    .word   0x7804799d
+    .word   0x2995bae0
+    .word   0xd16e8607
+    .word   0x9f3124d1
+
+
+    .word   0xdef96375
+    .word   0x7e1d5e93
+    .word   0xefd7fc9f
+    .word   0x9176eafc
+    .word   0x5768c1ca
+    .word   0x859b16bd
+    .word   0x4ddf9e8c
+    .word   0x2528fe85
+
+
+    .word   0x62162387
+    .word   0x794ca495
+    .word   0x5212cd6e
+    .word   0xd5a9cc8d
+    .word   0xcf58a5a3
+    .word   0x9976eeac
+    .word   0x2d337b4a
+    .word   0x2a67a884
+
+
+    .word   0x9fed20b1
+    .word   0x78390531
+    .word   0xb332ea30
+    .word   0xc5029984
+    .word   0x1027cd8f
+    .word   0x3025b89
+    .word   0x774ba9d0
+    .word   0x3f88c33e
+
+
+    .word   0x56009b77
+    .word   0x9fbf2991
+    .word   0x31ce1252
+    .word   0x98cfb994
+    .word   0x8cdfc472
+    .word   0xb431c9f6
+    .word   0x9452e0db
+    .word   0xa35dca27
+
+
+    .word   0xac794a15
+    .word   0x554d1858
+    .word   0xb0ee1ea5
+    .word   0x20cd5f73
+    .word   0xb7f3cbe4
+    .word   0x87d8a1ff
+    .word   0x6936f6c2
+    .word   0xbd49182e
+
+
+    .word   0x9ae29b88
+    .word   0xef1f1229
+    .word   0x75de740c
+    .word   0x9bf3d076
+    .word   0x4529ee29
+    .word   0x301abff8
+    .word   0xe1718801
+    .word   0x1e373473
+
+
+    .word   0xcefb5619
+    .word   0x50e5043b
+    .word   0x792aff67
+    .word   0xb74f757
+    .word   0x1e0bf981
+    .word   0x59976030
+    .word   0xe54505a8
+    .word   0xcd0a42f6
+
+
+    .word   0x7a15b2dc
+    .word   0x81c628a8
+    .word   0x20f3e212
+    .word   0xfaa2415a
+    .word   0xacc374fe
+    .word   0x75eec89b
+    .word   0x6a3ba5f9
+    .word   0x631cc8cb
+
+
+    .word   0xe0b50b05
+    .word   0xac04aa11
+    .word   0x4df86965
+    .word   0xf4dc8003
+    .word   0xd5d789f1
+    .word   0x10a89b81
+    .word   0xa0d602b
+    .word   0x5ac7ab7
+
+
+    .word   0x8cbf3ef9
+    .word   0x7cd59793
+    .word   0xd138fc30
+    .word   0xc49c6382
+    .word   0x50c96adf
+    .word   0xf394e79a
+    .word   0xdf67073a
+    .word   0xf73a7dc3
+
+
+    .word   0xa72e92c4
+    .word   0x53fa71f7
+    .word   0xcd8e62f1
+    .word   0x1970a515
+    .word   0xb8aaedf1
+    .word   0xbdcc57b8
+    .word   0x5b638d1e
+    .word   0xb2bc4ab0
+
+
+    .word   0x78a98cf
+    .word   0xa27334b2
+    .word   0xd435d909
+    .word   0xcee03332
+    .word   0xc2f10488
+    .word   0x7f97c6ec
+    .word   0xe87ce515
+    .word   0xe2881a44
+
+
+    .word   0x846cd3f9
+    .word   0xe66c39ed
+    .word   0xd895f142
+    .word   0x62df561a
+    .word   0x81ba5a44
+    .word   0x55df1f38
+    .word   0x90a96baf
+    .word   0x2d490f4d
+
+
+    .word   0x80ba71b3
+    .word   0xec008e5a
+    .word   0x1c0bf178
+    .word   0xa6edb8d9
+    .word   0x2552f7f5
+    .word   0x929bee5b
+    .word   0x7407090
+    .word   0xed7219d2
+
+
+    .word   0x67e17e17
+    .word   0xd8f34a1e
+    .word   0x415303e9
+    .word   0x4c4cf1db
+    .word   0xb069d85a
+    .word   0xa818d2a0
+    .word   0xbbda981f
+    .word   0x1af75504
+
+
+    .word   0xd0993b43
+    .word   0x788a7b0
+    .word   0xfbd112b7
+    .word   0xb65cf982
+    .word   0xac1c84be
+    .word   0x90746d6
+    .word   0xf7df91af
+    .word   0xa0535a61
+
+
+    .word   0x8eeaa90f
+    .word   0xa4fb98a0
+    .word   0x42644697
+    .word   0x5c169355
+    .word   0x8446cae4
+    .word   0x47a9e333
+    .word   0x81236659
+    .word   0xddd75422
+
+
+    .word   0x43b2d8db
+    .word   0x693123b3
+    .word   0xbd35f5a8
+    .word   0x13752e2a
+    .word   0xbe0630d9
+    .word   0xdef96375
+    .word   0x13ee0d43
+    .word   0x8241efc5
+
+
+    .word   0xe87ebc95
+    .word   0x7382ec1f
+    .word   0x8e7964df
+    .word   0xf696f008
+    .word   0xc2595c35
+    .word   0xf589292c
+    .word   0xced5619
+    .word   0x5be4bfc4
+
+
+    .word   0x35544d6
+    .word   0x8d0d3446
+    .word   0x4e551948
+    .word   0x1b854205
+    .word   0x557313bf
+    .word   0x8a67c62f
+    .word   0xbee79712
+    .word   0x7a4a1851
+
+
+    .word   0xf7817cf4
+    .word   0xd554238e
+    .word   0x6c4d3a4c
+    .word   0xeb931f6
+    .word   0x6fe2eee
+    .word   0x2f816cbd
+    .word   0x27f36142
+    .word   0xb2fef123
+
+
+    .word   0xa16c0f47
+    .word   0x6936f6c2
+    .word   0xf9996632
+    .word   0x6726c13f
+    .word   0x98b64caf
+    .word   0x61898e1a
+    .word   0xe8d531d
+    .word   0x2f27087a
+
+
+    .word   0x5034389d
+    .word   0x8b5003c4
+    .word   0x4e359e24
+    .word   0xbf1a2969
+    .word   0xaddf6594
+    .word   0x79a79523
+    .word   0x6e5ecba0
+    .word   0x14bd2773
+
+
+    .word   0x56725aab
+    .word   0x80e5bb8c
+    .word   0x427b570
+    .word   0x4a9a58da
+    .word   0x3f262301
+    .word   0xb34d94ea
+    .word   0xd7054cc3
+    .word   0x9a55e93f
+
+
+    .word   0x27f2678a
+    .word   0xc5301867
+    .word   0xa130b98a
+    .word   0x9083f4b6
+    .word   0x1161eff1
+    .word   0xa8c5ae07
+    .word   0x4c2b345b
+    .word   0xd26574ad
+
+
+    .word   0x31dba8dc
+    .word   0x5d126a59
+    .word   0x5a77be76
+    .word   0x6f7e576f
+    .word   0x12c4c582
+    .word   0xd209ed73
+    .word   0xcd56fa87
+    .word   0x7869c34f
+
+
+    .word   0x883c2a18
+    .word   0xfa6c0c3e
+    .word   0xe50a3891
+    .word   0xb3963b6e
+    .word   0x6dde16c8
+    .word   0xf293c399
+    .word   0x6018b5
+    .word   0x35615231
+
+
+    .word   0x6c224ec1
+    .word   0x1a360663
+    .word   0xc7d80ed6
+    .word   0x836c674a
+    .word   0xcadfc05a
+    .word   0x2f5aaaf3
+    .word   0x5ac7ab7
+    .word   0x1f1dff88
+
+
+    .word   0x6adc9fe4
+    .word   0xf5487191
+    .word   0xc986bb0
+    .word   0xfd02210d
+    .word   0xc8435406
+    .word   0x7cbb30b4
+    .word   0x8a85e737
+    .word   0xbaa365d2
+
+
+    .word   0xad1cdd61
+    .word   0x7e3b7aef
+    .word   0xc3c17d8b
+    .word   0xfcff6c9d
+    .word   0xef1408e5
+    .word   0x957c4b4d
+    .word   0x83ac0f24
+    .word   0x21f0431d
+
+
+    .word   0x1652f9f1
+    .word   0x7ce93bbe
+    .word   0x70747853
+    .word   0x80a4765a
+    .word   0x26c2e10d
+    .word   0x272157e4
+    .word   0xbda90256
+    .word   0x885ba2ef
+
+
+    .word   0x4e050da6
+    .word   0x941f9b88
+    .word   0x4e4ad2eb
+    .word   0x4bdbc4bd
+    .word   0x6fe721a2
+    .word   0xdfce1cf3
+    .word   0x9f4ffb01
+    .word   0x6727e373
+
+
+    .word   0x1333b6e9
+    .word   0x8a234e0d
+    .word   0x792e2c37
+    .word   0x51953e83
+    .word   0xb7afb2d5
+    .word   0x929dc809
+    .word   0x974567a6
+    .word   0x8833de40
+
+
+    .word   0x2f9579df
+    .word   0xd5743d7f
+    .word   0x7a6ccb02
+    .word   0xec1e716
+    .word   0xc0c3ff01
+    .word   0xf8da3442
+    .word   0x4a271d0a
+    .word   0xd7a03c6d
+
+
+    .word   0xe9eb1015
+    .word   0x20e5de8a
+    .word   0x500ccbc9
+    .word   0x99f9bec1
+    .word   0x9733373b
+    .word   0x24feb98f
+    .word   0x724fdc34
+    .word   0x804e9306
+
+
+    .word   0x13752e2a
+    .word   0x9f3124d1
+    .word   0x23211b8b
+    .word   0xfbd112b7
+    .word   0xe90b3c4c
+    .word   0xb33f3b75
+    .word   0x9b29b91b
+    .word   0xb1fd6af0
+
+
+    .word   0x5916c1bc
+    .word   0x2cd040e7
+    .word   0xa14d5c3f
+    .word   0xce8a2470
+    .word   0xec7c3b8d
+    .word   0x86b88961
+    .word   0x359f4905
+    .word   0x3ddc7226
+
+
+    .word   0xa1617102
+    .word   0x75aa1e3a
+    .word   0x11065315
+    .word   0xaa86f2e6
+    .word   0xa407704b
+    .word   0xd001836a
+    .word   0xaae66740
+    .word   0x5c1375b5
+
+
+    .word   0x41a40b9e
+    .word   0x9d643c89
+    .word   0xa4d38f66
+    .word   0x65a34371
+    .word   0x48a13b40
+    .word   0x9c7e331f
+    .word   0x80a2825e
+    .word   0xf1bbbe
+
+
+    .word   0xf3a2a059
+    .word   0xb11ec856
+    .word   0xc80b642b
+    .word   0xe66e9b2d
+    .word   0x5f5b65bb
+    .word   0xc6e4a788
+    .word   0xa4535d76
+    .word   0x7689909b
+
+
+    .word   0xf01103c2
+    .word   0xd83680ee
+    .word   0x4955388
+    .word   0x949d105f
+    .word   0x8d0d3446
+    .word   0xb2292ede
+    .word   0xe6659ed9
+    .word   0xf7df91af
+
+
+    .word   0x63d9754
+    .word   0x71864deb
+    .word   0x47757421
+    .word   0x233998c4
+    .word   0x28f83fc
+    .word   0x3025b89
+    .word   0x78bc4250
+    .word   0xd36aa823
+
+
+    .word   0xfdd02528
+    .word   0x864375a3
+    .word   0x6cbba65b
+    .word   0xe643e9b2
+    .word   0x4ccde29e
+    .word   0x1d16182e
+    .word   0x834ee1ca
+    .word   0x15bc0aef
+
+
+    .word   0x8d6aee9b
+    .word   0x6fe2eee
+    .word   0x1b854205
+    .word   0xcd525174
+    .word   0xc93132ea
+    .word   0x30b9e570
+    .word   0xdbaf0748
+    .word   0x282d1066
+
+
+    .word   0x6cd79cc2
+    .word   0xcf98d77e
+    .word   0x77603b35
+    .word   0x757ade5d
+    .word   0x55c2fd97
+    .word   0x5e4c6484
+    .word   0xdb72101b
+    .word   0x761d393f
+
+
+    .word   0x5efad3fb
+    .word   0x286fa8c5
+    .word   0xe585161d
+    .word   0x9727f8a1
+    .word   0x177572f6
+    .word   0xd1a8d5fd
+    .word   0x40bbdeac
+    .word   0x27ab651b
+
+
+    .word   0x311ad93f
+    .word   0x610bc694
+    .word   0x595cdf09
+    .word   0xcadfc05a
+    .word   0xa0d602b
+    .word   0xaea575c1
+    .word   0x71982638
+    .word   0x9caef48f
+
+
+    .word   0x95048c68
+    .word   0xbc639c47
+    .word   0xfc77c263
+    .word   0x886dc3fc
+    .word   0xf44712cc
+    .word   0x48b28f24
+    .word   0xe4d210b1
+    .word   0x46d2cd26
+
+
+    .word   0x73e22910
+    .word   0xc4a44303
+    .word   0xe699c366
+    .word   0x73b81e24
+    .word   0x73de6494
+    .word   0x6724215a
+    .word   0x740695f2
+    .word   0xcc49e65b
+
+
+    .word   0xa08c4ca2
+    .word   0x4a63f1cb
+    .word   0x784b0952
+    .word   0x69db3d78
+    .word   0x91180fc3
+    .word   0x533ef134
+    .word   0xf97fa8dc
+    .word   0xe184c9e
+
+
+    .word   0x6a161a16
+    .word   0x929bee5b
+    .word   0x760654c7
+    .word   0x2f1f6e50
+    .word   0xcca1f470
+    .word   0xdc0a0b58
+    .word   0xf9c962e4
+    .word   0x729c6c34
+
+
+    .word   0x3b5a5dad
+    .word   0xdc4941f2
+    .word   0x33f8bc73
+    .word   0xfde0097a
+    .word   0x4d3c637a
+    .word   0x79d662bd
+    .word   0x3757c465
+    .word   0x4e29af6c
+
+
+    .word   0xd489e1db
+    .word   0xcc57941a
+    .word   0x3c48cc49
+    .word   0x724fdc34
+    .word   0xbd35f5a8
+    .word   0xd16e8607
+    .word   0x6b897cdb
+    .word   0xd2daa140
+
+
+    .word   0x965999bc
+    .word   0x7cd59793
+    .word   0x733cb242
+    .word   0xef60c3e2
+    .word   0x81a4764f
+    .word   0xe5a2086a
+    .word   0x27f9756
+    .word   0xa75a0701
+
+
+    .word   0x76255888
+    .word   0xb54b40b5
+    .word   0xfc4a1dfa
+    .word   0x139ff603
+    .word   0xd1022a85
+    .word   0x301abff8
+    .word   0x4e57e698
+    .word   0x3d40d09
+
+
+    .word   0x95243545
+    .word   0x141b67b7
+    .word   0x9f3124d1
+    .word   0x788a7b0
+    .word   0xd488c91f
+    .word   0x18f13987
+    .word   0x8d7e1d8c
+    .word   0x4df55b09
+
+
+    .word   0x861f0895
+    .word   0xe57c6570
+    .word   0xe1579d70
+    .word   0x173275b9
+    .word   0xe56e3fc7
+    .word   0x8f75b40e
+    .word   0x91016910
+    .word   0x2118bfbe
+
+
+    .word   0xdd428d04
+    .word   0x410a48c4
+    .word   0x45be9be
+    .word   0x6e286238
+    .word   0x71917ae0
+    .word   0xf8e7d0a7
+    .word   0xb03b31bd
+    .word   0x8ea8039
+
+
+    .word   0x7d54ffc9
+    .word   0xab4e0cf5
+    .word   0xe6db216
+    .word   0x5469e046
+    .word   0x240fdb5b
+    .word   0x674da503
+    .word   0x3f929145
+    .word   0x925f1934
+
+
+    .word   0x76340619
+    .word   0x99d67667
+    .word   0xf1bea384
+    .word   0xfb1deecf
+    .word   0x6ff85312
+    .word   0x76f4b23b
+    .word   0x33050fe
+    .word   0x7733381e
+
+
+    .word   0x8fe3ac5b
+    .word   0x150e76a5
+    .word   0x448eb798
+    .word   0x324147
+    .word   0xf2dda243
+    .word   0x86073aab
+    .word   0x1a519573
+    .word   0xbd5933ec
+
+
+    .word   0x484d97aa
+    .word   0xe5dc0e06
+    .word   0x68471c13
+    .word   0x8020939d
+    .word   0x1e612d59
+    .word   0x4955388
+    .word   0x35544d6
+    .word   0x685fb890
+
+
+    .word   0xa545b836
+    .word   0x9b29b91b
+    .word   0xcfc1288d
+    .word   0xa440f712
+    .word   0x29cadd27
+    .word   0x96687dbd
+    .word   0x51b3e8e5
+    .word   0x5c49cbd6
+
+
+    .word   0xc2961a1f
+    .word   0xf60cae53
+    .word   0xfb05ac41
+    .word   0x23a5b564
+    .word   0x4e6ac227
+    .word   0x6b5a38cb
+    .word   0xcd803501
+    .word   0xe21f0960
+
+
+    .word   0x1c2df15b
+    .word   0xa63e63be
+    .word   0x5a01f905
+    .word   0xba5190ba
+    .word   0x4ad17cb5
+    .word   0x47c0ef2d
+    .word   0x217ebda4
+    .word   0xe558cac1
+
+
+    .word   0x610bc694
+    .word   0x836c674a
+    .word   0x10a89b81
+    .word   0xad276726
+    .word   0x15bc0aef
+    .word   0xeb931f6
+    .word   0xb2292ede
+    .word   0x90746d6
+
+
+    .word   0x33071c4
+    .word   0xb5a54a80
+    .word   0xf7b68ee3
+    .word   0x61a49c92
+    .word   0x1d9a21ae
+    .word   0x9e785a36
+    .word   0x55c1d135
+    .word   0x8d6aee9b
+
+
+    .word   0x4e551948
+    .word   0x1813d411
+    .word   0xf7bea5be
+    .word   0x69b20ace
+    .word   0x58acfeab
+    .word   0x79b403c3
+    .word   0xfa1faac9
+    .word   0x2fa20187
+
+
+    .word   0x3bea3721
+    .word   0x32e2b3d
+    .word   0xbc0c8b53
+    .word   0xc9b6ef3e
+    .word   0x852a3c07
+    .word   0x8be369e8
+    .word   0x5b5b0484
+    .word   0xd9b1f4e3
+
+
+    .word   0x225716e6
+    .word   0x2f5aaaf3
+    .word   0x2401df04
+    .word   0x663b92c8
+    .word   0xb909b2c3
+    .word   0x456f2ee7
+    .word   0xb79fb258
+    .word   0x168ceeef
+
+
+    .word   0xa29d7fa3
+    .word   0xa347e1e5
+    .word   0xff01274d
+    .word   0xe21d8387
+    .word   0x415883fd
+    .word   0x75de740c
+    .word   0xe0d8fd08
+    .word   0x86f862eb
+
+
+    .word   0xfa879f97
+    .word   0xd237c15d
+    .word   0x7a0d6a6d
+    .word   0x4b32bf46
+    .word   0xe4e014a9
+    .word   0x5c5bd850
+    .word   0x8a9c5a82
+    .word   0xeb84df5
+
+
+    .word   0x45694ae
+    .word   0xdc8ec6b1
+    .word   0xf8c00cc3
+    .word   0x3a9f5cd9
+    .word   0x6f2c6514
+    .word   0xb5b0ceca
+    .word   0x5c261dd8
+    .word   0x31337ea
+
+
+    .word   0x3a47ac75
+    .word   0xecbb1718
+    .word   0xec738c99
+    .word   0x31eeccbd
+    .word   0x631a0da4
+    .word   0xff9a3a8
+    .word   0x83229ece
+    .word   0xcc07f1a7
+
+
+    .word   0xe5a8827f
+    .word   0x8769f97
+    .word   0xb2dbb4a2
+    .word   0xa1ade2ba
+    .word   0x14f4e856
+    .word   0xec9cf226
+    .word   0x1e13fbd9
+    .word   0xbf1ee877
+
+
+    .word   0x255ba6c1
+    .word   0x95243545
+    .word   0x13752e2a
+    .word   0xd0993b43
+    .word   0x3af542b9
+    .word   0x2ae8fd3b
+    .word   0x67de3a60
+    .word   0xd4536cb
+
+
+    .word   0x1e81c7c5
+    .word   0xed11b635
+    .word   0xb7435acf
+    .word   0x485436c5
+    .word   0x89e09ad6
+    .word   0x7eaa8641
+    .word   0x900835cf
+    .word   0xb903864c
+
+
+    .word   0xf796998e
+    .word   0xd209ed73
+    .word   0xbd66e407
+    .word   0xc46ee065
+    .word   0x402c97aa
+    .word   0xc4dbd5c7
+    .word   0xc696019f
+    .word   0xc4ae1965
+
+
+    .word   0x5d5b9aae
+    .word   0xdfce1cf3
+    .word   0x190ff4a2
+    .word   0x9b9c3ef1
+    .word   0x83b37a7e
+    .word   0x305ac3ad
+    .word   0x5ecf233b
+    .word   0x500423d9
+
+
+    .word   0xa3b7bbce
+    .word   0x14caf645
+    .word   0x252f0190
+    .word   0x90a96baf
+    .word   0x5e663d46
+    .word   0xdd00a046
+    .word   0x3f24ffba
+    .word   0xef71a176
+
+
+    .word   0xd3cc6656
+    .word   0x71864deb
+    .word   0xb8e21c84
+    .word   0xc5029984
+    .word   0x3c13e427
+    .word   0x888397fd
+    .word   0xe196dd98
+    .word   0x1db7b09a
+
+
+    .word   0xb3a58141
+    .word   0xf665c3d3
+    .word   0x57de3ef7
+    .word   0x3f7a3647
+    .word   0x61530312
+    .word   0xab5e86e4
+    .word   0xa0a7ac09
+    .word   0xaa254eac
+
+
+    .word   0x1a5345dc
+    .word   0x3e45b126
+    .word   0x361f6bb9
+    .word   0x4c66fe34
+    .word   0xd48649ad
+    .word   0xfd77f699
+    .word   0x8020939d
+    .word   0xd83680ee
+
+
+    .word   0x5be4bfc4
+    .word   0x455cdfd5
+    .word   0xb2fb0ad7
+    .word   0x8d7e1d8c
+    .word   0xd2f593d9
+    .word   0x217ebda4
+    .word   0x311ad93f
+    .word   0xc7d80ed6
+
+
+    .word   0xd5d789f1
+    .word   0x3dff52a8
+    .word   0xe68f542d
+    .word   0xc60efe13
+    .word   0x1e1d78e9
+    .word   0x3c9d6cd1
+    .word   0xc0b3c17f
+    .word   0x94af6415
+
+
+    .word   0xcce61320
+    .word   0x1f31c1ff
+    .word   0xfa6c0c3e
+    .word   0x1394f0c2
+    .word   0xbfcd7b75
+    .word   0xdd592a63
+    .word   0x2437e703
+    .word   0x54b5c1
+
+
+    .word   0x1661da69
+    .word   0x874c87fa
+    .word   0x2912948f
+    .word   0x9df504d0
+    .word   0x6b051d0a
+    .word   0xee35dc9f
+    .word   0x51c8f87d
+    .word   0xaa968e92
+
+
+    .word   0x44195f74
+    .word   0xad7c81f8
+    .word   0x35d16343
+    .word   0x1afdc926
+    .word   0x8f808f82
+    .word   0xf2a35ab2
+    .word   0x4bafb70b
+    .word   0x10a89b81
+
+
+    .word   0x834ee1ca
+    .word   0x6c4d3a4c
+    .word   0x685fb890
+    .word   0xb33f3b75
+    .word   0xde7b8fb4
+    .word   0x946cd46a
+    .word   0x912ed187
+    .word   0x47ce64c1
+
+
+    .word   0x3bf16e3f
+    .word   0x5493d0c7
+    .word   0x5daa514
+    .word   0xc82fb9c5
+    .word   0xcfc3727c
+    .word   0xaa79fdd6
+    .word   0x8cebddfc
+    .word   0x7e09a919
+
+
+    .word   0xa8bf2cbe
+    .word   0xb0692ae
+    .word   0x32b67754
+    .word   0xc6adc9c6
+    .word   0x9e785a36
+    .word   0x15bc0aef
+    .word   0x8d0d3446
+    .word   0xac1c84be
+
+
+    .word   0xdf7f290a
+    .word   0x58bc8245
+    .word   0x1bc1dc15
+    .word   0xd0cd4445
+    .word   0x7f676441
+    .word   0xc6245756
+    .word   0x94259109
+    .word   0x3904669
+
+
+    .word   0xb2127d1c
+    .word   0x2f9d3e5a
+    .word   0x6d2fcbd2
+    .word   0x632158bb
+    .word   0xe91d568e
+    .word   0x13f3066f
+    .word   0x5871a0c3
+    .word   0x472b4596
+
+
+    .word   0xd6ca678a
+    .word   0x9d6ed7b3
+    .word   0xbd0383db
+    .word   0xa177f3e4
+    .word   0xe8d9cb1a
+    .word   0x437ca646
+    .word   0x900aeb0b
+    .word   0xdf393bd
+
+
+    .word   0x45ec84e5
+    .word   0x2af98e60
+    .word   0x74587540
+    .word   0x2623fbf0
+    .word   0xc8b3f721
+    .word   0xfde71d99
+    .word   0x2031c9c8
+    .word   0x38385076
+
+
+    .word   0xbf1ee877
+    .word   0x3d40d09
+    .word   0x804e9306
+    .word   0x1af75504
+    .word   0x46633f7d
+    .word   0x7dc994be
+    .word   0xecdb73ba
+    .word   0xec132bea
+
+
+    .word   0x9ec2a59d
+    .word   0xba278673
+    .word   0x1ee1468b
+    .word   0x29ab619
+    .word   0xeae68c35
+    .word   0xd16e8607
+    .word   0xd7d39c87
+    .word   0x5ac7ab7
+
+
+    .word   0xab8e6caa
+    .word   0x9176eafc
+    .word   0xb00f9fe7
+    .word   0xfc54a7b3
+    .word   0x7897d21d
+    .word   0x8aeca37a
+    .word   0x2be58cad
+    .word   0xac9e8814
+
+
+    .word   0x890a97ae
+    .word   0x558e998f
+    .word   0x884c28c6
+    .word   0xe1339b21
+    .word   0x71d4769
+    .word   0xc7c289db
+    .word   0x29a83b4b
+    .word   0xd2b6ea3b
+
+
+    .word   0x41da96bd
+    .word   0xe6939851
+    .word   0xc143eadb
+    .word   0x878ec9ae
+    .word   0x2a2dd59b
+    .word   0xd1a8d5fd
+    .word   0x6e626943
+    .word   0xe1813ce5
+
+
+    .word   0xe5bb12d4
+    .word   0x84a2fc7b
+    .word   0x93a747d2
+    .word   0xb8c00ab
+    .word   0xf7c85649
+    .word   0x4e830b5d
+    .word   0xfab439fb
+    .word   0x8d916c63
+
+
+    .word   0xae348d13
+    .word   0x6c2af138
+    .word   0xcfd10bd2
+    .word   0x27095a6d
+    .word   0x61cd3db7
+    .word   0x9ad8ee9b
+    .word   0x8b809a3
+    .word   0x8380756
+
+
+    .word   0xd7427ce7
+    .word   0x2246c941
+    .word   0xa7859694
+    .word   0x515fcfa3
+    .word   0xebfa2b97
+    .word   0x83ad3112
+    .word   0x9e04bb4f
+    .word   0x6936f6c2
+
+
+    .word   0x2b641c01
+    .word   0xb54b40b5
+    .word   0x7f06f8b9
+    .word   0x9bf3d076
+    .word   0x8c89546f
+    .word   0xcdd869a3
+    .word   0x70d55fd3
+    .word   0xd48649ad
+
+
+    .word   0x68471c13
+    .word   0xf01103c2
+    .word   0xced5619
+    .word   0xd7fc46e2
+    .word   0xbfee5d32
+    .word   0x67de3a60
+    .word   0x936a4f41
+    .word   0x8f375ccd
+
+
+    .word   0xb6fb100f
+    .word   0x1389ff4c
+    .word   0x30b9e570
+    .word   0x99fbabe9
+    .word   0x6e3e8134
+    .word   0x23211b8b
+    .word   0x7da9e2b0
+    .word   0xd7b407ed
+
+
+    .word   0x565083a5
+    .word   0x112e6200
+    .word   0x954949cb
+    .word   0x3e73c8c5
+    .word   0xf85f0da7
+    .word   0x8bc901f9
+    .word   0xd25b8092
+    .word   0xdb6c9bcc
+
+
+    .word   0x76d6a058
+    .word   0x6b0e0e8b
+    .word   0x1cca424d
+    .word   0x72e197e7
+    .word   0xda4e5d7a
+    .word   0x3ac5d42a
+    .word   0xa34b5fa1
+    .word   0xd061a31c
+
+
+    .word   0x97fc01b
+    .word   0xc6d0e3d
+    .word   0xffd1a4c6
+    .word   0x274bb751
+    .word   0x700281c8
+    .word   0xc5719eb1
+    .word   0xd1de5ee2
+    .word   0x608ece81
+
+
+    .word   0x2f4f1f82
+    .word   0xdf67073a
+    .word   0xdc5a12c6
+    .word   0xe3886930
+    .word   0x7a0ae307
+    .word   0x1970a515
+    .word   0xf94033e4
+    .word   0xa8c6c3f
+
+
+    .word   0x8962678e
+    .word   0x8be369e8
+    .word   0xf2a35ab2
+    .word   0x836c674a
+    .word   0x1d16182e
+    .word   0xd554238e
+    .word   0x455cdfd5
+    .word   0x18f13987
+
+
+    .word   0x23e695ef
+    .word   0x6b414e7d
+    .word   0xcf98293e
+    .word   0x3537d788
+    .word   0x3be21f98
+    .word   0xeb746c51
+    .word   0xaad09966
+    .word   0xd61d3611
+
+
+    .word   0x50f1e8c3
+    .word   0xb16538f
+    .word   0x3c9acbc
+    .word   0x869b9e41
+    .word   0xa418b97a
+    .word   0x3652770f
+    .word   0x208d66b1
+    .word   0xfc9c83b2
+
+
+    .word   0x7916e98d
+    .word   0xbe88ebd3
+    .word   0x39ae9abd
+    .word   0xf9593b69
+    .word   0x9a29ebb2
+    .word   0xb2b91562
+    .word   0xcafdb5e0
+    .word   0xfef7a7db
+
+
+    .word   0xd525f7d4
+    .word   0x32b67754
+    .word   0x1d9a21ae
+    .word   0x834ee1ca
+    .word   0x35544d6
+    .word   0xe90b3c4c
+    .word   0xf9e5e6e0
+    .word   0x2031c9c8
+
+
+    .word   0x1e13fbd9
+    .word   0x4e57e698
+    .word   0x724fdc34
+    .word   0xbbda981f
+    .word   0xc6adc9c6
+    .word   0xad276726
+    .word   0x949d105f
+    .word   0xb65cf982
+
+
+    .word   0x105e2a2b
+    .word   0xdcc7502a
+    .word   0x5cf5bd67
+    .word   0xf2c23667
+    .word   0xf9f3fa3e
+    .word   0xec43c73f
+    .word   0x352d683a
+    .word   0x9503a1d2
+
+
+    .word   0x611c49d1
+    .word   0x49eb9924
+    .word   0x8562f0cb
+    .word   0x2976079
+    .word   0xd44461b8
+    .word   0x850cded2
+    .word   0x2a21b42d
+    .word   0xf8da3442
+
+
+    .word   0x12c14e47
+    .word   0xb391ef8e
+    .word   0x6ec25dc5
+    .word   0x6bab4942
+    .word   0xc4545eed
+    .word   0x596fabff
+    .word   0x510f5ac9
+    .word   0x47457d6a
+
+
+    .word   0x6b587aa3
+    .word   0xd5067c9d
+    .word   0x2384a70b
+    .word   0x228fecd3
+    .word   0x8839adfc
+    .word   0x140da3de
+    .word   0x24e472a1
+    .word   0xa461cfb6
+
+
+    .word   0x2141ef87
+    .word   0xa4439086
+    .word   0xbc10cf3e
+    .word   0x6c7f9e01
+    .word   0x92173e91
+    .word   0x6e824391
+    .word   0xa9292640
+    .word   0xb966fc3c
+
+
+    .word   0xadd85cb8
+    .word   0x2d238049
+    .word   0xa8754ece
+    .word   0xe7355e24
+    .word   0x6739cc05
+    .word   0xbee79712
+    .word   0x555cb6c3
+    .word   0xaacb82b4
+
+
+    .word   0xe8b8b6a3
+    .word   0xeb931f6
+    .word   0x415c09f1
+    .word   0xc780fca1
+    .word   0x6691a6f9
+    .word   0xbe590ea5
+    .word   0xbfa4417
+    .word   0x76eab063
+
+
+    .word   0x4828962
+    .word   0x760654c7
+    .word   0xeb733f66
+    .word   0xa9afce50
+    .word   0xf96c525
+    .word   0xc8126a8d
+    .word   0x10926739
+    .word   0x2a98062a
+
+
+    .word   0x7d9a9ae
+    .word   0xc4dbd5c7
+    .word   0x1158855d
+    .word   0x4bdbc4bd
+    .word   0xf6c35f20
+    .word   0xfa0d4e14
+    .word   0xa8b29f3f
+    .word   0x77732495
+
+
+    .word   0xcdd869a3
+    .word   0x4c66fe34
+    .word   0xe5dc0e06
+    .word   0x7689909b
+    .word   0xf589292c
+    .word   0x1061d2d
+    .word   0x922f3cdc
+    .word   0xecdb73ba
+
+
+    .word   0x5f50d600
+    .word   0x8c690446
+    .word   0x87f3ed70
+    .word   0xfa998e98
+    .word   0x1cedaf33
+    .word   0x6b93aa2b
+    .word   0x1fc02a49
+    .word   0xc7513744
+
+
+    .word   0x27b51901
+    .word   0x1d7393b1
+    .word   0x14d377e7
+    .word   0xcc82407b
+    .word   0x5aabb34
+    .word   0x2db17360
+    .word   0xaf444660
+    .word   0x4c2b345b
+
+
+    .word   0xae7bb526
+    .word   0x7eaa8641
+    .word   0x32395930
+    .word   0x6f7e576f
+    .word   0x60b2b317
+    .word   0x8c77ce4a
+    .word   0xcd778e90
+    .word   0xd80abd31
+
+
+    .word   0xe1d59bbf
+    .word   0x71c77fce
+    .word   0x4023a224
+    .word   0x96f0be25
+    .word   0x4dd40fa1
+    .word   0xbf4077a7
+    .word   0xf2b747d7
+    .word   0x3c271955
+
+
+    .word   0xbce44a0e
+    .word   0xe5e5ae69
+    .word   0xadb23eba
+    .word   0x10f92379
+    .word   0x86af5cb7
+    .word   0x794ca495
+    .word   0x802c5ec0
+    .word   0x3af83f42
+
+
+    .word   0xd35be5a
+    .word   0x83676561
+    .word   0x7797048f
+    .word   0x452de1bb
+    .word   0xa9bcd26f
+    .word   0x312364b7
+    .word   0xa96ddcb
+    .word   0xb03b31bd
+
+
+    .word   0xdc1b4c94
+    .word   0xd00cbe1e
+    .word   0xc1227c10
+    .word   0x43dd690c
+    .word   0x78749c0d
+    .word   0x8962678e
+    .word   0x8f808f82
+    .word   0x610bc694
+
+
+    .word   0x4ccde29e
+    .word   0xf7817cf4
+    .word   0xd7fc46e2
+    .word   0x2ae8fd3b
+    .word   0xd0a960b1
+    .word   0xe1d24e46
+    .word   0x4ee02d81
+    .word   0xdfa8543
+
+
+    .word   0x4211678b
+    .word   0x83ac0f24
+    .word   0x4783b54
+    .word   0x3eaccc0c
+    .word   0x404657eb
+    .word   0x80a4765a
+    .word   0x9f865e1
+    .word   0x296ec49f
+
+
+    .word   0x5f00a2c9
+    .word   0xdce1464
+    .word   0x168ceeef
+    .word   0xdd7b24ef
+    .word   0x4a984a4d
+    .word   0xbd49182e
+    .word   0xd12bba9f
+    .word   0x65f99287
+
+
+    .word   0x58b42543
+    .word   0x48008f5a
+    .word   0xaf6cf23c
+    .word   0xad874668
+    .word   0x459dd45d
+    .word   0xecb6009b
+    .word   0x359f1d7
+    .word   0x2e8f6b62
+
+
+    .word   0xb916ac4c
+    .word   0x24f000df
+    .word   0x2c3df307
+    .word   0xa3685330
+    .word   0xdf8edbd8
+    .word   0x3d7e8ba3
+    .word   0xfef7a7db
+    .word   0xb0692ae
+
+
+    .word   0x61a49c92
+    .word   0x1d16182e
+    .word   0x5be4bfc4
+    .word   0xd488c91f
+    .word   0xde8fc07d
+    .word   0x318b88c
+    .word   0x4668e056
+    .word   0x49e318cd
+
+
+    .word   0x208a2de3
+    .word   0x5b7e57d5
+    .word   0x8f73aa2c
+    .word   0x933b27fa
+    .word   0x211ffa24
+    .word   0xd97130f5
+    .word   0x8ef96459
+    .word   0x5eea2f8e
+
+
+    .word   0xfe651406
+    .word   0xba278673
+    .word   0xa403b1db
+    .word   0x724fdc34
+    .word   0x32b67754
+    .word   0x10a89b81
+    .word   0x4955388
+    .word   0xfbd112b7
+
+
+    .word   0x1540f96d
+    .word   0x94f8b5e2
+    .word   0x7650c6ac
+    .word   0xece060d
+    .word   0x19110d43
+    .word   0x493dc65d
+    .word   0x951c2ad5
+    .word   0xe3f94128
+
+
+    .word   0x4abdea32
+    .word   0x8cd0d423
+    .word   0xee674694
+    .word   0xb1d106cb
+    .word   0x2cee95af
+    .word   0x6a881009
+    .word   0xdd1ce3ad
+    .word   0x6cdf5297
+
+
+    .word   0xe496ef7e
+    .word   0xbf24df85
+    .word   0xe7dac548
+    .word   0xa08bcab5
+    .word   0x6269e0d6
+    .word   0x10438318
+    .word   0x3cfc2704
+    .word   0x6421c660
+
+
+    .word   0xa2a0061b
+    .word   0x56b331ef
+    .word   0x3e2eda08
+    .word   0xc923c627
+    .word   0xeb6c5523
+    .word   0xdd592a63
+    .word   0xb1f2a050
+    .word   0x7de2808d
+
+
+    .word   0x20a8f1cf
+    .word   0xa6b82da8
+    .word   0x305ac3ad
+    .word   0xbd5729bf
+    .word   0xf2d3a27b
+    .word   0x62df561a
+    .word   0x98c4f075
+    .word   0x9bb83671
+
+
+    .word   0x2a04d360
+    .word   0xa8b29f3f
+    .word   0x8c89546f
+    .word   0x361f6bb9
+    .word   0x484d97aa
+    .word   0xa4535d76
+    .word   0xc2595c35
+    .word   0xb05f65e4
+
+
+    .word   0xe1be15ca
+    .word   0x949d105f
+    .word   0x3282dc85
+    .word   0x3114b147
+    .word   0xd50c6f99
+    .word   0x2f6d1d94
+    .word   0xb9888561
+    .word   0x674da503
+
+
+    .word   0x59c08eae
+    .word   0x74d01160
+    .word   0xe59b4600
+    .word   0xc05686c0
+    .word   0xc77a6fd0
+    .word   0x45559876
+    .word   0x8844df6
+    .word   0x4851969c
+
+
+    .word   0xb82eccdc
+    .word   0xc6d9382c
+    .word   0xa65858ec
+    .word   0x5c261dd8
+    .word   0xd5bdead9
+    .word   0x2ba5a683
+    .word   0xd64a13b7
+    .word   0xbf5e6128
+
+
+    .word   0x54d48d28
+    .word   0xdb7b6495
+    .word   0xd28a6f88
+    .word   0xde437bb8
+    .word   0x34ff2e48
+    .word   0xa4fb98a0
+    .word   0xcb58725d
+    .word   0x4ddc1b1d
+
+
+    .word   0x21822a1b
+    .word   0x2801b4f6
+    .word   0x7f3b897e
+    .word   0x214481dc
+    .word   0xd6b05422
+    .word   0x83ad3112
+    .word   0x18069637
+    .word   0xa75a0701
+
+
+    .word   0x7b297bc0
+    .word   0xef1f1229
+    .word   0xc8a6064d
+    .word   0xb3b45fde
+    .word   0x1f131cbe
+    .word   0xfde4bb59
+    .word   0x439b5135
+    .word   0xdb72101b
+
+
+    .word   0x7a5224e9
+    .word   0xe6939851
+    .word   0xd2e0713a
+    .word   0x9727f8a1
+    .word   0xdeceff21
+    .word   0x124da866
+    .word   0x2d53bc56
+    .word   0xe83c3394
+
+
+    .word   0x8301382b
+    .word   0x35ec9621
+    .word   0x184a1dc3
+    .word   0xa41855
+    .word   0x1cd109ac
+    .word   0x88199458
+    .word   0x5529fd02
+    .word   0xcd6ef781
+
+
+    .word   0x43dd690c
+    .word   0xa8c6c3f
+    .word   0x1afdc926
+    .word   0xe558cac1
+    .word   0xe643e9b2
+    .word   0x7a4a1851
+    .word   0x1061d2d
+    .word   0x7dc994be
+
+
+    .word   0x537523ae
+    .word   0x7744f7a
+    .word   0x1bd8731b
+    .word   0x4b4d9d42
+    .word   0xeb48c6d5
+    .word   0xd7581557
+    .word   0xcb46a53e
+    .word   0x9661b3b3
+
+
+    .word   0x5c9ad291
+    .word   0x4fbe136e
+    .word   0x8b244e4a
+    .word   0x698a4508
+    .word   0xa9fe7471
+    .word   0xf4d04473
+    .word   0xb3d7b0d
+    .word   0xa3cf0d21
+
+
+    .word   0x73739fb0
+    .word   0xb8e21c84
+    .word   0xf81e2cfe
+    .word   0x9e0902a8
+    .word   0xae235e6a
+    .word   0xd5fcab7a
+    .word   0xd37658f9
+    .word   0x67bb70fe
+
+
+    .word   0x8f12b04f
+    .word   0xf97fa8dc
+    .word   0xfaaa565d
+    .word   0x6610d6e5
+    .word   0x5785351a
+    .word   0x2f1f6e50
+    .word   0x2f32dc95
+    .word   0xbdaed433
+
+
+    .word   0x5ff67b79
+    .word   0xb231a797
+    .word   0xdade066c
+    .word   0xe30440b1
+    .word   0xd433d936
+    .word   0xb34d94ea
+    .word   0x38946c9e
+    .word   0xe6a97424
+
+
+    .word   0xa90a1464
+    .word   0xada6dc26
+    .word   0xc9f93e6a
+    .word   0xdf8edbd8
+    .word   0xcafdb5e0
+    .word   0xa8bf2cbe
+    .word   0xf7b68ee3
+    .word   0x4ccde29e
+
+
+    .word   0xced5619
+    .word   0x3af542b9
+    .word   0xbf3570ec
+    .word   0x1bb2b6b7
+    .word   0x35007953
+    .word   0xd81f23ba
+    .word   0x8dcd6720
+    .word   0xd237c15d
+
+
+    .word   0x6f05ce74
+    .word   0x18febe5f
+    .word   0xbe714a50
+    .word   0x13657293
+    .word   0x2401cd8f
+    .word   0x3ba5e34a
+    .word   0x402266a0
+    .word   0x4c7263b1
+
+
+    .word   0x32fabd24
+    .word   0x68420a21
+    .word   0xfeec769c
+    .word   0x7541494f
+    .word   0x1e7eef35
+    .word   0xcc122a3f
+    .word   0xa56e6096
+    .word   0x14b93ac6
+
+
+    .word   0xebff9e41
+    .word   0x10efad5f
+    .word   0xba278673
+    .word   0x4e57e698
+    .word   0xb0692ae
+    .word   0x836c674a
+    .word   0xd83680ee
+    .word   0x788a7b0
+
+
+    .word   0x924a9301
+    .word   0x9472d4a6
+    .word   0xfdabaeee
+    .word   0x52f6780
+    .word   0xee488974
+    .word   0xa403b1db
+    .word   0xd525f7d4
+    .word   0x4bafb70b
+
+
+    .word   0x1e612d59
+    .word   0x23211b8b
+    .word   0x2360ddd1
+    .word   0x630c788f
+    .word   0x2e671274
+    .word   0xe2d659e4
+    .word   0x114f41f5
+    .word   0x3bf3b8cc
+
+
+    .word   0x895e709c
+    .word   0xe1aeb337
+    .word   0x29e92497
+    .word   0xd12bba9f
+    .word   0x8017ae04
+    .word   0xc9225b0
+    .word   0xfb9acb31
+    .word   0x33aa74a2
+
+
+    .word   0xf3c6d31d
+    .word   0x8e007f55
+    .word   0x56dd982d
+    .word   0x94907daf
+    .word   0xd74bbb0b
+    .word   0xb8d36ca5
+    .word   0x6f868412
+    .word   0xecca07e5
+
+
+    .word   0x4091f242
+    .word   0xc8126a8d
+    .word   0x713e6f3c
+    .word   0xc46ee065
+    .word   0xd35ad90b
+    .word   0x941f9b88
+    .word   0x8ffb24d3
+    .word   0x81836f9a
+
+
+    .word   0xf62b011b
+    .word   0x44d99e4
+    .word   0x2eebe4ce
+    .word   0xe11b351f
+    .word   0xf45cf746
+    .word   0x33050fe
+    .word   0x2f42bdb4
+    .word   0xdf9518d1
+
+
+    .word   0xa9739832
+    .word   0x324147
+    .word   0xa7be2a91
+    .word   0xadefc5f4
+    .word   0xebf65c73
+    .word   0xfbe78b72
+    .word   0x99694b7
+    .word   0x56a3517b
+
+
+    .word   0x7374ac93
+    .word   0x81125d71
+    .word   0x25408900
+    .word   0x8c050b94
+    .word   0x6bc8cea9
+    .word   0x907dd80e
+    .word   0x686c9650
+    .word   0xb84a6438
+
+
+    .word   0xdd466420
+    .word   0x15448418
+    .word   0x368df5ae
+    .word   0xc4500e4
+    .word   0x736a769d
+    .word   0x26f4047d
+    .word   0x629eb701
+    .word   0x8c6eb9b8
+
+
+    .word   0x9fdedda8
+    .word   0x75a2f03e
+    .word   0x8f375ccd
+    .word   0xfab2ff83
+    .word   0x9a2fa77c
+    .word   0x804e9306
+    .word   0x6c5c724f
+    .word   0x1a0e568c
+
+
+    .word   0x26735b18
+    .word   0x78971835
+    .word   0xdc1b1670
+    .word   0xfbe6804e
+    .word   0x7baf6f0d
+    .word   0x14c85c6a
+    .word   0x5ccbf599
+    .word   0x68e0659e
+
+
+    .word   0x35b8f376
+    .word   0x4b540e1
+    .word   0x6f6f7be6
+    .word   0x5529fd02
+    .word   0xc1227c10
+    .word   0xf94033e4
+    .word   0x35d16343
+    .word   0x217ebda4
+
+
+    .word   0x6cbba65b
+    .word   0xbee79712
+    .word   0xb05f65e4
+    .word   0xad276726
+    .word   0x4d25011
+    .word   0x569648fd
+    .word   0x6d39c7c4
+    .word   0x20e1f702
+
+
+    .word   0x9b79446e
+    .word   0x2db17360
+    .word   0xdbc29fe8
+    .word   0x485436c5
+    .word   0xb54229ba
+    .word   0x5d126a59
+    .word   0x79b10f66
+    .word   0xca7dd6fc
+
+
+    .word   0xc8a523da
+    .word   0x79dd4967
+    .word   0xbf8edc07
+    .word   0xeb116778
+    .word   0x67a12451
+    .word   0x9c7e331f
+    .word   0xf661f536
+    .word   0x5607d178
+
+
+    .word   0x9d7c7cb2
+    .word   0xb1c6482
+    .word   0x1b3dd6ec
+    .word   0xe4f054be
+    .word   0x23352d8e
+    .word   0x15ed3226
+    .word   0x1a054a10
+    .word   0x7203c4cc
+
+
+    .word   0x33170bc6
+    .word   0xfe2a7889
+    .word   0x21fdd777
+    .word   0x2c20f77e
+    .word   0xd51810f1
+    .word   0xf8edc740
+    .word   0xefccc5b2
+    .word   0xc4bd3d61
+
+
+    .word   0x8ee3bdf3
+    .word   0xed677ad0
+    .word   0xd84d24f4
+    .word   0xe8f37dba
+    .word   0xa3e7b2c2
+    .word   0x8e297c79
+    .word   0x6e8283d9
+    .word   0xbafe29e4
+
+
+    .word   0xa4a6988f
+    .word   0xb79fb258
+    .word   0x2eb60a3c
+    .word   0x9e04bb4f
+    .word   0x8c9f31b0
+    .word   0xe21d8387
+    .word   0xd2a48025
+    .word   0xa159d44b
+
+
+    .word   0xada6dc26
+    .word   0xa3685330
+    .word   0xb2b91562
+    .word   0x7e09a919
+    .word   0xb5a54a80
+    .word   0xe643e9b2
+    .word   0xf589292c
+    .word   0x46633f7d
+
+
+    .word   0x69360c29
+    .word   0xa4fa4430
+    .word   0x4b572e99
+    .word   0x5ba5738c
+    .word   0x41f6ef18
+    .word   0x76fb25db
+    .word   0x5d915938
+    .word   0x383f72e8
+
+
+    .word   0x1c88d8eb
+    .word   0x8672631e
+    .word   0x71932f18
+    .word   0x8e8afdd5
+    .word   0xb6cc0dda
+    .word   0x70ca0c22
+    .word   0xd82feb42
+    .word   0x74e68aa1
+
+
+    .word   0xe5bfb8c2
+    .word   0xc7ee6e45
+    .word   0x66365d6a
+    .word   0x158c48a2
+    .word   0x2f4003e9
+    .word   0xb25903f8
+    .word   0xf33721bb
+    .word   0x974e631e
+
+
+    .word   0x968b1e75
+    .word   0x91aed081
+    .word   0xf8ed113a
+    .word   0x5ef5a372
+    .word   0xab5fcec4
+    .word   0x1061d2d
+    .word   0x609b7aad
+    .word   0x4d071e71
+
+
+    .word   0xffcc919c
+    .word   0xebff9e41
+    .word   0xfe651406
+    .word   0x1e13fbd9
+    .word   0xa8bf2cbe
+    .word   0x610bc694
+    .word   0xf01103c2
+    .word   0xd0993b43
+
+
+    .word   0x853b78c8
+    .word   0x6494752e
+    .word   0xadbe7015
+    .word   0x9406ec13
+    .word   0x4d3fc3ab
+    .word   0xe50274c2
+    .word   0x579a3033
+    .word   0x6e213c5c
+
+
+    .word   0xa8dcc8a3
+    .word   0xb2571c89
+    .word   0x7d90cd42
+    .word   0x280f9b66
+    .word   0xb4338a41
+    .word   0xdb4682f3
+    .word   0x52f6780
+    .word   0xba278673
+
+
+    .word   0xfef7a7db
+    .word   0xf2a35ab2
+    .word   0x8020939d
+    .word   0x9f3124d1
+    .word   0x6a9c4af
+    .word   0x7dae54ea
+    .word   0x43cd41e6
+    .word   0x5d45f02
+
+
+    .word   0x67471efc
+    .word   0x1f7e67a2
+    .word   0xb077816f
+    .word   0x72f9a835
+    .word   0x875bca82
+    .word   0x3c0f95e6
+    .word   0x6594633a
+    .word   0xa3391ac9
+
+
+    .word   0xdbac37a5
+    .word   0x9ad11033
+    .word   0xc780fca1
+    .word   0xa76c2ef3
+    .word   0x3d2d7d14
+    .word   0xe184c9e
+    .word   0xffd5d436
+    .word   0x4177e917
+
+
+    .word   0xaa09015
+    .word   0x6c4c4b6a
+    .word   0xc21a2840
+    .word   0x8b04dc29
+    .word   0xc20d60b0
+    .word   0x3f24ffba
+    .word   0x47dd5b74
+    .word   0xec9f6d89
+
+
+    .word   0x20c622c
+    .word   0xc5029984
+    .word   0x619cfb29
+    .word   0xa553bd2a
+    .word   0x69a655c7
+    .word   0x18ae755e
+    .word   0xbb9b7863
+    .word   0x7303a729
+
+
+    .word   0xeb8607ec
+    .word   0xf1f3deee
+    .word   0xb3c22b2c
+    .word   0x31049910
+    .word   0x359bf751
+    .word   0x6a48b54b
+    .word   0x459c8fc8
+    .word   0x4ecd6a95
+
+
+    .word   0xfaa8b8eb
+    .word   0xc65aae66
+    .word   0x7ef216ce
+    .word   0xb3f15d99
+    .word   0xcc528cb0
+    .word   0x12811af
+    .word   0xef1cd656
+    .word   0xdf3bb88
+
+
+    .word   0xef43e060
+    .word   0x2801b4f6
+    .word   0x31180624
+    .word   0x515fcfa3
+    .word   0x47113a4a
+    .word   0xe5a2086a
+    .word   0xe1aeb337
+    .word   0xbd49182e
+
+
+    .word   0x4ebddf50
+    .word   0xb6ed8fe6
+    .word   0xd6c0eb11
+    .word   0xbda000a8
+    .word   0xf0e9965
+    .word   0xf900e89d
+    .word   0x8cb8f9f
+    .word   0x2a21b42d
+
+
+    .word   0x5c0dd19a
+    .word   0x1606036f
+    .word   0x84b44550
+    .word   0x96b14ea4
+    .word   0xc4d80210
+    .word   0xb96eec1b
+    .word   0xad5c7cb5
+    .word   0xc0b3c17f
+
+
+    .word   0x766158cf
+    .word   0x56b331ef
+    .word   0xcf607593
+    .word   0x1394f0c2
+    .word   0x89a8e220
+    .word   0xe58de576
+    .word   0xd6227e35
+    .word   0x9bc66d8f
+
+
+    .word   0x5429c21e
+    .word   0xa240acf1
+    .word   0xd07f723e
+    .word   0xe411481a
+    .word   0x853e7c09
+    .word   0xfaa2415a
+    .word   0x6805077c
+    .word   0x24695d90
+
+
+    .word   0x4fc56249
+    .word   0xcee64ffc
+    .word   0x83676561
+    .word   0x906c3b9c
+    .word   0xc8bebd0a
+    .word   0x6e286238
+    .word   0x4267781d
+    .word   0x5c9064eb
+
+
+    .word   0x2b079b83
+    .word   0x4fece5cf
+    .word   0xeae3f887
+    .word   0x432c9054
+    .word   0x70ea77ce
+    .word   0xfde4bb59
+    .word   0xaecd547b
+    .word   0xd2b6ea3b
+
+
+    .word   0x9b84cab2
+    .word   0x286fa8c5
+    .word   0xdb2b6818
+    .word   0xd551f2a5
+    .word   0xe6d8dd88
+    .word   0x557e5b9c
+    .word   0xddacf4c6
+    .word   0xc5719eb1
+
+
+    .word   0x1b2b932c
+    .word   0xff9d6e4f
+    .word   0x78332a7e
+    .word   0xf73a7dc3
+    .word   0x512281cf
+    .word   0xd2a48025
+    .word   0xa90a1464
+    .word   0x2c3df307
+
+
+    .word   0x9a29ebb2
+    .word   0x8cebddfc
+    .word   0x33071c4
+    .word   0x6cbba65b
+    .word   0xc2595c35
+    .word   0xc6adc9c6
+    .word   0xe16c0668
+    .word   0xed0163a5
+
+
+    .word   0x252ef6d1
+    .word   0xa271ee7d
+    .word   0x3d1e4670
+    .word   0x792dfcf3
+    .word   0x3a895115
+    .word   0xe5dc0e06
+    .word   0x5bc160ae
+    .word   0x6c5c724f
+
+
+    .word   0x304fdd9a
+    .word   0xd284d374
+    .word   0x5ade47fd
+    .word   0xe5f7e2ef
+    .word   0xca6ec47f
+    .word   0xd22d6e1d
+    .word   0xd9f087b1
+    .word   0x7470dad6
+
+
+    .word   0xea864df7
+    .word   0x62df561a
+    .word   0x123c3032
+    .word   0x47c1a1d0
+    .word   0x656b66c5
+    .word   0x49f2695e
+    .word   0xb2992a8d
+    .word   0x3e4e3be5
+
+
+    .word   0x7720c0d4
+    .word   0xa0ae8ecc
+    .word   0xb52a75c6
+    .word   0xa63b5ca9
+    .word   0xd0f86a40
+    .word   0xcbefba84
+    .word   0x6e127392
+    .word   0xcad02fbf
+
+
+    .word   0x671ab6f3
+    .word   0x6a9f7014
+    .word   0xcadcfe97
+    .word   0xa4612dda
+    .word   0xa7c01ae5
+    .word   0x384456c5
+    .word   0x6e3c6dd9
+    .word   0x75e94852
+
+
+    .word   0x4d071e71
+    .word   0x14b93ac6
+    .word   0x5eea2f8e
+    .word   0x2031c9c8
+    .word   0x7e09a919
+    .word   0xe558cac1
+    .word   0x7689909b
+    .word   0x1af75504
+
+
+    .word   0xbd2f44b7
+    .word   0xc3b54b71
+    .word   0xa1cda3a2
+    .word   0xa682cc3d
+    .word   0x790699b7
+    .word   0x6409120a
+    .word   0x671ea653
+    .word   0x971ba59a
+
+
+    .word   0xe10097a0
+    .word   0x34b6c08c
+    .word   0x32a69c93
+    .word   0xbebca7ef
+    .word   0x741b5562
+    .word   0x4cd8136d
+    .word   0x53782768
+    .word   0x20c26ea5
+
+
+    .word   0x8e29d8ee
+    .word   0x2fc8f877
+    .word   0x47ea7ef5
+    .word   0x4249c078
+    .word   0xcec24123
+    .word   0xccaa54ee
+    .word   0x43552160
+    .word   0xb4338a41
+
+
+    .word   0xfdabaeee
+    .word   0xfe651406
+    .word   0xcafdb5e0
+    .word   0x8f808f82
+    .word   0x68471c13
+    .word   0x13752e2a
+    .word   0xdcb41ed7
+    .word   0x5032e79
+
+
+    .word   0x847873c6
+    .word   0x167aa68f
+    .word   0xdb4682f3
+    .word   0x10efad5f
+    .word   0x3d7e8ba3
+    .word   0x8be369e8
+    .word   0xfd77f699
+    .word   0x141b67b7
+
+
+    .word   0x7462a3a
+    .word   0x9986c897
+    .word   0x7e83a7ab
+    .word   0xcd184045
+    .word   0x6dcf8afe
+    .word   0x6e626943
+    .word   0xeffc7515
+    .word   0xad4d7e39
+
+
+    .word   0xf7a5949d
+    .word   0xb8c00ab
+    .word   0x45bf4a7b
+    .word   0x81319624
+    .word   0x2ed083ea
+    .word   0xee2f8bac
+    .word   0x7d3570e4
+    .word   0x2d238049
+
+
+    .word   0x728e05bc
+    .word   0x79ce9b5c
+    .word   0x5ef5a372
+    .word   0x7a4a1851
+    .word   0x1ec1d58c
+    .word   0x53dcae49
+    .word   0xb3bc2719
+    .word   0x37791734
+
+
+    .word   0x637800ea
+    .word   0x647d39a0
+    .word   0xe55d8b0e
+    .word   0x27703cf6
+    .word   0xde02f6fa
+    .word   0xd01a9583
+    .word   0xadb2dec6
+    .word   0x20cf3b61
+
+
+    .word   0x35bdac1
+    .word   0x70849e94
+    .word   0x45559876
+    .word   0xcfde8bf8
+    .word   0xdfc82445
+    .word   0x3a9f5cd9
+    .word   0x6d7c161e
+    .word   0xdabc9562
+
+
+    .word   0x37ff9886
+    .word   0x44626bb
+    .word   0x33f8cff6
+    .word   0xaea6ce83
+    .word   0x9de4d759
+    .word   0x230aa797
+    .word   0x208a3a6b
+    .word   0x84060b33
+
+
+    .word   0x335199a0
+    .word   0xbf1a2969
+    .word   0xef0aa059
+    .word   0xc70dbdbf
+    .word   0xc06a70a6
+    .word   0xc82f4713
+    .word   0xd3d763a9
+    .word   0x936a4f41
+
+
+    .word   0x4a982d83
+    .word   0xa403b1db
+    .word   0xda86395d
+    .word   0x99fbabe9
+    .word   0xff2844bf
+    .word   0x452147e1
+    .word   0xeb35cfc1
+    .word   0x13dd8cbc
+
+
+    .word   0x928cb3eb
+    .word   0x48bedc22
+    .word   0x68f1d185
+    .word   0x98fad788
+    .word   0xcf6a9aa1
+    .word   0x369004e7
+    .word   0x8de96b1a
+    .word   0xdbb094a7
+
+
+    .word   0x49c15310
+    .word   0x569648fd
+    .word   0xe88958fd
+    .word   0xcc82407b
+    .word   0xa380abfe
+    .word   0xed11b635
+    .word   0xa68a2d8d
+    .word   0xd26574ad
+
+
+    .word   0x39e2fe74
+    .word   0x53ad411d
+    .word   0x4d2bfdd8
+    .word   0xad368564
+    .word   0x99fd1645
+    .word   0x5baac64e
+    .word   0xd12e487
+    .word   0xd6a3f4d6
+
+
+    .word   0x3bd92093
+    .word   0xffd5d436
+    .word   0x8305539a
+    .word   0x6136577
+    .word   0xd58785a1
+    .word   0xda76ac76
+    .word   0xd214b05a
+    .word   0xe8726d3c
+
+
+    .word   0xee6ea9f
+    .word   0x47113a4a
+    .word   0x895e709c
+    .word   0x4a984a4d
+    .word   0x49be8fd
+    .word   0x70790817
+    .word   0x405198f3
+    .word   0xb7b6ceb0
+
+
+    .word   0xe7bafbea
+    .word   0xf94033e4
+    .word   0xb5016e81
+    .word   0xe7355e24
+    .word   0xf1159594
+    .word   0x836c674a
+    .word   0x53f6fbed
+    .word   0x544e6965
+
+
+    .word   0xf064367b
+    .word   0x29cdbd29
+    .word   0x698a4508
+    .word   0x8796793f
+    .word   0xa2ebf053
+    .word   0xef71a176
+    .word   0x37193766
+    .word   0xfe0c9db0
+
+
+    .word   0x86bcf373
+    .word   0xe73c25ca
+    .word   0x7a3a3ee5
+    .word   0xe9e6b880
+    .word   0xc080eace
+    .word   0xcfa0ee5e
+    .word   0xc1d83a66
+    .word   0xb9888561
+
+
+    .word   0x348c08ca
+    .word   0x50e4fa7f
+    .word   0x92502980
+    .word   0xb6cc201
+    .word   0xe7432037
+    .word   0xfbb0efd7
+    .word   0x2f32863f
+    .word   0xe1d24e46
+
+
+    .word   0x6f328dd4
+    .word   0x83512ba4
+    .word   0x61b9624d
+    .word   0x21f0431d
+    .word   0x1edcba07
+    .word   0x66847335
+    .word   0x9184766e
+    .word   0x353319ff
+
+
+    .word   0x16c7ceed
+    .word   0x5f7c9cc
+    .word   0x5914fd47
+    .word   0x284fe80f
+    .word   0xa3957b0b
+    .word   0xa6a1fbd
+    .word   0xdcd86801
+    .word   0x6e3c6dd9
+
+
+    .word   0x609b7aad
+    .word   0xa56e6096
+    .word   0x8ef96459
+    .word   0xf9e5e6e0
+    .word   0x8cebddfc
+    .word   0x217ebda4
+    .word   0xa4535d76
+    .word   0xbbda981f
+
+
+    .word   0xf3fe588f
+    .word   0x73f33556
+    .word   0x9436030f
+    .word   0xc5d221d3
+    .word   0x3cb338c8
+    .word   0x56bd2036
+    .word   0xa161b52d
+    .word   0x88d48707
+
+
+    .word   0x57431498
+    .word   0x51953e83
+    .word   0xb0f6c870
+    .word   0xc2686224
+    .word   0x21ab95ff
+    .word   0xfd006606
+    .word   0x9fc63456
+    .word   0xfc944b14
+
+
+    .word   0xf8e34485
+    .word   0x5a0a4350
+    .word   0x3af99eac
+    .word   0x1501a015
+    .word   0x4e12729d
+    .word   0x75d77f10
+    .word   0xe75317a8
+    .word   0x3cad5f11
+
+
+    .word   0x326c6d15
+    .word   0xdaf1f482
+    .word   0x180d697b
+    .word   0x507c021a
+    .word   0x122d54c5
+    .word   0xf3e8501a
+    .word   0x2bc62df4
+    .word   0xe1ff024b
+
+
+    .word   0xccaa54ee
+    .word   0x280f9b66
+    .word   0x9472d4a6
+    .word   0x5eea2f8e
+    .word   0xb2b91562
+    .word   0x1afdc926
+    .word   0xe5dc0e06
+    .word   0x804e9306
+
+
+    .word   0x26f79199
+    .word   0xeb6f9187
+    .word   0x39966f8a
+    .word   0x99ece313
+    .word   0x675fb7ac
+    .word   0x24e472a1
+    .word   0xb912b144
+    .word   0x201a1d73
+
+
+    .word   0x88de6f2c
+    .word   0x6c7f9e01
+    .word   0xb4024570
+    .word   0x8ec5fc20
+    .word   0x32ef7a8d
+    .word   0x847873c6
+    .word   0xb4338a41
+    .word   0xebff9e41
+
+
+    .word   0xdf8edbd8
+    .word   0x8962678e
+    .word   0xd48649ad
+    .word   0x95243545
+    .word   0xd0c9605c
+    .word   0x58af5246
+    .word   0xba3125
+    .word   0xc8f844a1
+
+
+    .word   0xe938ece1
+    .word   0x8d4a2bf3
+    .word   0xca0c3847
+    .word   0xfd0a9d8c
+    .word   0x94e65e4e
+    .word   0xaa86f2e6
+    .word   0x1634b987
+    .word   0xcc2f1d7b
+
+
+    .word   0x8dfa39f1
+    .word   0x99a238f8
+    .word   0x4d2041bd
+    .word   0x662244e9
+    .word   0xb89f949
+    .word   0x58bc8245
+    .word   0x33d43e63
+    .word   0x96636be4
+
+
+    .word   0x9dbcaf0b
+    .word   0x29fbd01b
+    .word   0xabeec815
+    .word   0x89722bc
+    .word   0x1aa0f699
+    .word   0xa6c1d727
+    .word   0xd3225a36
+    .word   0xfcbba6ef
+
+
+    .word   0x82d1652a
+    .word   0x334db50a
+    .word   0xfb7667a
+    .word   0x7f014ad4
+    .word   0xacf1b34a
+    .word   0x82a24c40
+    .word   0x883f1347
+    .word   0xa8b29f3f
+
+
+    .word   0x11bd633e
+    .word   0x91aed081
+    .word   0xd05aa0af
+    .word   0x7689909b
+    .word   0x84ef7e78
+    .word   0x715cfaa4
+    .word   0xb63032ef
+    .word   0xc8dcf86
+
+
+    .word   0xe7b93152
+    .word   0x4e7abbac
+    .word   0xce02c0e3
+    .word   0x8dcd6720
+    .word   0x6242bc6d
+    .word   0xde468679
+    .word   0x485df757
+    .word   0x9edebb1b
+
+
+    .word   0xa993d60c
+    .word   0xcc9907c0
+    .word   0x8c6eb9b8
+    .word   0x8e20deaf
+    .word   0xbdfa8286
+    .word   0x38385076
+    .word   0x7fd5af9d
+    .word   0xac2ac6dd
+
+
+    .word   0x6b8b978f
+    .word   0xa4281eb7
+    .word   0x983a4e0
+    .word   0x83b7c704
+    .word   0xe9b488ed
+    .word   0xd42296b3
+    .word   0xb44f68d9
+    .word   0x728e05bc
+
+
+    .word   0xf8ed113a
+    .word   0xe643e9b2
+    .word   0xda03fd98
+    .word   0x1dc56818
+    .word   0x79f8de62
+    .word   0xbfde89a1
+    .word   0x48dd5bbb
+    .word   0xddf1c3a
+
+
+    .word   0xaf5c0df
+    .word   0x9acbc1e
+    .word   0x55700f22
+    .word   0xd101768
+    .word   0xdcb3c7bb
+    .word   0xe334e2ae
+    .word   0x3dedbda
+    .word   0xd670c538
+
+
+    .word   0x1b552e0e
+    .word   0xf2b747d7
+    .word   0x923539c6
+    .word   0xa1ec8f00
+    .word   0xc3572640
+    .word   0x10f92379
+    .word   0xfe5c00a5
+    .word   0x11ea2e11
+
+
+    .word   0x115d108f
+    .word   0x4fece5cf
+    .word   0x1900beaa
+    .word   0xb3b45fde
+    .word   0xb3df6db8
+    .word   0xc7c289db
+    .word   0x23b161ae
+    .word   0x761d393f
+
+
+    .word   0x40e218f5
+    .word   0x59e46781
+    .word   0xa8e23226
+    .word   0x4a4cbc14
+    .word   0x79aff3cc
+    .word   0xb96eec1b
+    .word   0xd4667f3
+    .word   0x6421c660
+
+
+    .word   0x962c2aa2
+    .word   0x1f31c1ff
+    .word   0x3ee2c7f4
+    .word   0xb9ecd47f
+    .word   0x9a74f0b6
+    .word   0xe058056d
+    .word   0x48cac91c
+    .word   0xb410b890
+
+
+    .word   0x11921256
+    .word   0x713e6f3c
+    .word   0x70b4db6f
+    .word   0x3b87f944
+    .word   0xb68c0ec5
+    .word   0x64f97c5b
+    .word   0x5902c486
+    .word   0x2ce05ebe
+
+
+    .word   0x87ca93da
+    .word   0xdf393420
+    .word   0xffd1ddc7
+    .word   0xee3c5a10
+    .word   0x57cebb4f
+    .word   0x886dc3fc
+    .word   0x6d52ee1a
+    .word   0x4fa10ddb
+
+
+    .word   0xa1d6e4bc
+    .word   0x5811cb79
+    .word   0x8e297c79
+    .word   0x9f865e1
+    .word   0xe8726d3c
+    .word   0x515fcfa3
+    .word   0x3bf3b8cc
+    .word   0xdd7b24ef
+
+
+    .word   0xfafb52ec
+    .word   0x5dfb7044
+    .word   0x7af9c45e
+    .word   0xdc48ebe4
+    .word   0xab3f2943
+    .word   0x8acd354a
+    .word   0xbb6356d9
+    .word   0xc873d678
+
+
+    .word   0xb9224573
+    .word   0x133a2091
+    .word   0x1df616b2
+    .word   0xe811a98
+    .word   0xf570eb44
+    .word   0x913537ae
+    .word   0x782da3c4
+    .word   0xd5fcab7a
+
+
+    .word   0x65899028
+    .word   0xc1eafa13
+    .word   0xd6a3f4d6
+    .word   0xe184c9e
+    .word   0xb6d60979
+    .word   0xb764d573
+    .word   0xfcf1aab1
+    .word   0xf6b22e92
+
+
+    .word   0x100a72e7
+    .word   0x8b1285a6
+    .word   0x36106ef7
+    .word   0xad28482b
+    .word   0xd0eca428
+    .word   0xd57675e1
+    .word   0xd4025695
+    .word   0x3870df56
+
+
+    .word   0x14346e31
+    .word   0x8b8bfc8a
+    .word   0x3156b2e4
+    .word   0x7ca693ff
+    .word   0xfb053965
+    .word   0x112e6200
+    .word   0x2bd4ccda
+    .word   0x6ec4f1e1
+
+
+    .word   0xdc97029
+    .word   0x2bc62df4
+    .word   0xcec24123
+    .word   0x7d90cd42
+    .word   0x924a9301
+    .word   0x8ef96459
+    .word   0x9a29ebb2
+    .word   0x35d16343
+
+
+    .word   0x484d97aa
+    .word   0x724fdc34
+    .word   0x2a94a1f0
+    .word   0xd172d24f
+    .word   0xba493756
+    .word   0x4407ac2d
+    .word   0xd84cf17f
+    .word   0xad1dedc
+
+
+    .word   0x45aa1c2
+    .word   0xa436151c
+    .word   0x1463dacf
+    .word   0xa11efd83
+    .word   0x25500dcd
+    .word   0xdc91c34f
+    .word   0x66039a6e
+    .word   0xd5bbe564
+
+
+    .word   0xc78a4ca6
+    .word   0xf7d5a2c9
+    .word   0x6d9fbab3
+    .word   0x34575ad3
+    .word   0xc266f584
+    .word   0x37193766
+    .word   0xc60abaa3
+    .word   0xf3e134e2
+
+
+    .word   0x8ec5fc20
+    .word   0x5032e79
+    .word   0x280f9b66
+    .word   0x14b93ac6
+    .word   0xa3685330
+    .word   0xa8c6c3f
+    .word   0x4c66fe34
+    .word   0x3d40d09
+
+
+    .word   0xfd46dbfd
+    .word   0xe5c6f70b
+    .word   0xcd173fee
+    .word   0x32ef7a8d
+    .word   0x43552160
+    .word   0xffcc919c
+    .word   0xc9f93e6a
+    .word   0x78749c0d
+
+
+    .word   0x70d55fd3
+    .word   0x255ba6c1
+    .word   0xdff210c5
+    .word   0xca77c284
+    .word   0x3a67f4f4
+    .word   0x3714b41b
+    .word   0x281183cc
+    .word   0xb1f2a050
+
+
+    .word   0xbde37c62
+    .word   0xd22d6e1d
+    .word   0x7ce78925
+    .word   0xbd5729bf
+    .word   0x6d2f3d0a
+    .word   0x45d11c2c
+    .word   0xcd89e6d2
+    .word   0xead55073
+
+
+    .word   0xd71bbe6b
+    .word   0x8784821c
+    .word   0xb3e63fc7
+    .word   0xd9a6a151
+    .word   0x654f8f3b
+    .word   0x6e286238
+    .word   0xa6090d5c
+    .word   0x63ba55fa
+
+
+    .word   0xe5869049
+    .word   0x4fb01ed6
+    .word   0xf9bd4af
+    .word   0x8023f1a6
+    .word   0x86caf6bb
+    .word   0xb2b91562
+    .word   0x3a895115
+    .word   0x9a2fa77c
+
+
+    .word   0x22b54d0
+    .word   0x50f7b863
+    .word   0x5f3415e0
+    .word   0x7df49251
+    .word   0x185fccb5
+    .word   0x753ba568
+    .word   0xe4902eab
+    .word   0x8fd90727
+
+
+    .word   0x4032f34a
+    .word   0x9c44bfee
+    .word   0x2b26fcc0
+    .word   0xb6e4ecc4
+    .word   0x3dec7113
+    .word   0xd08d3bec
+    .word   0xcb773c3a
+    .word   0x44d99e4
+
+
+    .word   0xa2099d37
+    .word   0xb384771b
+    .word   0xf7c3a987
+    .word   0x7733381e
+    .word   0x53bf0e94
+    .word   0xfddae129
+    .word   0x3017e1cb
+    .word   0x26e55b14
+
+
+    .word   0xd7fa2f93
+    .word   0xd64a13b7
+    .word   0x506dcb76
+    .word   0xb88f6483
+    .word   0xa025d12d
+    .word   0xde437bb8
+    .word   0x6797a385
+    .word   0xf2d1a65a
+
+
+    .word   0x2956d272
+    .word   0x31bcd36
+    .word   0xb6ed8fe6
+    .word   0xcf36c376
+    .word   0xb9d103a6
+    .word   0x2976079
+    .word   0x1a3e57fc
+    .word   0xca576819
+
+
+    .word   0x5e00d27d
+    .word   0x60c911d0
+    .word   0xdcdcf469
+    .word   0x182b9872
+    .word   0x1ffaa0fa
+    .word   0x5cdf3237
+    .word   0x8c9f337b
+    .word   0xab332b00
+
+
+    .word   0x27e9d2e4
+    .word   0xa440f712
+    .word   0x6ad0ac14
+    .word   0x7b9760f5
+    .word   0x51755fcb
+    .word   0xc3c75db9
+    .word   0x438f29c0
+    .word   0x8a95939c
+
+
+    .word   0xda988966
+    .word   0x8f4c0250
+    .word   0xc94a4a86
+    .word   0x9cb7e170
+    .word   0xa9368981
+    .word   0x1c0c6173
+    .word   0xfa1f7008
+    .word   0x347874f5
+
+
+    .word   0x36b8bed
+    .word   0xc82f4713
+    .word   0xe3e762dc
+    .word   0x52f6780
+    .word   0x44dd334c
+    .word   0x1389ff4c
+    .word   0x572c0e6
+    .word   0xbd4130a2
+
+
+    .word   0x3f528239
+    .word   0x70790817
+    .word   0x270ed135
+    .word   0x5529fd02
+    .word   0xd42296b3
+    .word   0x2d238049
+    .word   0x91aed081
+    .word   0xe558cac1
+
+
+    .word   0x6b520bcc
+    .word   0x3bc9287d
+    .word   0x9bc6334d
+    .word   0x2f0290e9
+    .word   0xbe9156ac
+    .word   0xe4bb0181
+    .word   0xa5f9088d
+    .word   0x3dcbce0
+
+
+    .word   0xa6a3b7ce
+    .word   0xab8cf5e3
+    .word   0x9b2a585
+    .word   0xeb9862e6
+    .word   0x16de7f10
+    .word   0x985059bb
+    .word   0xc2cef55e
+    .word   0x92b97eef
+
+
+    .word   0xefd07126
+    .word   0x107eb02a
+    .word   0xcec38b39
+    .word   0x77dd8c44
+    .word   0xe01adfb1
+    .word   0x533b6d15
+    .word   0x484bd32e
+    .word   0x1b4f3d6d
+
+
+    .word   0x1be2c2a9
+    .word   0x690c166f
+    .word   0xa851c9e
+    .word   0x1d5dc7bc
+    .word   0xbce61eb0
+    .word   0x69b20ace
+    .word   0x4b68bdf5
+    .word   0xcfd09a55
+
+
+    .word   0xc3516aa9
+    .word   0x1d3e8c15
+    .word   0xed0163a5
+    .word   0x396a4d25
+    .word   0xc8a4bdab
+    .word   0x77732495
+    .word   0xf82f4081
+    .word   0x7fd5af9d
+
+
+    .word   0x53bb8132
+    .word   0xa524788f
+    .word   0xc1204618
+    .word   0x97af2b72
+    .word   0xbc0408c9
+    .word   0x2f32dc95
+    .word   0xd281afb6
+    .word   0x424514ca
+
+
+    .word   0x53971a76
+    .word   0xe30440b1
+    .word   0x4a919ba9
+    .word   0x2ba248f6
+    .word   0x27eaffca
+    .word   0x434dcf
+    .word   0xcbe1218d
+    .word   0x8e297c79
+
+
+    .word   0xd214b05a
+    .word   0x31180624
+    .word   0x114f41f5
+    .word   0x168ceeef
+    .word   0x2514c98e
+    .word   0xc799a99a
+    .word   0xa8102b19
+    .word   0xa1604531
+
+
+    .word   0x960757b6
+    .word   0x9101a182
+    .word   0xe0ea935b
+    .word   0xa6d0fa4e
+    .word   0xea154145
+    .word   0x10d75e15
+    .word   0x21309b90
+    .word   0x606d52ce
+
+
+    .word   0xe5b5e993
+    .word   0x7bc533d
+    .word   0x416f3871
+    .word   0xdf9faa5f
+    .word   0xed0f632f
+    .word   0x8c77ce4a
+    .word   0x91e967b2
+    .word   0x4caaf498
+
+
+    .word   0xfb5b9d6
+    .word   0x708dec5e
+    .word   0x7e150ea8
+    .word   0x6ca913cc
+    .word   0x670c10d0
+    .word   0xc74b2f97
+    .word   0xb649334c
+    .word   0xa8f2aed1
+
+
+    .word   0xe6732a41
+    .word   0x3a9f5cd9
+    .word   0x8aec15c3
+    .word   0xc60abaa3
+    .word   0xb4024570
+    .word   0xdcb41ed7
+    .word   0x7d90cd42
+    .word   0xa56e6096
+
+
+    .word   0x2c3df307
+    .word   0xf94033e4
+    .word   0x361f6bb9
+    .word   0x4e57e698
+    .word   0xfd4751f1
+    .word   0xe49a9acd
+    .word   0x756090a5
+    .word   0x3d8df9d1
+
+
+    .word   0x39b3c42a
+    .word   0xdf2c76f
+    .word   0x82eb1831
+    .word   0x65899028
+    .word   0xd12e487
+    .word   0x3d2d7d14
+    .word   0xb2b988af
+    .word   0xa6531a5
+
+
+    .word   0xe5c6f70b
+    .word   0x8ec5fc20
+    .word   0xccaa54ee
+    .word   0x4d071e71
+    .word   0xada6dc26
+    .word   0x43dd690c
+    .word   0xcdd869a3
+    .word   0xbf1ee877
+
+
+    .word   0x14ddfd5a
+    .word   0xc371ab27
+    .word   0x6142f527
+    .word   0x1b776ebd
+    .word   0xcefad323
+    .word   0x6327cf25
+    .word   0xf2a16d5a
+    .word   0xddacf4c6
+
+
+    .word   0x609acde2
+    .word   0xda0c63ed
+    .word   0xe5c66740
+    .word   0x9480cc51
+    .word   0x2fad8606
+    .word   0xa76769e0
+    .word   0x86d48373
+    .word   0x3025aca
+
+
+    .word   0x3149ca6d
+    .word   0x810d77e8
+    .word   0xa5d30e02
+    .word   0x41a14da5
+    .word   0x73c51dc5
+    .word   0x5a45a72
+    .word   0xc445f76
+    .word   0xfdbac6ae
+
+
+    .word   0x2d53c77b
+    .word   0x6f868412
+    .word   0xd2cbea0b
+    .word   0x2964074e
+    .word   0xff2f048a
+    .word   0xc46ee065
+    .word   0x9f6741fc
+    .word   0xcbf4171
+
+
+    .word   0xf3643f47
+    .word   0x6a4caf55
+    .word   0xf676f4a8
+    .word   0x86db935
+    .word   0xc15ef53b
+    .word   0x48008f5a
+    .word   0xc3549b10
+    .word   0xd56523c7
+
+
+    .word   0x6bcd6cbc
+    .word   0xeeb4d8e9
+    .word   0x852348e
+    .word   0x7ba45eea
+    .word   0x55383e92
+    .word   0x93677367
+    .word   0x1d0c8e91
+    .word   0xc86fe2db
+
+
+    .word   0x17408121
+    .word   0xd34c6b18
+    .word   0xf01d1c09
+    .word   0xb1a2021c
+    .word   0x8ca61385
+    .word   0xd44fa291
+    .word   0xba3b40c6
+    .word   0x6c4c4b6a
+
+
+    .word   0x161df7bf
+    .word   0xe69ab414
+    .word   0x34575ad3
+    .word   0xef71a176
+    .word   0xb7649819
+    .word   0x36abff1e
+    .word   0xc1a580f1
+    .word   0x4f4b36fc
+
+
+    .word   0xa270dc50
+    .word   0xfdcef61
+    .word   0xf931bc52
+    .word   0x524ee7be
+    .word   0xc7f501d5
+    .word   0xb820de39
+    .word   0x8bb97c94
+    .word   0xd8cf74b3
+
+
+    .word   0x424ba06b
+    .word   0x2877c2fa
+    .word   0xc70dbdbf
+    .word   0x629eb701
+    .word   0x8023f1a6
+    .word   0x5eea2f8e
+    .word   0x792dfcf3
+    .word   0xfab2ff83
+
+
+    .word   0xcee95bed
+    .word   0xfb12595a
+    .word   0xe9afb78d
+    .word   0x3de12cdf
+    .word   0x6c3f873b
+    .word   0x82a24c40
+    .word   0x1c763efa
+    .word   0x974e631e
+
+
+    .word   0x86c1888a
+    .word   0x4c66fe34
+    .word   0x994985ea
+    .word   0xf57fb159
+    .word   0x66dd3338
+    .word   0x9a49aa41
+    .word   0xcb1595d
+    .word   0x914e473c
+
+
+    .word   0xbe2d2dad
+    .word   0xbdd52777
+    .word   0xfa428d75
+    .word   0xd0cb0964
+    .word   0xbcd5c63b
+    .word   0x233a77fc
+    .word   0x51423a93
+    .word   0x15cef21e
+
+
+    .word   0x1a5a1068
+    .word   0xc7bce963
+    .word   0xfd7717cc
+    .word   0x505020ff
+    .word   0xe4ebc66b
+    .word   0xff09e8a1
+    .word   0x14444b52
+    .word   0xde10fe98
+
+
+    .word   0x13cbccf7
+    .word   0x59e46781
+    .word   0xabb6a3f4
+    .word   0x96b14ea4
+    .word   0x45c7cff2
+    .word   0x10438318
+    .word   0x5afca1c5
+    .word   0x94af6415
+
+
+    .word   0xe9ad3f98
+    .word   0x1ccdd1a1
+    .word   0x7643eda7
+    .word   0x4cb4b80f
+    .word   0xabe02bec
+    .word   0x79b10f66
+    .word   0xd5559d7a
+    .word   0x30d09e5b
+
+
+    .word   0x50f31d8f
+    .word   0xeb116778
+    .word   0x62bae39a
+    .word   0xa2084eb6
+    .word   0xc8342257
+    .word   0xfdd97b0d
+    .word   0xf51bd93
+    .word   0x2758774b
+
+
+    .word   0x9275b95a
+    .word   0xa29fc13e
+    .word   0x2621ce37
+    .word   0xb00d69fe
+    .word   0x35aca3e5
+    .word   0x9ebbdbbd
+    .word   0xea405bc5
+    .word   0xd10d9bce
+
+
+    .word   0xd4e2b8ab
+    .word   0x270ed135
+    .word   0xe9b488ed
+    .word   0x7d3570e4
+    .word   0x968b1e75
+    .word   0x1afdc926
+    .word   0x2f065120
+    .word   0xb5c425d2
+
+
+    .word   0xa13280b8
+    .word   0x92b80b5e
+    .word   0xe73c25ca
+    .word   0xd3ee6880
+    .word   0xc7cb323
+    .word   0x3114b147
+    .word   0x23f8a57c
+    .word   0xa3388b66
+
+
+    .word   0x32ff593f
+    .word   0x61616e28
+    .word   0xa2f9b36b
+    .word   0x7e9c3236
+    .word   0x94858f55
+    .word   0x3cc8c12f
+    .word   0x208da655
+    .word   0xb84ce36b
+
+
+    .word   0xa1e47020
+    .word   0xc7d4092b
+    .word   0xc1a56ce8
+    .word   0x699edbcf
+    .word   0xbad09d96
+    .word   0x6dea755f
+    .word   0x4319f089
+    .word   0xd2a48025
+
+
+    .word   0xc907754f
+    .word   0xd42296b3
+    .word   0x11bd633e
+    .word   0x7e09a919
+    .word   0x981d147b
+    .word   0xb5998080
+    .word   0x7b2c6a66
+    .word   0xcf43f569
+
+
+    .word   0x659e1e35
+    .word   0x71eba15f
+    .word   0xf6853462
+    .word   0x74e90e85
+    .word   0x103f22e1
+    .word   0x70d46419
+    .word   0xd546c83f
+    .word   0x36994f12
+
+
+    .word   0x9f55902c
+    .word   0x62f5f9cf
+    .word   0x434dcf
+    .word   0x5811cb79
+    .word   0xda76ac76
+    .word   0x2801b4f6
+    .word   0xe2d659e4
+    .word   0xdce1464
+
+
+    .word   0x3cc1d86f
+    .word   0x75222e5c
+    .word   0x74b041a5
+    .word   0xe0954244
+    .word   0x62bd7670
+    .word   0x8ab10151
+    .word   0x64b03fae
+    .word   0x8611ece0
+
+
+    .word   0xbd23b7ff
+    .word   0x632158bb
+    .word   0x242cc889
+    .word   0x30bdfd5a
+    .word   0x92a1b280
+    .word   0x93bc9f9
+    .word   0xd18bc375
+    .word   0xb1cd7632
+
+
+    .word   0x6a32c85d
+    .word   0xe88958fd
+    .word   0x264b32b
+    .word   0x25ad42a4
+    .word   0xec1c0ab0
+    .word   0xb2b988af
+    .word   0xfd46dbfd
+    .word   0xb4024570
+
+
+    .word   0xcec24123
+    .word   0x609b7aad
+    .word   0xa90a1464
+    .word   0xc1227c10
+    .word   0x8c89546f
+    .word   0x1e13fbd9
+    .word   0x76695606
+    .word   0xf088ef39
+
+
+    .word   0xa6531a5
+    .word   0xf3e134e2
+    .word   0xe1ff024b
+    .word   0x75e94852
+    .word   0xa159d44b
+    .word   0xcd6ef781
+    .word   0x77732495
+    .word   0x38385076
+
+
+    .word   0x6e859a1
+    .word   0x7cd0eb92
+    .word   0xb7908a66
+    .word   0x79cd9759
+    .word   0xfe5abc98
+    .word   0x56ee72da
+    .word   0xe06d0ee4
+    .word   0xc65ba618
+
+
+    .word   0x1154b7ff
+    .word   0x5a9e8753
+    .word   0x8adb3c27
+    .word   0x812487b3
+    .word   0x837c2429
+    .word   0x65d02c91
+    .word   0x678c07c3
+    .word   0x93c32125
+
+
+    .word   0x7df1d52
+    .word   0x4e2a55d7
+    .word   0x99258bd2
+    .word   0xf82f4081
+    .word   0x83a01f04
+    .word   0x52437d2c
+    .word   0x89864402
+    .word   0x6d5f600
+
+
+    .word   0xd58071fe
+    .word   0x4bccc3da
+    .word   0x8c122833
+    .word   0x95faee34
+    .word   0x91a90624
+    .word   0xfc54a7b3
+    .word   0x7153a631
+    .word   0xfc46eb71
+
+
+    .word   0x100502b5
+    .word   0x92ddaec4
+    .word   0x69d5387a
+    .word   0x6594633a
+    .word   0xdf2c76f
+    .word   0xd5fcab7a
+    .word   0x5baac64e
+    .word   0xa76c2ef3
+
+
+    .word   0x17d85ada
+    .word   0x42fdeba0
+    .word   0x3aab37f8
+    .word   0x8956a120
+    .word   0xdb3bb53d
+    .word   0x47ddb461
+    .word   0x94a18996
+    .word   0x2f32863f
+
+
+    .word   0x27bc6ab7
+    .word   0xf58fe3e3
+    .word   0xe52da01b
+    .word   0x8fd7e4ee
+    .word   0xab3d1aca
+    .word   0xe50299ae
+    .word   0x309a2231
+    .word   0x9986c897
+
+
+    .word   0x8b5a42e9
+    .word   0xcc0c0bee
+    .word   0xb553e239
+    .word   0xe1813ce5
+    .word   0xf5497cfe
+    .word   0x444e4d1a
+    .word   0xf73a2ad5
+    .word   0x85e4420a
+
+
+    .word   0xb94e292
+    .word   0x3714b41b
+    .word   0xe6f8f04f
+    .word   0xe5f7e2ef
+    .word   0x96dea7d4
+    .word   0xa6b82da8
+    .word   0x80fbb1e5
+    .word   0xea08ebfd
+
+
+    .word   0x9b78ec62
+    .word   0x10798b54
+    .word   0x715cfaa4
+    .word   0xa9fbaed5
+    .word   0xc7af1f64
+    .word   0x1bb2b6b7
+    .word   0xa03214db
+    .word   0x5341897e
+
+
+    .word   0x8e6858fb
+    .word   0xd0b22253
+    .word   0x881f9df1
+    .word   0x6ea29923
+    .word   0x6f620a88
+    .word   0xef1cd656
+    .word   0x56029e54
+    .word   0x2db814c2
+
+
+    .word   0xf634fc1b
+    .word   0x515fcfa3
+    .word   0x4be02934
+    .word   0x2a685b24
+    .word   0xd0a13c2a
+    .word   0x90fbb705
+    .word   0x9e2adf84
+    .word   0x982ff3da
+
+
+    .word   0xa3ca5109
+    .word   0x34c8a073
+    .word   0xa3f973ff
+    .word   0x34789dd6
+    .word   0xfdec15c0
+    .word   0xee69a00d
+    .word   0xbf43d831
+    .word   0xb500d85a
+
+
+    .word   0xef06787d
+    .word   0xfa5ce11f
+    .word   0x8b9f510f
+    .word   0x49e6484a
+    .word   0xdc6d436
+    .word   0x33aae467
+    .word   0xa1cd242f
+    .word   0xba6f3b3d
+
+
+    .word   0x6af8f9e8
+    .word   0x1c0c6173
+    .word   0x4dfccec3
+    .word   0xc70dbdbf
+    .word   0xf9bd4af
+    .word   0x9472d4a6
+    .word   0x3d1e4670
+    .word   0x8f375ccd
+
+
+    .word   0xa83c88d1
+    .word   0x27889c70
+    .word   0x5f10f00a
+    .word   0xad0fcdda
+    .word   0xeea2c5aa
+    .word   0x721433f7
+    .word   0x64734a44
+    .word   0x161df7bf
+
+
+    .word   0x6d9fbab3
+    .word   0xa2ebf053
+    .word   0xa88e1c62
+    .word   0xaf04c4fb
+    .word   0xa2519d3a
+    .word   0x87dd69d6
+    .word   0xa955beea
+    .word   0x6805077c
+
+
+    .word   0x7501138d
+    .word   0x8784821c
+    .word   0x5698c92d
+    .word   0x906c3b9c
+    .word   0xea92bffa
+    .word   0xd77da06d
+    .word   0xdd55dd6d
+    .word   0x42835a4d
+
+
+    .word   0x7770bb53
+    .word   0xcabe4f3c
+    .word   0xa1ec1e4
+    .word   0x48bb2e29
+    .word   0x4e202706
+    .word   0x72e197e7
+    .word   0x236fc402
+    .word   0xe6d8146c
+
+
+    .word   0xc5aafa08
+    .word   0x55643578
+    .word   0xb9ecd47f
+    .word   0xf753b931
+    .word   0x96c47aec
+    .word   0xecca07e5
+    .word   0x74b14e4
+    .word   0x5b96f17c
+
+
+    .word   0x9fd27987
+    .word   0xe857ba43
+    .word   0xfffb8114
+    .word   0xb794da7
+    .word   0x666b58e
+    .word   0x7e5bb199
+    .word   0x988e9366
+    .word   0x313474b9
+
+
+    .word   0x8999766b
+    .word   0xd8a2457a
+    .word   0x14216a2a
+    .word   0xcbf2cba0
+    .word   0x79642ed3
+    .word   0xd18c367e
+    .word   0xd10d9bce
+    .word   0x70790817
+
+
+    .word   0x83b7c704
+    .word   0xee2f8bac
+    .word   0x974e631e
+    .word   0xa8c6c3f
+    .word   0x1d5ea231
+    .word   0xe38166fa
+    .word   0xf9ba9ed9
+    .word   0x9f7ed5be
+
+
+    .word   0x8068b45b
+    .word   0xe16c0668
+    .word   0x1c79879d
+    .word   0x883f1347
+    .word   0xdcc6ad8f
+    .word   0x792dfcf3
+    .word   0x7d702411
+    .word   0x9517e168
+
+
+    .word   0x817fd806
+    .word   0xb20182de
+    .word   0x1ceb2ff4
+    .word   0x331503e1
+    .word   0x6455f635
+    .word   0x907dd80e
+    .word   0xb99371f0
+    .word   0x151cb3aa
+
+
+    .word   0x7095acc
+    .word   0x7b281cd1
+    .word   0x660e3959
+    .word   0x71aca016
+    .word   0x5c4d3f9b
+    .word   0x5eb37ec8
+    .word   0x57d49be6
+    .word   0x3d4e0563
+
+
+    .word   0x115f04f6
+    .word   0x869b9e41
+    .word   0x6dc6c41a
+    .word   0x6c809f12
+    .word   0x2e5d324c
+    .word   0x9f55902c
+    .word   0x27eaffca
+    .word   0xa1d6e4bc
+
+
+    .word   0xd58785a1
+    .word   0xef43e060
+    .word   0x2e671274
+    .word   0x5f00a2c9
+    .word   0xc02797c0
+    .word   0x88c1d991
+    .word   0x3b01905b
+    .word   0xceb1a53f
+
+
+    .word   0x532df525
+    .word   0xbf405aea
+    .word   0x93118b7f
+    .word   0x1fa1c34f
+    .word   0xf2ce63e9
+    .word   0x3b3a69e7
+    .word   0x4eed35d9
+    .word   0x76695606
+
+
+    .word   0xb2b988af
+    .word   0xc60abaa3
+    .word   0x2bc62df4
+    .word   0x6e3c6dd9
+    .word   0xd2a48025
+    .word   0x5529fd02
+    .word   0xa8b29f3f
+    .word   0x2031c9c8
+
+
+    .word   0x52922039
+    .word   0x47c1cc69
+    .word   0x129e5ab8
+    .word   0xf5dd117
+    .word   0x3b5f37c4
+    .word   0x6ba16b9
+    .word   0x852cf985
+    .word   0x83ced197
+
+
+    .word   0x3f574f79
+    .word   0xb0503e68
+    .word   0x87846e9
+    .word   0xbc3d44ea
+    .word   0xe17f95a
+    .word   0x8d73868
+    .word   0xcf34db44
+    .word   0x954548ca
+
+
+    .word   0x66a98216
+    .word   0x1900beaa
+    .word   0x2b2de4c1
+    .word   0x6e7e274e
+    .word   0x3560796
+    .word   0x98e48df3
+    .word   0xc4a494c0
+    .word   0xdc70102b
+
+
+    .word   0xd383b2c1
+    .word   0x9936994f
+    .word   0xc3b491b2
+    .word   0x9516a745
+    .word   0xa08f7540
+    .word   0x2976079
+    .word   0xc88f1edc
+    .word   0xd42f08d3
+
+
+    .word   0x3e91c18d
+    .word   0x5af5fbe2
+    .word   0x482b26ed
+    .word   0xd0570976
+    .word   0x4cbd2661
+    .word   0xb1c6482
+    .word   0xd9e7699c
+    .word   0x8d368ba1
+
+
+    .word   0x8f35362d
+    .word   0x77cc8bdc
+    .word   0x1e3a2c5c
+    .word   0xbe320ea1
+    .word   0xdbf74ea0
+    .word   0xdcb41ed7
+    .word   0x682d3d7
+    .word   0xb7b6ceb0
+
+
+    .word   0x5c958a2b
+    .word   0x10efad5f
+    .word   0x75694a20
+    .word   0x6cb4dc2b
+    .word   0x9ca7a7f7
+    .word   0x2c3c6a9f
+    .word   0x81a90c0b
+    .word   0xeb6f9187
+
+
+    .word   0xd3c3dec0
+    .word   0x9572c12d
+    .word   0x92ba4854
+    .word   0xa461cfb6
+    .word   0xd37fc48b
+    .word   0xbabb82ca
+    .word   0x7dcdb4a0
+    .word   0x74346a28
+
+
+    .word   0x4fd8311
+    .word   0xb942cce2
+    .word   0xca23dcd
+    .word   0xe3548bd6
+    .word   0x47304fb4
+    .word   0xd88e1bae
+    .word   0xfc9667a5
+    .word   0xe4615f50
+
+
+    .word   0xe5aa6da4
+    .word   0x375b5de4
+    .word   0x63ba55fa
+    .word   0x5ed2359a
+    .word   0x6f0b4932
+    .word   0xa159d44b
+    .word   0xc8a4bdab
+    .word   0xbdfa8286
+
+
+    .word   0xd005e72b
+    .word   0xbb22f683
+    .word   0x99875778
+    .word   0xeeaa9df0
+    .word   0xddac00cb
+    .word   0x69d5387a
+    .word   0x39b3c42a
+    .word   0x782da3c4
+
+
+    .word   0x99fd1645
+    .word   0xc780fca1
+    .word   0x90362bda
+    .word   0x63823c80
+    .word   0xa94ed7f4
+    .word   0xa0692be5
+    .word   0xaf6a6038
+    .word   0xadb2dec6
+
+
+    .word   0x1e6a57bd
+    .word   0xc74b2f97
+    .word   0x7874999e
+    .word   0xcfde8bf8
+    .word   0xf74b3afc
+    .word   0x6f09ca13
+    .word   0x72836e7f
+    .word   0x4637a6fb
+
+
+    .word   0x22bedb9e
+    .word   0xa8eab5
+    .word   0x9c97ab38
+    .word   0xd9f7d30c
+    .word   0xd683c502
+    .word   0x7d9c11dc
+    .word   0xc2ed2638
+    .word   0xea670da9
+
+
+    .word   0x90f3a8ed
+    .word   0xfb12595a
+    .word   0xea20c7fa
+    .word   0x7f014ad4
+    .word   0x538d05c7
+    .word   0xb25903f8
+    .word   0x4e2a55d7
+    .word   0x77732495
+
+
+    .word   0xbd4575ab
+    .word   0x4e9ecae2
+    .word   0x2ff4a03e
+    .word   0x71284af0
+    .word   0x60aec21c
+    .word   0xe0ba7303
+    .word   0xed95d6c5
+    .word   0xba65abb
+
+
+    .word   0xe6fe1fe1
+    .word   0x8c1be5bc
+    .word   0x89f626b0
+    .word   0xda7288aa
+    .word   0xe200eccf
+    .word   0x7e94b691
+    .word   0x724e234b
+    .word   0xa819644e
+
+
+    .word   0x7a119aa
+    .word   0x48159ec8
+    .word   0x4060b064
+    .word   0x6dd22f6d
+    .word   0xe47dda81
+    .word   0xb207259b
+    .word   0xaf9fe24
+    .word   0x4216beed
+
+
+    .word   0x23850de2
+    .word   0x8de96b1a
+    .word   0x9393e305
+    .word   0x675dae81
+    .word   0x7e24adf6
+    .word   0xcc82407b
+    .word   0xce8f5c07
+    .word   0x2faaeef0
+
+
+    .word   0x79fdd5c0
+    .word   0x206ad513
+    .word   0x1c0c6173
+    .word   0x2877c2fa
+    .word   0x4fb01ed6
+    .word   0x280f9b66
+    .word   0xa271ee7d
+    .word   0x75a2f03e
+
+
+    .word   0xdb654731
+    .word   0x11e883aa
+    .word   0x57c0987
+    .word   0xd4705aca
+    .word   0x87c3c4d7
+    .word   0xe77ce217
+    .word   0xbbd4b966
+    .word   0x3ae1664c
+
+
+    .word   0xd61a23f9
+    .word   0x4a8b71d4
+    .word   0x85293046
+    .word   0x339ca551
+    .word   0x6d47f210
+    .word   0x7bf739c9
+    .word   0xfdc41636
+    .word   0xe334e2ae
+
+
+    .word   0x2ae39171
+    .word   0xf0a9421a
+    .word   0x8659604e
+    .word   0x3c271955
+    .word   0xb7742237
+    .word   0x107b0a36
+    .word   0xc74d2dd1
+    .word   0x335415b5
+
+
+    .word   0x48e13a62
+    .word   0x655fd225
+    .word   0xb21e5442
+    .word   0x91b5234b
+    .word   0xfd0b59b0
+    .word   0xf0a5854d
+    .word   0x403bc7d4
+    .word   0x16d5b9e8
+
+
+    .word   0x361d3c68
+    .word   0xeb7370cd
+    .word   0x82ee5787
+    .word   0x53f6fbed
+    .word   0x721433f7
+    .word   0x6c4c4b6a
+    .word   0xf7d5a2c9
+    .word   0x8796793f
+
+
+    .word   0xf95c7fe2
+    .word   0x2a1e2aef
+    .word   0x9ff44e9c
+    .word   0x79642ed3
+    .word   0xea405bc5
+    .word   0x3f528239
+    .word   0x983a4e0
+    .word   0x2ed083ea
+
+
+    .word   0xf33721bb
+    .word   0x43dd690c
+    .word   0x7f509a14
+    .word   0x7ab6c06e
+    .word   0x86ece198
+    .word   0xdc988c50
+    .word   0xed775683
+    .word   0xf93a3d69
+
+
+    .word   0x32820af6
+    .word   0xf2bdfb1f
+    .word   0x10906cb7
+    .word   0x7fcab352
+    .word   0x161a4c96
+    .word   0xab665e7c
+    .word   0x144ccf5a
+    .word   0x83c89721
+
+
+    .word   0xfbdd5611
+    .word   0xf4691456
+    .word   0xf663a567
+    .word   0xcb773c3a
+    .word   0x52529d5
+    .word   0xcb2627f7
+    .word   0x47871a30
+    .word   0x8d259ffa
+
+
+    .word   0x6c809f12
+    .word   0x36994f12
+    .word   0x2ba248f6
+    .word   0x4fa10ddb
+    .word   0x6136577
+    .word   0xdf3bb88
+    .word   0x630c788f
+    .word   0x296ec49f
+
+
+    .word   0x18ab0a0
+    .word   0x4eed35d9
+    .word   0xec1c0ab0
+    .word   0x8aec15c3
+    .word   0xdc97029
+    .word   0xdcd86801
+    .word   0x512281cf
+    .word   0x6f6f7be6
+
+
+    .word   0x2a04d360
+    .word   0xf9e5e6e0
+    .word   0xa01110fa
+    .word   0x80c3ebff
+    .word   0xa146635d
+    .word   0xe58753dd
+    .word   0xc36a8138
+    .word   0x812314b4
+
+
+    .word   0x1430108b
+    .word   0xe162d28d
+    .word   0x483b6207
+    .word   0x5c4e1494
+    .word   0xf02a789
+    .word   0x3a828f3c
+    .word   0x7d792b1e
+    .word   0xb2c396f8
+
+
+    .word   0x203e6d41
+    .word   0x6dea755f
+    .word   0xafea03b4
+    .word   0x83b7c704
+    .word   0x1c763efa
+    .word   0xa3685330
+    .word   0x4e78eb7c
+    .word   0x5887e9dc
+
+
+    .word   0x548d0fe1
+    .word   0xcfd373b9
+    .word   0xd01c2889
+    .word   0x4fd54c4d
+    .word   0xc0ef93e2
+    .word   0xe58de576
+    .word   0x9e725838
+    .word   0x54252b5d
+
+
+    .word   0xc691a85e
+    .word   0x9b9f7cd9
+    .word   0xa5d70705
+    .word   0x8525c49f
+    .word   0x78042a38
+    .word   0xa41a0278
+    .word   0x1ccc3cdb
+    .word   0xbf77e564
+
+
+    .word   0xf75fa1bf
+    .word   0x74b14e4
+    .word   0x66fa46c3
+    .word   0x6f7c80fd
+    .word   0x96bccd70
+    .word   0x879a6721
+    .word   0x456cc67b
+    .word   0x2bc62df4
+
+
+    .word   0x4319f089
+    .word   0x270ed135
+    .word   0x883f1347
+    .word   0x5eea2f8e
+    .word   0x3b828212
+    .word   0x37b0c940
+    .word   0x5ae54e2b
+    .word   0x4f48945d
+
+
+    .word   0x36302b0e
+    .word   0x61c90f6f
+    .word   0x17a99b03
+    .word   0x846f92b2
+    .word   0xd121b30a
+    .word   0x2824b9a9
+    .word   0xf4fca80e
+    .word   0x15a12c00
+
+
+    .word   0x9c1d3fa7
+    .word   0x9cdf2109
+    .word   0xc371ab27
+    .word   0x88241fc
+    .word   0x199f5990
+    .word   0xd551f2a5
+    .word   0xc9103f59
+    .word   0xbfd337
+
+
+    .word   0xb1797412
+    .word   0x3a98f22a
+    .word   0x42c0e8e6
+    .word   0x96695b30
+    .word   0x84ad1ec6
+    .word   0x6d7884b7
+    .word   0xa0c22203
+    .word   0xd0e4c63c
+
+
+    .word   0x3dc022a6
+    .word   0xb1d106cb
+    .word   0x64f3781e
+    .word   0xab20b6f6
+    .word   0xa15f6786
+    .word   0x9f0b33c5
+    .word   0xee0926f6
+    .word   0x8282d333
+
+
+    .word   0xb214984d
+    .word   0x283b030c
+    .word   0x77944118
+    .word   0xe6688c99
+    .word   0xe24c89dc
+    .word   0x2c196031
+    .word   0xf3e2cf8f
+    .word   0xa9859180
+
+
+    .word   0xfe9644e7
+    .word   0x1634b987
+    .word   0x63a7e7b4
+    .word   0x46f6b632
+    .word   0xd82ab3f8
+    .word   0x662244e9
+    .word   0x380d5f45
+    .word   0xf9b947b1
+
+
+    .word   0x6d48cc93
+    .word   0x444e4d1a
+    .word   0x89ee68a2
+    .word   0xca77c284
+    .word   0xa360fea
+    .word   0xd284d374
+    .word   0xfbd719df
+    .word   0x7de2808d
+
+
+    .word   0x8588d76
+    .word   0x12f63dbe
+    .word   0xcd785963
+    .word   0xb5b6621e
+    .word   0xe1014277
+    .word   0xc86088ca
+    .word   0x466f9dda
+    .word   0xcbe1218d
+
+
+    .word   0xc5cf8b43
+    .word   0xd2586431
+    .word   0x5e97f689
+    .word   0x30cd2211
+    .word   0x578deedd
+    .word   0x3079404
+    .word   0xeeaa9df0
+    .word   0x92ddaec4
+
+
+    .word   0x3d8df9d1
+    .word   0x913537ae
+    .word   0xad368564
+    .word   0x9ad11033
+    .word   0xc48c8489
+    .word   0xe676761d
+    .word   0x7cdca61a
+    .word   0xacdb5c7c
+
+
+    .word   0x40ac9dd3
+    .word   0xc85d0e03
+    .word   0x7b1e175b
+    .word   0x75d517ab
+    .word   0x43df20e2
+    .word   0x3114b147
+    .word   0x8ba778db
+    .word   0x9cd49976
+
+
+    .word   0xc8666d5d
+    .word   0xf3a78139
+    .word   0xd8cf74b3
+    .word   0x485df757
+    .word   0x5ed2359a
+    .word   0x75e94852
+    .word   0x396a4d25
+    .word   0x8e20deaf
+
+
+    .word   0xd571df1
+    .word   0x80847fe6
+    .word   0x3527f652
+    .word   0x46d41961
+    .word   0x80d9cc83
+    .word   0x3d188e00
+    .word   0xcd414a1a
+    .word   0x9b59a674
+
+
+    .word   0xd9642bb
+    .word   0x491c9657
+    .word   0xf6c9a598
+    .word   0xe6aee8fb
+    .word   0x5af475c8
+    .word   0x7e779ac8
+    .word   0x5fa24721
+    .word   0xfddae129
+
+
+    .word   0xd09a02cb
+    .word   0xde79ca84
+    .word   0xb80663dc
+    .word   0xbf5e6128
+    .word   0x24d9042f
+    .word   0x166c0404
+    .word   0x291ad473
+    .word   0xa02bf03e
+
+
+    .word   0x75463ca2
+    .word   0x9eb6637a
+    .word   0x968a75e5
+    .word   0x99193e31
+    .word   0x454fd6f9
+    .word   0x8efb2902
+    .word   0x2208036c
+    .word   0xd21a445f
+
+
+    .word   0x6d13692a
+    .word   0x79fdd5c0
+    .word   0x6af8f9e8
+    .word   0x424ba06b
+    .word   0xe5869049
+    .word   0xccaa54ee
+    .word   0x252ef6d1
+    .word   0x9fdedda8
+
+
+    .word   0xcaf89059
+    .word   0x9f93a1dd
+    .word   0x51cbaf16
+    .word   0x7a10cd9a
+    .word   0xc63d5bce
+    .word   0xfe5c00a5
+    .word   0x885dae15
+    .word   0xf084e51b
+
+
+    .word   0xa689bd05
+    .word   0xb3b45fde
+    .word   0xc53d5984
+    .word   0xc3d25baa
+    .word   0x88b9b945
+    .word   0x9e25ebd6
+    .word   0xd84006fa
+    .word   0x2ce46671
+
+
+    .word   0x20ba0b8d
+    .word   0x538d05c7
+    .word   0x7df1d52
+    .word   0xc8a4bdab
+    .word   0x896801fa
+    .word   0x87ae7e39
+    .word   0xbbb020b6
+    .word   0x18bfa53a
+
+
+    .word   0xee31cfa6
+    .word   0x46288417
+    .word   0xd76ff15
+    .word   0xa8840d73
+    .word   0x120d4aab
+    .word   0x1459bdb9
+    .word   0x475feb31
+    .word   0xbf65f83b
+
+
+    .word   0x2a1e2aef
+    .word   0xcbf2cba0
+    .word   0x9ebbdbbd
+    .word   0xbd4130a2
+    .word   0xa4281eb7
+    .word   0x81319624
+    .word   0xb25903f8
+    .word   0xcd6ef781
+
+
+    .word   0x7c4d6b3d
+    .word   0x4ebb2b70
+    .word   0x66abf3e4
+    .word   0x21374b87
+    .word   0xf4059b5d
+    .word   0x87dd69d6
+    .word   0x9edbe023
+    .word   0xead55073
+
+
+    .word   0x862c6ef0
+    .word   0xcee64ffc
+    .word   0xda3c1e7d
+    .word   0x47871a30
+    .word   0x6dc6c41a
+    .word   0xd546c83f
+    .word   0x4a919ba9
+    .word   0x6d52ee1a
+
+
+    .word   0x8305539a
+    .word   0xef1cd656
+    .word   0x2360ddd1
+    .word   0x9f865e1
+    .word   0x666b82c5
+    .word   0xd17eada9
+    .word   0xee77481c
+    .word   0xb2a77417
+
+
+    .word   0xcd7f56e6
+    .word   0x82ee5787
+    .word   0xeea2c5aa
+    .word   0xba3b40c6
+    .word   0xc78a4ca6
+    .word   0x698a4508
+    .word   0xc3932912
+    .word   0xf7433cc4
+
+
+    .word   0x752b99af
+    .word   0x321fe70b
+    .word   0x817af8a7
+    .word   0xeac6be48
+    .word   0x5d13a1c
+    .word   0x44626bb
+    .word   0x7f998cc7
+    .word   0x1fa6d1db
+
+
+    .word   0x552f773a
+    .word   0x5002f7d3
+    .word   0x2152d48d
+    .word   0xf6e4da96
+    .word   0x45427376
+    .word   0x17c4b8af
+    .word   0xe4ec4d0f
+    .word   0xb27ed261
+
+
+    .word   0x3a5790a3
+    .word   0x29bd16c2
+    .word   0x502f611f
+    .word   0x71da8d8d
+    .word   0x3a6542ef
+    .word   0x61f99cfc
+    .word   0xe10998e7
+    .word   0xa524788f
+
+
+    .word   0xe147e1d5
+    .word   0x60060ac8
+    .word   0x7b3883c8
+    .word   0xbdaed433
+    .word   0xf6600874
+    .word   0xb563e3d6
+    .word   0xe9c54604
+    .word   0x69c349d8
+
+
+    .word   0xe723b4e4
+    .word   0xd4025695
+    .word   0x1c23ace3
+    .word   0xde998c
+    .word   0x74ca1647
+    .word   0x7ca693ff
+    .word   0xddb29368
+    .word   0xa8fe07e2
+
+
+    .word   0xf09dbb8d
+    .word   0x9bd49b97
+    .word   0x30bdfd5a
+    .word   0xddf56a0d
+    .word   0x2ea77bfc
+    .word   0xdbb094a7
+    .word   0x8fc65d62
+    .word   0xcd9da9c1
+
+
+    .word   0xc24789a8
+    .word   0x29335dab
+    .word   0xa8b1c674
+    .word   0xedd68016
+    .word   0xa37f029d
+    .word   0x915bbe4a
+    .word   0x46a54a0b
+    .word   0xb410655
+
+
+    .word   0xf3fc3400
+    .word   0x1bb2b6b7
+    .word   0xe98636d0
+    .word   0xc5779c7a
+    .word   0xe784964c
+    .word   0xd485cb67
+    .word   0x99d6118d
+    .word   0x4a23ec4b
+
+
+    .word   0xa2777727
+    .word   0xabb6a3f4
+    .word   0xaee54f96
+    .word   0xc94c5505
+    .word   0x755a8620
+    .word   0xcc748072
+    .word   0xa78833cf
+    .word   0x228e614e
+
+
+    .word   0x93a8ffeb
+    .word   0xffc73953
+    .word   0xc23c2b0c
+    .word   0x2607c82e
+    .word   0x3c175d5c
+    .word   0xd9885861
+    .word   0xdd91e45c
+    .word   0xe505d397
+
+
+    .word   0x61adf3fb
+    .word   0x77cc8bdc
+    .word   0x879a6721
+    .word   0xc60abaa3
+    .word   0x6dea755f
+    .word   0x70790817
+    .word   0x82a24c40
+    .word   0x14b93ac6
+
+
+    .word   0x954759c1
+    .word   0x2fbd5399
+    .word   0xe13c898e
+    .word   0x3c316c1b
+    .word   0x5d03dfa8
+    .word   0x13bd7b71
+    .word   0x74bd05b5
+    .word   0x5f2ce979
+
+
+    .word   0xb4562e31
+    .word   0xd1abca60
+    .word   0xaaa34f8e
+    .word   0xff30a02c
+    .word   0xe7e9e742
+    .word   0xd562c6cd
+    .word   0x63cf7fb8
+    .word   0xc375ae70
+
+
+    .word   0x1857f792
+    .word   0xa86a6749
+    .word   0xc722b7d4
+    .word   0x17a712c
+    .word   0x836b008
+    .word   0x7632d66a
+    .word   0x24a2f75e
+    .word   0x8df6f70f
+
+
+    .word   0xf1292db6
+    .word   0xa058446f
+    .word   0x9c9858b5
+    .word   0x20875191
+    .word   0x7ee70256
+    .word   0x630c788f
+    .word   0xb571d5d0
+    .word   0x35ce6a8b
+
+
+    .word   0xcec54e28
+    .word   0x392d30f1
+    .word   0x42fdeba0
+    .word   0x1b6ea0f5
+    .word   0x1a7caa97
+    .word   0xb6cc201
+    .word   0x6b641d0e
+    .word   0xb6f41648
+
+
+    .word   0x4b9000ce
+    .word   0xaf5640f6
+    .word   0xcf128993
+    .word   0x22ea3acf
+    .word   0x7a69cddc
+    .word   0xa6090d5c
+    .word   0xe2c99092
+    .word   0x4319f089
+
+
+    .word   0x1c79879d
+    .word   0x8023f1a6
+    .word   0xf123c30d
+    .word   0xf107461e
+    .word   0x3d9add7b
+    .word   0xb54739c0
+    .word   0xdd1b780e
+    .word   0x5a45a72
+
+
+    .word   0xc037f849
+    .word   0x589ed360
+    .word   0xbf77e564
+    .word   0xecca07e5
+    .word   0x4990a8f8
+    .word   0x18d64139
+    .word   0x3a0bf56f
+    .word   0x578deedd
+
+
+    .word   0x99875778
+    .word   0x100502b5
+    .word   0x756090a5
+    .word   0xf570eb44
+    .word   0x4d2bfdd8
+    .word   0xdbac37a5
+    .word   0x61dd3cb1
+    .word   0x11ada0b7
+
+
+    .word   0xb52c799a
+    .word   0xe5724f25
+    .word   0x1dec0adb
+    .word   0x4350b442
+    .word   0xc29f3cf6
+    .word   0x73f33556
+    .word   0xf223cd74
+    .word   0xec4d7f3e
+
+
+    .word   0xb2329ce4
+    .word   0x235466d
+    .word   0xd06a1465
+    .word   0xa748bc4f
+    .word   0x7019d3e8
+    .word   0xaf68ed3c
+    .word   0x4534fb14
+    .word   0xfe711b74
+
+
+    .word   0xa69746cd
+    .word   0xadefc5f4
+    .word   0xfa532c36
+    .word   0xfcdf901b
+    .word   0x522ac8e4
+    .word   0x60b54f26
+    .word   0xc38ab9ad
+    .word   0x6797a385
+
+
+    .word   0xfe95ed87
+    .word   0x9936994f
+    .word   0xb65a5b97
+    .word   0xcf36c376
+    .word   0xd82d755c
+    .word   0xbd6835b7
+    .word   0xeb25a737
+    .word   0x778ec2d1
+
+
+    .word   0xc4fddf63
+    .word   0xa0692be5
+    .word   0xb0941cdd
+    .word   0x6ca913cc
+    .word   0x44b40fab
+    .word   0x70849e94
+    .word   0xf8dd551d
+    .word   0xffd76daa
+
+
+    .word   0xd21a445f
+    .word   0x2faaeef0
+    .word   0xba6f3b3d
+    .word   0xd8cf74b3
+    .word   0x63ba55fa
+    .word   0xe1ff024b
+    .word   0xed0163a5
+    .word   0x8c6eb9b8
+
+
+    .word   0x8a82939
+    .word   0x7f1b8e2e
+    .word   0x2a908741
+    .word   0xb6220740
+    .word   0x9732ed15
+    .word   0xa07d54f5
+    .word   0xf7e046f3
+    .word   0x756d2935
+
+
+    .word   0xb426b8f3
+    .word   0x92d99e66
+    .word   0x47e6442e
+    .word   0x35b76097
+    .word   0x38e99a43
+    .word   0xb96dff76
+    .word   0x79fab13f
+    .word   0xc18a7cb7
+
+
+    .word   0x3c4b3f6e
+    .word   0x53cdf3a9
+    .word   0x3f213847
+    .word   0x32e5631a
+    .word   0xf1febbe5
+    .word   0x475feb31
+    .word   0xf95c7fe2
+    .word   0x14216a2a
+
+
+    .word   0x35aca3e5
+    .word   0x572c0e6
+    .word   0x6b8b978f
+    .word   0x45bf4a7b
+    .word   0x2f4003e9
+    .word   0x5529fd02
+    .word   0x3c3091f0
+    .word   0x56ea73ae
+
+
+    .word   0x4f2b2f45
+    .word   0x1639b380
+    .word   0xe2d6bd69
+    .word   0x23950bc4
+    .word   0x4d3da63a
+    .word   0x58af5246
+    .word   0x358966ff
+    .word   0xce1cd52b
+
+
+    .word   0x5a347f15
+    .word   0x9daa1766
+    .word   0x324af8a
+    .word   0xf60ed64a
+    .word   0xc741e5a2
+    .word   0xc8cf4e82
+    .word   0x5ab0dd87
+    .word   0x7fad703c
+
+
+    .word   0xd8bc3815
+    .word   0x2ced42bb
+    .word   0x7c79a32f
+    .word   0x1adaa18b
+    .word   0xad75c3d0
+    .word   0xe5e67330
+    .word   0x6b159631
+    .word   0x1ccdd1a1
+
+
+    .word   0xdb59c68f
+    .word   0x1e47a3df
+    .word   0x22c3ff45
+    .word   0xca7dd6fc
+    .word   0x7efb0840
+    .word   0x4599375b
+    .word   0x5f8953e8
+    .word   0x65f3d022
+
+
+    .word   0x483251cb
+    .word   0x4b35810e
+    .word   0x784d270e
+    .word   0x309a2231
+    .word   0xadb07f3
+    .word   0x37d4fcf3
+    .word   0xa8789948
+    .word   0x8ab32c60
+
+
+    .word   0x86e4d5d6
+    .word   0x3eb63b36
+    .word   0xe38166fa
+    .word   0x4b68bdf5
+    .word   0x2ce46671
+    .word   0x7f014ad4
+    .word   0x93c32125
+    .word   0x396a4d25
+
+
+    .word   0x63ca9122
+    .word   0x81d81c9f
+    .word   0x6769ed11
+    .word   0xb84a4f1
+    .word   0xbd1dec09
+    .word   0xb4ed633d
+    .word   0x5322811c
+    .word   0x5ed6d3ed
+
+
+    .word   0xa6d5bec3
+    .word   0x2c20f77e
+    .word   0x37f054d3
+    .word   0xfc192679
+    .word   0x7609a729
+    .word   0xb410070e
+    .word   0xb2a77417
+    .word   0xeb7370cd
+
+
+    .word   0xad0fcdda
+    .word   0xd44fa291
+    .word   0xd5bbe564
+    .word   0x29cdbd29
+    .word   0x25829491
+    .word   0xbe0eb3fb
+    .word   0x7909e83c
+    .word   0x86d8fb62
+
+
+    .word   0x4badb487
+    .word   0xa7ca9ade
+    .word   0x4232f8d3
+    .word   0x5786c80
+    .word   0xda282c0b
+    .word   0xf436154f
+    .word   0xc5b924a5
+    .word   0x1e7ed261
+
+
+    .word   0xbfd0a038
+    .word   0x3a828f3c
+    .word   0x3fe62ce3
+    .word   0x699edbcf
+    .word   0xe8adf36f
+    .word   0xa4281eb7
+    .word   0x538d05c7
+    .word   0xa159d44b
+
+
+    .word   0x55775fb0
+    .word   0x53f5a662
+    .word   0x54b89201
+    .word   0x65fafa25
+    .word   0x563bd2ee
+    .word   0x21309b90
+    .word   0x646e1395
+    .word   0x6ae022e4
+
+
+    .word   0xfeec19e2
+    .word   0xdf9faa5f
+    .word   0x49fa8f45
+    .word   0x995aaaab
+    .word   0xa7fd6ae9
+    .word   0x9d156a61
+    .word   0x4c2a33c8
+    .word   0xf6250268
+
+
+    .word   0x220249da
+    .word   0x4dfccec3
+    .word   0xbd4be6db
+    .word   0xfa760f6
+    .word   0x1ce1b538
+    .word   0x61ba596d
+    .word   0x7277797b
+    .word   0xd30d02eb
+
+
+    .word   0xe5eeda64
+    .word   0x935b364d
+    .word   0x1c872cd9
+    .word   0x6128e9d3
+    .word   0x1f43dfac
+    .word   0x8e8afdd5
+    .word   0x135d6b7e
+    .word   0x6cf2a009
+
+
+    .word   0xb438af14
+    .word   0xc0e2fba0
+    .word   0xbc3d44ea
+    .word   0xf86826ff
+    .word   0x847dc3e6
+    .word   0x11ea2e11
+    .word   0x5cdb8d20
+    .word   0xab74e3ae
+
+
+    .word   0x8874744f
+    .word   0x28978516
+    .word   0xe1c01548
+    .word   0xd7d305f
+    .word   0xf7756552
+    .word   0x45f1b5b4
+    .word   0xe7a2b2e4
+    .word   0x34d4a318
+
+
+    .word   0x6267b5a6
+    .word   0x865f2034
+    .word   0x974f0f7
+    .word   0x95ef2299
+    .word   0xd932fe4e
+    .word   0x61adf3fb
+    .word   0x96bccd70
+    .word   0xb2b988af
+
+
+    .word   0xbad09d96
+    .word   0x3f528239
+    .word   0xacf1b34a
+    .word   0x4d071e71
+    .word   0xcccff6d5
+    .word   0xe6612892
+    .word   0x3a5b72bd
+    .word   0xd8f9c7be
+
+
+    .word   0xe009db8b
+    .word   0x9a93437d
+    .word   0xc84d3d1c
+    .word   0x10d1c491
+    .word   0x74f85518
+    .word   0x396601d4
+    .word   0xfb2464e5
+    .word   0x9f58c71a
+
+
+    .word   0x96ce0f33
+    .word   0xed9b1755
+    .word   0x6a71e7b
+    .word   0x91754c55
+    .word   0x43cee0e8
+    .word   0x64f97c5b
+    .word   0x8a51d9d4
+    .word   0x4aa13ce9
+
+
+    .word   0x1dd501fe
+    .word   0x48091e76
+    .word   0xfc98c05a
+    .word   0xbf7fe870
+    .word   0xdd01015b
+    .word   0x879a6721
+    .word   0x203e6d41
+    .word   0xd10d9bce
+
+
+    .word   0x6c3f873b
+    .word   0x280f9b66
+    .word   0x6a485787
+    .word   0x2a307e5
+    .word   0xa2426ab1
+    .word   0x3b003511
+    .word   0xbc26ae60
+    .word   0xf2025ab0
+
+
+    .word   0x93aac8a0
+    .word   0x96e2acdf
+    .word   0xb355fe7c
+    .word   0x7be0055f
+    .word   0x941c3afe
+    .word   0x584453f0
+    .word   0xf3f90c37
+    .word   0xfc6b4a4c
+
+
+    .word   0x3441ce34
+    .word   0x9f6741fc
+    .word   0xf776e6a9
+    .word   0x301b8a6a
+    .word   0x8c106b96
+    .word   0x86db935
+    .word   0xee7032a4
+    .word   0x6c4afa9f
+
+
+    .word   0x18d64139
+    .word   0x30cd2211
+    .word   0xbb22f683
+    .word   0xfc46eb71
+    .word   0xe49a9acd
+    .word   0xe811a98
+    .word   0x53ad411d
+    .word   0xa3391ac9
+
+
+    .word   0x49cb6733
+    .word   0x8ccff294
+    .word   0xaeb4f1c8
+    .word   0xde550551
+    .word   0xb807f94b
+    .word   0xade3616f
+    .word   0x9e2654e4
+    .word   0xddf326ed
+
+
+    .word   0x6976c5db
+    .word   0x8fc65d62
+    .word   0xcbfd9ea
+    .word   0xfdd7ae2
+    .word   0x57b345f5
+    .word   0x152c5266
+    .word   0xe27469ce
+    .word   0xf456db35
+
+
+    .word   0x4172a913
+    .word   0x952fde27
+    .word   0x66c5e66f
+    .word   0x9745787f
+    .word   0x49481b59
+    .word   0x5db14651
+    .word   0x36c44c8c
+    .word   0x95defd2d
+
+
+    .word   0xc74779fb
+    .word   0x38f5c599
+    .word   0x6ada1692
+    .word   0xf1d12e00
+    .word   0xbbe644f
+    .word   0xa553bd2a
+    .word   0x973b2def
+    .word   0xf8dd551d
+
+
+    .word   0x2208036c
+    .word   0xce8f5c07
+    .word   0xa1cd242f
+    .word   0x8bb97c94
+    .word   0xa6090d5c
+    .word   0x2bc62df4
+    .word   0xe16c0668
+    .word   0x629eb701
+
+
+    .word   0x1c47df0e
+    .word   0xe73fb366
+    .word   0x1fb14beb
+    .word   0xda940a15
+    .word   0xe0cbe87c
+    .word   0x19c290c7
+    .word   0x5d23d731
+    .word   0x29e4f87f
+
+
+    .word   0x39d6ce80
+    .word   0x42074db2
+    .word   0xad8560d9
+    .word   0x94e31cc9
+    .word   0x22a86b46
+    .word   0x359e121e
+    .word   0x279f656d
+    .word   0xd0b22253
+
+
+    .word   0xd1bd82e
+    .word   0x533d3ffc
+    .word   0x20875191
+    .word   0xdf3bb88
+    .word   0x5b182c10
+    .word   0xe87641c0
+    .word   0x8e5fa4
+    .word   0xa4f3f321
+
+
+    .word   0x28b36ec2
+    .word   0x3aea2b18
+    .word   0x9ebbc783
+    .word   0xc037f849
+    .word   0x1ccc3cdb
+    .word   0x96c47aec
+    .word   0x269d06b0
+    .word   0xd4ce9162
+
+
+    .word   0x4eb4e660
+    .word   0xcc838ffe
+    .word   0x2faaeef0
+    .word   0xf3a78139
+    .word   0x375b5de4
+    .word   0xf3e134e2
+    .word   0x1d3e8c15
+    .word   0xcc9907c0
+
+
+    .word   0xbad72c68
+    .word   0x4bd84603
+    .word   0xf946325b
+    .word   0xadb88673
+    .word   0x8d5e91e9
+    .word   0x14444b52
+    .word   0x166f28f0
+    .word   0x3ac212a6
+
+
+    .word   0xa23c640d
+    .word   0x96b14ea4
+    .word   0xa02a6ec4
+    .word   0xa2c416f5
+    .word   0x603d0648
+    .word   0x4c193f20
+    .word   0x2c66cf06
+    .word   0x33ff489e
+
+
+    .word   0x9ba76f29
+    .word   0xae28e070
+    .word   0xe9a1d98d
+    .word   0x30c4ff5c
+    .word   0x173a7ac6
+    .word   0x482f396f
+    .word   0x5d48cb7
+    .word   0x5f0c196
+
+
+    .word   0xbd71d1f7
+    .word   0xd9019adc
+    .word   0x913d3222
+    .word   0x81a90c0b
+    .word   0x4aab01a9
+    .word   0x29dafb8d
+    .word   0x56daf16e
+    .word   0x669537eb
+
+
+    .word   0x21e71745
+    .word   0x4ebb2b70
+    .word   0x15ae10af
+    .word   0xaf04c4fb
+    .word   0x8c62845b
+    .word   0x45d11c2c
+    .word   0x6f3be07f
+    .word   0x24695d90
+
+
+    .word   0x6842f8e9
+    .word   0x6693c631
+    .word   0x1b882cb4
+    .word   0xc7453e95
+    .word   0xc296c4ba
+    .word   0x8ed118c2
+    .word   0x5d4b5d92
+    .word   0xa534a09f
+
+
+    .word   0x93c28957
+    .word   0x7b3ce036
+    .word   0x4920924d
+    .word   0xca0511c1
+    .word   0x6c1948
+    .word   0x5c6cdaf5
+    .word   0xcfdd59e3
+    .word   0x2f065120
+
+
+    .word   0xc67cb992
+    .word   0xc85d0e03
+    .word   0xce28f63a
+    .word   0xd3ee6880
+    .word   0x2fbdec38
+    .word   0x7d1b128f
+    .word   0xa9c43a77
+    .word   0x7da2da2a
+
+
+    .word   0xee27b2c8
+    .word   0xe4e46dd1
+    .word   0x33eb130f
+    .word   0xf62362cd
+    .word   0xe4c7d4a5
+    .word   0xd551f2a5
+    .word   0x45e0959e
+    .word   0xdb8290a2
+
+
+    .word   0xcc9a4c4d
+    .word   0xd07e3462
+    .word   0xab665e7c
+    .word   0x50a30105
+    .word   0x36c462d9
+    .word   0xb6e4ecc4
+    .word   0x52b5d347
+    .word   0x5c11cb00
+
+
+    .word   0xfdd9f4cf
+    .word   0x47ce366f
+    .word   0x2178e306
+    .word   0x7609a729
+    .word   0xee77481c
+    .word   0x361d3c68
+    .word   0x5f10f00a
+    .word   0x8ca61385
+
+
+    .word   0x66039a6e
+    .word   0xf064367b
+    .word   0x76afda25
+    .word   0x330a72b6
+    .word   0xe1491673
+    .word   0x48de74d9
+    .word   0x29137875
+    .word   0xe38166fa
+
+
+    .word   0xd84006fa
+    .word   0xea20c7fa
+    .word   0x678c07c3
+    .word   0xed0163a5
+    .word   0x718b70
+    .word   0xa4159016
+    .word   0x19fd25db
+    .word   0xfe8854f2
+
+
+    .word   0x393590d3
+    .word   0xd546c83f
+    .word   0x8905ff9c
+    .word   0x6ea29923
+    .word   0xc9ad9792
+    .word   0x5811cb79
+    .word   0xe5e11e96
+    .word   0x7d761e3c
+
+
+    .word   0xa4810d19
+    .word   0x91d56954
+    .word   0x737e5355
+    .word   0xe490ad09
+    .word   0xf5793b52
+    .word   0x60c911d0
+    .word   0x3eb1d2af
+    .word   0x8adc87a4
+
+
+    .word   0x5ea4e476
+    .word   0xd58c781f
+    .word   0x36d66cc
+    .word   0x4f555eea
+    .word   0x3a764a25
+    .word   0x8c5cfbe9
+    .word   0xd201653c
+    .word   0x8a6c966f
+
+
+    .word   0x29cdeac
+    .word   0x47c1a1d0
+    .word   0xe3cf2997
+    .word   0x3201ad6c
+    .word   0xfb6402e4
+    .word   0x415ec47a
+    .word   0x3a8e0790
+    .word   0xcf4cde36
+
+
+    .word   0xc2b4d70c
+    .word   0x4eb8490a
+    .word   0x8d60e4c8
+    .word   0x7c25ca10
+    .word   0xa1cd5b0f
+    .word   0x900b4ce0
+    .word   0x390b16d
+    .word   0x1235793c
+
+
+    .word   0x193d1065
+    .word   0x71fe09c
+    .word   0xbad5c4e2
+    .word   0x99c3b90
+    .word   0x1456d5
+    .word   0xbd38d85
+    .word   0x33f9ebce
+    .word   0x6fcf7333
+
+
+    .word   0x95ef2299
+    .word   0xe505d397
+    .word   0x6f7c80fd
+    .word   0x76695606
+    .word   0x699edbcf
+    .word   0xbd4130a2
+    .word   0x7f014ad4
+    .word   0x75e94852
+
+
+    .word   0xb8c6f82d
+    .word   0xfaa9889d
+    .word   0x88ecd9a2
+    .word   0x1378d8f3
+    .word   0x59dde8a1
+    .word   0xc79d4462
+    .word   0xe8207fc4
+    .word   0xfdc41636
+
+
+    .word   0x527dcbf7
+    .word   0x4d898675
+    .word   0xbc6be071
+    .word   0x7c135525
+    .word   0x80401dd
+    .word   0x86589af1
+    .word   0xfcf207ab
+    .word   0xbe99dccc
+
+
+    .word   0xcb2be833
+    .word   0xe8adf36f
+    .word   0x20ba0b8d
+    .word   0x6f0b4932
+    .word   0x6a937c72
+    .word   0x95cd9f4e
+    .word   0x40e0f47e
+    .word   0x92355dd
+
+
+    .word   0x7e47d820
+    .word   0x67647369
+    .word   0xfc89cefb
+    .word   0xa2b7c2b6
+    .word   0x84f4ec7f
+    .word   0xbebca7ef
+    .word   0x33348ec0
+    .word   0x59df58e6
+
+
+    .word   0xb7f73861
+    .word   0xf8cd478
+    .word   0x4a987db3
+    .word   0x129d69c
+    .word   0xc7121954
+    .word   0x533b6d15
+    .word   0xe7394f0
+    .word   0x6a5f9957
+
+
+    .word   0x10ae2b52
+    .word   0xee7032a4
+    .word   0x4990a8f8
+    .word   0x5e97f689
+    .word   0xd005e72b
+    .word   0x7153a631
+    .word   0xfd4751f1
+    .word   0x1df616b2
+
+
+    .word   0x39e2fe74
+    .word   0x6594633a
+    .word   0xd94df273
+    .word   0xbb65fcbf
+    .word   0xa6e56e6b
+    .word   0xe54236be
+    .word   0xbf7fe870
+    .word   0x77cc8bdc
+
+
+    .word   0xb2c396f8
+    .word   0xd18c367e
+    .word   0x3de12cdf
+    .word   0x5032e79
+    .word   0x266458b2
+    .word   0xf37bb99f
+    .word   0xca39a6ef
+    .word   0xe7006f43
+
+
+    .word   0xafff8af3
+    .word   0xd5ac4cd5
+    .word   0x5c3642b9
+    .word   0x4683d65
+    .word   0xb4aec732
+    .word   0x7e505068
+    .word   0x234ef725
+    .word   0x971391f3
+
+
+    .word   0x4605072f
+    .word   0xdd28b6be
+    .word   0x12f63dbe
+    .word   0x1e873d48
+    .word   0xeb6872af
+    .word   0x2ba248f6
+    .word   0x74806c99
+    .word   0xfb75fd50
+
+
+    .word   0xe1eddd08
+    .word   0x7192b915
+    .word   0xebb863cb
+    .word   0x3405796e
+    .word   0xec673f29
+    .word   0x3bfcae8a
+    .word   0xfe5944a6
+    .word   0xe89f4f3a
+
+
+    .word   0xfead1330
+    .word   0x81319624
+    .word   0x3f412c4d
+    .word   0xed092db5
+    .word   0x36d203e0
+    .word   0xb7240221
+    .word   0xf415ce28
+    .word   0x80fbb1e5
+
+
+    .word   0x8068a1ed
+    .word   0x915bbe4a
+    .word   0xd71029c7
+    .word   0xa9fbaed5
+    .word   0x770eb070
+    .word   0x5b66448b
+    .word   0x6fb534fd
+    .word   0xade59b1b
+
+
+    .word   0x61ddd973
+    .word   0x8a651ad5
+    .word   0x89382044
+    .word   0xb895f083
+    .word   0x1e5fc938
+    .word   0x5cdb8d20
+    .word   0x6cc19cdb
+    .word   0xa605d659
+
+
+    .word   0x3a0c75a6
+    .word   0xbd6835b7
+    .word   0xa3b9227b
+    .word   0x63823c80
+    .word   0x3e233cdf
+    .word   0x708dec5e
+    .word   0x3e63630
+    .word   0x20cf3b61
+
+
+    .word   0x5b9d5e69
+    .word   0x8e979234
+    .word   0x1535ab08
+    .word   0x7a446ca
+    .word   0xf1808ed9
+    .word   0x9ca40445
+    .word   0xfc731058
+    .word   0xc04604e9
+
+
+    .word   0x527105b8
+    .word   0x1918c78f
+    .word   0x85309e62
+    .word   0x28c771af
+    .word   0xd3959569
+    .word   0x62e3420d
+    .word   0x6a8e2cb4
+    .word   0x4402e2d1
+
+
+    .word   0xf40408b7
+    .word   0x35f557f3
+    .word   0xaf93bb19
+    .word   0xa4d2252a
+    .word   0xe6fb2f69
+    .word   0xe3b8d5ae
+    .word   0xdbf76f33
+    .word   0x658daf62
+
+
+    .word   0xa7c942f3
+    .word   0xa1cd242f
+    .word   0x7a69cddc
+    .word   0x456cc67b
+    .word   0x8068b45b
+    .word   0xc70dbdbf
+    .word   0x9120668a
+    .word   0x9e0c81be
+
+
+    .word   0x39e2861d
+    .word   0x4eb4e660
+    .word   0xd21a445f
+    .word   0xc8666d5d
+    .word   0xe5aa6da4
+    .word   0xa6531a5
+    .word   0xc3516aa9
+    .word   0xa993d60c
+
+
+    .word   0x78353515
+    .word   0x7cb3f19a
+    .word   0x364b5fc7
+    .word   0x4c258c95
+    .word   0x92850ce0
+    .word   0x60b54f26
+    .word   0xdab3556d
+    .word   0xdc70102b
+
+
+    .word   0x58237bc4
+    .word   0x31bcd36
+    .word   0x680f1159
+    .word   0xa09efb89
+    .word   0xdbdb45b8
+    .word   0x52c500b8
+    .word   0x1ce229d5
+    .word   0xb207259b
+
+
+    .word   0xff658b73
+    .word   0x79dd995f
+    .word   0xddf326ed
+    .word   0xdbb094a7
+    .word   0x26e261fe
+    .word   0xf125459a
+    .word   0x50212186
+    .word   0x420541e3
+
+
+    .word   0x9ed50994
+    .word   0x5c89341
+    .word   0x884dd8b0
+    .word   0x854cbb73
+    .word   0x57fa2fe6
+    .word   0x64f2656d
+    .word   0xafad8c01
+    .word   0x15bbd3c2
+
+
+    .word   0xba816f09
+    .word   0xd442b407
+    .word   0xdbdba580
+    .word   0x236fc402
+    .word   0x3aea2b18
+    .word   0x5a45a72
+    .word   0xa41a0278
+    .word   0xf753b931
+
+
+    .word   0xa31bc40f
+    .word   0xc954f9fa
+    .word   0xb3917d7
+    .word   0xc337d865
+    .word   0x45a353f3
+    .word   0xdd98b943
+    .word   0xf9b7716d
+    .word   0xd1bd82e
+
+
+    .word   0x9c9858b5
+    .word   0x6136577
+    .word   0x439a46e6
+    .word   0xdd3dbfe5
+    .word   0x3d4da548
+    .word   0x6b02708e
+    .word   0x8d73eec3
+    .word   0xe922b2d8
+
+
+    .word   0x6c026fc9
+    .word   0x89ee68a2
+    .word   0xd00bebc4
+    .word   0x9e1a5343
+    .word   0xd1956616
+    .word   0x70c2fe4e
+    .word   0xc565c7f9
+    .word   0x5d1eacf5
+
+
+    .word   0xe17576ea
+    .word   0x4bd67de7
+    .word   0x726e2f7a
+    .word   0xda7b663
+    .word   0xefb13c33
+    .word   0x1df21e0c
+    .word   0xa01285f3
+    .word   0x51ca45d5
+
+
+    .word   0x47ce366f
+    .word   0xfc192679
+    .word   0xd17eada9
+    .word   0x16d5b9e8
+    .word   0x27889c70
+    .word   0xb1a2021c
+    .word   0xdc91c34f
+    .word   0x544e6965
+
+
+    .word   0xc686c262
+    .word   0xc2949b28
+    .word   0xa70402be
+    .word   0xd38a7785
+    .word   0x98fe0d3a
+    .word   0x7d702411
+    .word   0x1efa6a3d
+    .word   0x89a2dc90
+
+
+    .word   0xfc4ebe43
+    .word   0x331503e1
+    .word   0x493e497b
+    .word   0xccbee5ca
+    .word   0xc84f93c7
+    .word   0xe91325c5
+    .word   0xa3394e73
+    .word   0x4a0fd98f
+
+
+    .word   0xda798dc8
+    .word   0x2f7dafb8
+    .word   0x80f57902
+    .word   0xff94bae9
+    .word   0x5e8c46b4
+    .word   0xfc50d371
+    .word   0xfeaa26ab
+    .word   0x77a4adab
+
+
+    .word   0xd383419d
+    .word   0x48dd2a72
+    .word   0xfeaf73a1
+    .word   0xbcf1bd3e
+    .word   0x8e0ebfd0
+    .word   0xb6cc201
+    .word   0xdd94e33e
+    .word   0xf9f9cfda
+
+
+    .word   0xafa3846d
+    .word   0xe0cc402a
+    .word   0x48de74d9
+    .word   0x3eb63b36
+    .word   0x9e25ebd6
+    .word   0xfb12595a
+    .word   0x65d02c91
+    .word   0x1d3e8c15
+
+
+    .word   0x7b8bb9a
+    .word   0x6638f251
+    .word   0x2bbc0d13
+    .word   0xdb24c043
+    .word   0x26173b86
+    .word   0x698e4a35
+    .word   0xa9266f81
+    .word   0x5fa24721
+
+
+    .word   0x82e98a08
+    .word   0xf37898a3
+    .word   0xdaebd6d3
+    .word   0x33f9ebce
+    .word   0x974f0f7
+    .word   0xdd91e45c
+    .word   0x66fa46c3
+    .word   0x4eed35d9
+
+
+    .word   0xc1a56ce8
+    .word   0x572c0e6
+    .word   0xfb7667a
+    .word   0x6e3c6dd9
+    .word   0xd0c5b809
+    .word   0x476d3df7
+    .word   0xb5c1ab0c
+    .word   0xd8546044
+
+
+    .word   0x19c83a20
+    .word   0xcfec291c
+    .word   0x8c98565e
+    .word   0x63228f4e
+    .word   0x8593e3c8
+    .word   0x4d8c9f3c
+    .word   0xfb14b932
+    .word   0x3be9896a
+
+
+    .word   0xea9cc2c2
+    .word   0x350989c
+    .word   0xc5779c7a
+    .word   0x83d57ce2
+    .word   0x5975aed9
+    .word   0xde10fe98
+    .word   0x211d5c5b
+    .word   0x536e3ea7
+
+
+    .word   0xaf0dc245
+    .word   0xa5936673
+    .word   0xf74fe953
+    .word   0xa2af808a
+    .word   0x53f3dbba
+    .word   0xc1aec705
+    .word   0xa436ebf
+    .word   0x828c4f40
+
+
+    .word   0x822b3625
+    .word   0xc2686224
+    .word   0xe609e159
+    .word   0xab7cdda2
+    .word   0xb6e0656b
+    .word   0x96fa00d5
+    .word   0x63ee5265
+    .word   0xbdd02f0e
+
+
+    .word   0x527533b
+    .word   0xbf1b20c1
+    .word   0xd097200
+    .word   0xb5005e25
+    .word   0x9b021b9d
+    .word   0x2b85fbd
+    .word   0x4880d986
+    .word   0x1bb741e3
+
+
+    .word   0xad84c0a6
+    .word   0xc88f1edc
+    .word   0xe90f776f
+    .word   0x285fa7c9
+    .word   0xd290e708
+    .word   0xd0570976
+    .word   0x108d3e9e
+    .word   0x9e5de09
+
+
+    .word   0xe4d28b49
+    .word   0x48091e76
+    .word   0xf924a08
+    .word   0x6f7c80fd
+    .word   0x3fe62ce3
+    .word   0x9ebbdbbd
+    .word   0xea20c7fa
+    .word   0xe1ff024b
+
+
+    .word   0x2f041c2d
+    .word   0x1d823564
+    .word   0x3b65189c
+    .word   0xfa3cb7f1
+    .word   0x9133e25a
+    .word   0x5c267e03
+    .word   0xdc0dfd09
+    .word   0xf323f723
+
+
+    .word   0x4da83bdc
+    .word   0x8b14023c
+    .word   0xfc543a09
+    .word   0x62a37ab3
+    .word   0xfe3e83b7
+    .word   0xfc2f8299
+    .word   0xeefd1d28
+    .word   0x936a53f2
+
+
+    .word   0xfa38c28a
+    .word   0xf1decf53
+    .word   0xf7322464
+    .word   0x603913aa
+    .word   0x1f244d35
+    .word   0xfe25f0e
+    .word   0xc130a815
+    .word   0xa6e56e6b
+
+
+    .word   0xfc98c05a
+    .word   0x61adf3fb
+    .word   0x7d792b1e
+    .word   0x79642ed3
+    .word   0xe9afb78d
+    .word   0x8ec5fc20
+    .word   0xb1520582
+    .word   0xd00b0e44
+
+
+    .word   0x47dbf466
+    .word   0xedf00f54
+    .word   0xaf5640f6
+    .word   0xfc9667a5
+    .word   0xbe99dccc
+    .word   0x699edbcf
+    .word   0x2ce46671
+    .word   0x5ed2359a
+
+
+    .word   0x90592245
+    .word   0xd6164600
+    .word   0x7f0f418b
+    .word   0xec01711a
+    .word   0x4376073a
+    .word   0x8d26bd4b
+    .word   0x507aee4b
+    .word   0xe1982766
+
+
+    .word   0xf54f49bf
+    .word   0x7aaac311
+    .word   0xab406e9c
+    .word   0x77af09e3
+    .word   0xd1f5bc18
+    .word   0x95313f39
+    .word   0x63268667
+    .word   0x2c196031
+
+
+    .word   0x956608af
+    .word   0xa85004f4
+    .word   0x645895bc
+    .word   0xcc2f1d7b
+    .word   0xd6b263ee
+    .word   0xec81b4b4
+    .word   0x7a289ac3
+    .word   0xb919e873
+
+
+    .word   0x1d0df3d8
+    .word   0x507bbd26
+    .word   0xacc4d6cb
+    .word   0xe10998e7
+    .word   0x61e01ac
+    .word   0x10847940
+    .word   0x3a8f7188
+    .word   0xb53528f6
+
+
+    .word   0x40da8b04
+    .word   0x38692f26
+    .word   0xd283b5b6
+    .word   0xf66d356c
+    .word   0x646a7dc
+    .word   0x75222e5c
+    .word   0x97c7eeb5
+    .word   0x6be5c4fa
+
+
+    .word   0xbdf98426
+    .word   0x7300e3ae
+    .word   0xa9947cad
+    .word   0x50a8a360
+    .word   0xa3eb2a53
+    .word   0xc2ed2638
+    .word   0x962e12a2
+    .word   0x147ee388
+
+
+    .word   0x757b79e5
+    .word   0x7f014ad4
+    .word   0xb56178d5
+    .word   0xd85439d8
+    .word   0x1a42769b
+    .word   0xcbd4f720
+    .word   0x2ef90f04
+    .word   0xfeab07d4
+
+
+    .word   0x803e83af
+    .word   0x9685f132
+    .word   0xe59d3fe6
+    .word   0x891fe0c5
+    .word   0x21355051
+    .word   0x6f8f51c2
+    .word   0x92fba155
+    .word   0x76db1484
+
+
+    .word   0x1aa67f29
+    .word   0x9c0ccf49
+    .word   0x5ec2df59
+    .word   0xc14f41d0
+    .word   0xced8a05f
+    .word   0x1ea4b44e
+    .word   0x84eb06a2
+    .word   0x193f2d82
+
+
+    .word   0x9e0c81be
+    .word   0xd4ce9162
+    .word   0xffd76daa
+    .word   0x9cd49976
+    .word   0xe4615f50
+    .word   0xf088ef39
+    .word   0xcfd09a55
+    .word   0x9edebb1b
+
+
+    .word   0x305976d4
+    .word   0x7ae4cfdd
+    .word   0xc7c01c5e
+    .word   0x7cf90f35
+    .word   0x1591cd6
+    .word   0x90f9ec87
+    .word   0x2546955e
+    .word   0x18e52cd0
+
+
+    .word   0x3da096be
+    .word   0x456efc6d
+    .word   0xcc7b1f6c
+    .word   0x68fba106
+    .word   0x7d227333
+    .word   0x5ae93b49
+    .word   0x658daf62
+    .word   0xce8f5c07
+
+
+    .word   0x22ea3acf
+    .word   0x879a6721
+    .word   0x9f7ed5be
+    .word   0x2877c2fa
+    .word   0x69311248
+    .word   0x1a9282e
+    .word   0x9ac7257a
+    .word   0x2f7f4a78
+
+
+    .word   0x205b23f
+    .word   0x5f8c3143
+    .word   0xc0c6c3c8
+    .word   0x62022012
+    .word   0xef7e1a23
+    .word   0x1dc56818
+    .word   0xa3f9807b
+    .word   0xd290ee4
+
+
+    .word   0x7a41ed69
+    .word   0x7b49df67
+    .word   0x89d9960d
+    .word   0xc8d76491
+    .word   0x8fffc6c9
+    .word   0x52437d2c
+    .word   0x21cadbb6
+    .word   0xa8b8c2e5
+
+
+    .word   0x3e6dd600
+    .word   0x87be760f
+    .word   0x4aab822
+    .word   0x297243e9
+    .word   0x32408d7f
+    .word   0xb19fbc3f
+    .word   0x56decdf5
+    .word   0xf6f6bf12
+
+
+    .word   0xb2797615
+    .word   0x76590028
+    .word   0x20475ad7
+    .word   0xd586a169
+    .word   0xbcddaa0f
+    .word   0xd87d0a4f
+    .word   0xdc590da8
+    .word   0x9f93a1dd
+
+
+    .word   0x8c4b9858
+    .word   0xe468f3a9
+    .word   0xb895f083
+    .word   0x11ea2e11
+    .word   0x19f958b6
+    .word   0xa01285f3
+    .word   0xfdd9f4cf
+    .word   0x37f054d3
+
+
+    .word   0x666b82c5
+    .word   0x403bc7d4
+    .word   0xa83c88d1
+    .word   0xf01d1c09
+    .word   0x25500dcd
+    .word   0x53f6fbed
+    .word   0xb6eb0437
+    .word   0x727098d
+
+
+    .word   0xcb9ed650
+    .word   0xd1916f7e
+    .word   0x4599375b
+    .word   0x8aeea77f
+    .word   0x10f521d4
+    .word   0x8fd7e4ee
+    .word   0xa099afc4
+    .word   0xdd9f7eda
+
+
+    .word   0x8a663f66
+    .word   0x9b4d610e
+    .word   0xb2a5a4f5
+    .word   0x5094f4f4
+    .word   0x5c1a9081
+    .word   0xdbdba580
+    .word   0x28b36ec2
+    .word   0xdd1b780e
+
+
+    .word   0x78042a38
+    .word   0xb9ecd47f
+    .word   0xcc09e243
+    .word   0x1b83ea8
+    .word   0xff2f8594
+    .word   0x36a7885f
+    .word   0x4e49b87b
+    .word   0xfff3ff08
+
+
+    .word   0xfe09224d
+    .word   0xa3d49e60
+    .word   0xfc06086a
+    .word   0xe7d4b789
+    .word   0x971dc1bc
+    .word   0xc1d7464
+    .word   0x774edad8
+    .word   0x8156b59
+
+
+    .word   0x318910d4
+    .word   0x8ef7fd25
+    .word   0x7b8b23a5
+    .word   0xff658b73
+    .word   0x9e2654e4
+    .word   0x2ea77bfc
+    .word   0xfc333998
+    .word   0x5c194759
+
+
+    .word   0x253bb339
+    .word   0xa4159016
+    .word   0x2e40286
+    .word   0x47871a30
+    .word   0xdd98b943
+    .word   0xd0b22253
+    .word   0xa058446f
+    .word   0x4fa10ddb
+
+
+    .word   0x595db45a
+    .word   0xa47089a5
+    .word   0x4e9130e7
+    .word   0x97c94b21
+    .word   0xb8dbff75
+    .word   0x5c6cdaf5
+    .word   0x8775a030
+    .word   0xacdb5c7c
+
+
+    .word   0x30177acf
+    .word   0x92b80b5e
+    .word   0x88fc6345
+    .word   0x250979b
+    .word   0xc138b041
+    .word   0xafa3846d
+    .word   0xe1491673
+    .word   0x86e4d5d6
+
+
+    .word   0x88b9b945
+    .word   0x90f3a8ed
+    .word   0x837c2429
+    .word   0xc3516aa9
+    .word   0x19e01234
+    .word   0x67ee1086
+    .word   0x9dce7ea8
+    .word   0xd028e337
+
+
+    .word   0xe09ae22e
+    .word   0x7f177d55
+    .word   0x27da85fe
+    .word   0x3e9d37af
+    .word   0x6b9f5abd
+    .word   0xe811a98
+    .word   0x19480179
+    .word   0xe080e857
+
+
+    .word   0x4a1ac406
+    .word   0xef02dad4
+    .word   0x995aaaab
+    .word   0x4ad992d4
+    .word   0xca170e7e
+    .word   0xba6f3b3d
+    .word   0x8410c1c4
+    .word   0xddb2bd86
+
+
+    .word   0xba90a1b0
+    .word   0xc3e640dc
+    .word   0xb6620848
+    .word   0x9ae3355a
+    .word   0x98ce812a
+    .word   0x4e78eb7c
+    .word   0x564b3c75
+    .word   0xa2cb462d
+
+
+    .word   0x4e4e26e2
+    .word   0x4fd54c4d
+    .word   0x3e10bb3d
+    .word   0x9b658853
+    .word   0x63ede719
+    .word   0xcb224b39
+    .word   0xb8bda637
+    .word   0xb563e3d6
+
+
+    .word   0x311ed025
+    .word   0x89d46ce8
+    .word   0xed6c658f
+    .word   0x3870df56
+    .word   0x566e8fab
+    .word   0x5606607
+    .word   0x52e40137
+    .word   0xcc75312c
+
+
+    .word   0x90623018
+    .word   0x25e9f7fc
+    .word   0x60979e80
+    .word   0x9e242e3a
+    .word   0x2e24927b
+    .word   0x86865a2c
+    .word   0x233c3462
+    .word   0xa2abe6ff
+
+
+    .word   0xa73f08f8
+    .word   0xd9198d73
+    .word   0x143f4c66
+    .word   0xecd34cc6
+    .word   0xe17c73c1
+    .word   0xd77da06d
+    .word   0x62725751
+    .word   0x17bc5ab8
+
+
+    .word   0x3234b4da
+    .word   0xf1a5174d
+    .word   0xef78479a
+    .word   0xc41ae77a
+    .word   0x8459f68
+    .word   0x471d47d0
+    .word   0x7ff97153
+    .word   0x82b1350d
+
+
+    .word   0x416cf795
+    .word   0xd172d24f
+    .word   0x7a00d5d9
+    .word   0x66ef9897
+    .word   0x3255991e
+    .word   0xde442202
+    .word   0x3e118c2a
+    .word   0xf4fca80e
+
+
+    .word   0xaf98c16b
+    .word   0xe4e46dd1
+    .word   0xad1205e2
+    .word   0x88241fc
+    .word   0x949a058b
+    .word   0xb5c86184
+    .word   0xf69004ca
+    .word   0x48d3d81b
+
+
+    .word   0x3266d502
+    .word   0x21bcab5b
+    .word   0xbe9c5795
+    .word   0x6b159631
+    .word   0xf5f768d0
+    .word   0xcfa148b7
+    .word   0xba2851fd
+    .word   0xaee1a9b8
+
+
+    .word   0xfe25f0e
+    .word   0xbb65fcbf
+    .word   0x48091e76
+    .word   0xe505d397
+    .word   0x3a828f3c
+    .word   0xcbf2cba0
+    .word   0xfb12595a
+    .word   0xf3e134e2
+
+
+    .word   0x6e771f2
+    .word   0xb7504074
+    .word   0x4743c324
+    .word   0xee84b600
+    .word   0x1efea0e8
+    .word   0x37204d0b
+    .word   0xddca302c
+    .word   0xca49086b
+
+
+    .word   0x700aa8d9
+    .word   0xa6c3e123
+    .word   0xb4caecd7
+    .word   0xad312982
+    .word   0x76a47e0d
+    .word   0x1016a531
+    .word   0x669dfb9e
+    .word   0x8ad2974f
+
+
+    .word   0x575ec308
+    .word   0x6355982b
+    .word   0x6bd7c953
+    .word   0xf32e45b8
+    .word   0x7e57c322
+    .word   0x404ec8dc
+    .word   0x9d8c3d6c
+    .word   0x4751885f
+
+
+    .word   0x269ca2d0
+    .word   0x380d5f45
+    .word   0x1b3195f0
+    .word   0x6e3adf2a
+    .word   0x5371499c
+    .word   0xca77c284
+    .word   0xac326289
+    .word   0xf90b85cb
+
+
+    .word   0xd357671b
+    .word   0xd697bb15
+    .word   0x7c8e18ca
+    .word   0x783d5ff9
+    .word   0xeae2a254
+    .word   0x7b281cd1
+    .word   0x6ab089d9
+    .word   0xca73d5ec
+
+
+    .word   0xfc6ff49f
+    .word   0x46d1f98e
+    .word   0xf5c2fc09
+    .word   0x1b14b740
+    .word   0xea50526e
+    .word   0xa9e6f9b2
+    .word   0xd7ac247
+    .word   0x828ae2e7
+
+
+    .word   0xb8576d80
+    .word   0xddb072fa
+    .word   0x770eb664
+    .word   0xbf92a20f
+    .word   0x70522ac6
+    .word   0x9fc424f5
+    .word   0xd2a1e128
+    .word   0xaf5640f6
+
+
+    .word   0xfcf207ab
+    .word   0x3fe62ce3
+    .word   0xd84006fa
+    .word   0x63ba55fa
+    .word   0xf7f94d71
+    .word   0x8eb0f011
+    .word   0x80beba86
+    .word   0xbcbdd6c8
+
+
+    .word   0xb6b59718
+    .word   0x207cf27d
+    .word   0x5f482bb0
+    .word   0xcdf02aea
+    .word   0xaa47f2db
+    .word   0x211d5c5b
+    .word   0xfc9a58f9
+    .word   0x84eb06a2
+
+
+    .word   0x9120668a
+    .word   0x269d06b0
+    .word   0xf8dd551d
+    .word   0x8ba778db
+    .word   0xfc9667a5
+    .word   0x76695606
+    .word   0x4b68bdf5
+    .word   0x485df757
+
+
+    .word   0xc50ed9ae
+    .word   0xd73e05c0
+    .word   0xb3023bb4
+    .word   0xcd6df8a0
+    .word   0xc9be6d88
+    .word   0x997706a8
+    .word   0x223e7c8a
+    .word   0x63110994
+
+
+    .word   0xbe98b6b5
+    .word   0xb6e4ecc4
+    .word   0x951d905b
+    .word   0xb2963b81
+    .word   0x814fd1ac
+    .word   0x99fa7c6f
+    .word   0xc00dfcf
+    .word   0x9ea62f70
+
+
+    .word   0x8f52b95c
+    .word   0xaec6807c
+    .word   0x8a2049b1
+    .word   0x17d1fd6c
+    .word   0x61aba853
+    .word   0x2c743dd9
+    .word   0xd9037b0f
+    .word   0x2f1f6e72
+
+
+    .word   0xe972b53e
+    .word   0xb7240221
+    .word   0xbdab3309
+    .word   0xedd68016
+    .word   0x40f43594
+    .word   0x10798b54
+    .word   0xca88fec
+    .word   0xe4e23c4
+
+
+    .word   0x284ef5cd
+    .word   0x7cb3f19a
+    .word   0x683fcf99
+    .word   0xfcdf901b
+    .word   0x55b0841d
+    .word   0x98e48df3
+    .word   0x28d44d75
+    .word   0xf2d1a65a
+
+
+    .word   0xeeb11aeb
+    .word   0x6da78ec8
+    .word   0xa5297ae0
+    .word   0x7d227333
+    .word   0xdbf76f33
+    .word   0x2208036c
+    .word   0xcf128993
+    .word   0x96bccd70
+
+
+    .word   0xf9ba9ed9
+    .word   0x424ba06b
+    .word   0xdefa0ea
+    .word   0x5dd44c8c
+    .word   0xab2080a0
+    .word   0x42d86f61
+    .word   0x574f3e7e
+    .word   0x41efffe1
+
+
+    .word   0x8c4fd366
+    .word   0xda20f3cd
+    .word   0xb0451a12
+    .word   0xe97c2f6f
+    .word   0xca35c0fe
+    .word   0xa84ca1db
+    .word   0xb6869ab6
+    .word   0xd3f8b44c
+
+
+    .word   0x3e449d13
+    .word   0xd9687f3a
+    .word   0x9351f4cd
+    .word   0x2682b287
+    .word   0x5a7dca1f
+    .word   0x7b9760f5
+    .word   0x4bcab6de
+    .word   0xb39c5176
+
+
+    .word   0x24c4aba8
+    .word   0xbf7d1442
+    .word   0x482f396f
+    .word   0x820f7d0d
+    .word   0xe8f99c40
+    .word   0x6cb4dc2b
+    .word   0x8c8ec6ca
+    .word   0x19bf94a6
+
+
+    .word   0x2906ce5d
+    .word   0x4b88ba60
+    .word   0x7f68903d
+    .word   0x89b7964e
+    .word   0xa9a7aea8
+    .word   0xba17077c
+    .word   0xae60aaee
+    .word   0x149282e4
+
+
+    .word   0x587b1d11
+    .word   0x9517eab4
+    .word   0x38de5560
+    .word   0xd46521a1
+    .word   0xacb29c8a
+    .word   0x11b4f6bf
+    .word   0x43648f5a
+    .word   0x475feb31
+
+
+    .word   0x4a4292d9
+    .word   0x3bfcae8a
+    .word   0x147ee388
+    .word   0xbd4130a2
+    .word   0xaf16c36a
+    .word   0x6386da58
+    .word   0x4e4bca0e
+    .word   0x337f01da
+
+
+    .word   0x82a54f99
+    .word   0x7b59e431
+    .word   0xd7910577
+    .word   0xe542281d
+    .word   0x4413e3d
+    .word   0x60c9520f
+    .word   0x17da0726
+    .word   0xcce95c18
+
+
+    .word   0xc43409b5
+    .word   0x3732afc8
+    .word   0x35991157
+    .word   0x13e20ffc
+    .word   0x4d41a7ed
+    .word   0xbb22f683
+    .word   0xe93f0cf
+    .word   0xe79c0433
+
+
+    .word   0x72de6abc
+    .word   0xf14e20f8
+    .word   0xf2b96f94
+    .word   0x9ea24c1d
+    .word   0x288bd03f
+    .word   0xb7790c63
+    .word   0xf150ad19
+    .word   0x9006520c
+
+
+    .word   0x2db3afb8
+    .word   0xeb9862e6
+    .word   0x927dbd5f
+    .word   0xe3ab47e
+    .word   0x871c4c68
+    .word   0x5381f640
+    .word   0x5094f4f4
+    .word   0xd442b407
+
+
+    .word   0xa4f3f321
+    .word   0xb54739c0
+    .word   0x8525c49f
+    .word   0x55643578
+    .word   0x5f3058dd
+    .word   0xfe0865a2
+    .word   0xb053387a
+    .word   0x3d622bf8
+
+
+    .word   0x10126b26
+    .word   0xc3932912
+    .word   0x375f10e0
+    .word   0x76841929
+    .word   0x1f0ae1a5
+    .word   0xeac6be48
+    .word   0x59172d85
+    .word   0x55afda53
+
+
+    .word   0x250979b
+    .word   0xf9f9cfda
+    .word   0x330a72b6
+    .word   0x8ab32c60
+    .word   0xc3d25baa
+    .word   0xea670da9
+    .word   0x812487b3
+    .word   0xcfd09a55
+
+
+    .word   0xd4f669a7
+    .word   0x3c8a1049
+    .word   0x747f2d03
+    .word   0x745f7c4d
+    .word   0x944b5b2c
+    .word   0xa8aaa3a
+    .word   0xb0ff66c3
+    .word   0x8c4b9858
+
+
+    .word   0x89382044
+    .word   0x847dc3e6
+    .word   0x58b7062e
+    .word   0xe00a47b7
+    .word   0x211fe354
+    .word   0x82965863
+    .word   0x653c5c5b
+    .word   0xd9caf18
+
+
+    .word   0x4b852ee1
+    .word   0x66ded9eb
+    .word   0xfdb51074
+    .word   0x60ac367c
+    .word   0x3d1006e
+    .word   0x7bdb8ade
+    .word   0x1a561153
+    .word   0xdd3906cd
+
+
+    .word   0xd5af17fc
+    .word   0x2e40286
+    .word   0x45a353f3
+    .word   0x279f656d
+    .word   0xf1292db6
+    .word   0x2ba248f6
+    .word   0x1cab9488
+    .word   0x810b1a68
+
+
+    .word   0x50097fbb
+    .word   0x65df73e
+    .word   0x46bdd1d7
+    .word   0xddb29368
+    .word   0x8ef7fd25
+    .word   0xb207259b
+    .word   0xade3616f
+    .word   0xddf56a0d
+
+
+    .word   0x85da1078
+    .word   0xb28ade6c
+    .word   0x453e8681
+    .word   0x9aa5d797
+    .word   0x59ded7d9
+    .word   0x319ff486
+    .word   0x927e3ec1
+    .word   0x340dde0e
+
+
+    .word   0x7c67b6fc
+    .word   0x4f8270a7
+    .word   0x6688ead4
+    .word   0xe65faf87
+    .word   0xdf730907
+    .word   0xc63fde80
+    .word   0xbe38703b
+    .word   0x53f5a662
+
+
+    .word   0x6c90d732
+    .word   0xb5559387
+    .word   0x3d6a3eba
+    .word   0x606d52ce
+    .word   0x9f99bd9d
+    .word   0x98a227b5
+    .word   0x8341aee5
+    .word   0x24bf6264
+
+
+    .word   0x64e84c46
+    .word   0x7ee0400b
+    .word   0x27f309a8
+    .word   0xb400f48b
+    .word   0x8ae91541
+    .word   0x9c3e7e66
+    .word   0xe9f419b1
+    .word   0xc4c95056
+
+
+    .word   0xf89d9bf5
+    .word   0x668e6728
+    .word   0xfaa9889d
+    .word   0xb7d4fa1f
+    .word   0xaf12a184
+    .word   0x339ca551
+    .word   0xb045f87d
+    .word   0x554db978
+
+
+    .word   0xd92695c2
+    .word   0xba2851fd
+    .word   0x1f244d35
+    .word   0xd94df273
+    .word   0x1dd501fe
+    .word   0xdd91e45c
+    .word   0xf02a789
+    .word   0x14216a2a
+
+
+    .word   0xcee95bed
+    .word   0xc60abaa3
+    .word   0x8073fa32
+    .word   0x8df0d1e5
+    .word   0x2689e900
+    .word   0x4f134a2e
+    .word   0x2917ddaa
+    .word   0xea8244fa
+
+
+    .word   0x74689808
+    .word   0x15ae10af
+    .word   0x1cf41087
+    .word   0xa51c3c39
+    .word   0xab0b7e49
+    .word   0x6af16d4f
+    .word   0x78c64d31
+    .word   0x61e9d04b
+
+
+    .word   0xa9d32daf
+    .word   0x461789f1
+    .word   0x18df32d6
+    .word   0xe4054ea7
+    .word   0xfb46d071
+    .word   0x676bd816
+    .word   0x5606209f
+    .word   0xd052389c
+
+
+    .word   0x6ee33ed2
+    .word   0xfe25f0e
+    .word   0xe4d28b49
+    .word   0x95ef2299
+    .word   0xbfd0a038
+    .word   0x2a1e2aef
+    .word   0x90f3a8ed
+    .word   0xa6531a5
+
+
+    .word   0x2c4be070
+    .word   0xace6e989
+    .word   0x32b93e17
+    .word   0xb78609c3
+    .word   0xdf351561
+    .word   0x41ea9c3f
+    .word   0xb3b79db3
+    .word   0xaa15fceb
+
+
+    .word   0x6f9affd0
+    .word   0xe1760a27
+    .word   0x1d19c46b
+    .word   0x2656c76b
+    .word   0x45e90c5e
+    .word   0x63bb3eb4
+    .word   0xdce81e44
+    .word   0xb571d5d0
+
+
+    .word   0x24e5eccb
+    .word   0x48dd2a72
+    .word   0xe96d5471
+    .word   0x1b6ea0f5
+    .word   0x1d53981e
+    .word   0x5eedee09
+    .word   0xdbc0dfaa
+    .word   0xd3d9b458
+
+
+    .word   0xf823bff
+    .word   0x1abdc885
+    .word   0x72a180ad
+    .word   0xab1bc5d8
+    .word   0x82d4283b
+    .word   0x9480cc51
+    .word   0x81200bcd
+    .word   0x602fe2e8
+
+
+    .word   0xaffe22e2
+    .word   0x1887e4d9
+    .word   0x971391f3
+    .word   0xa3d0f22f
+    .word   0x108365bf
+    .word   0x8d259ffa
+    .word   0x94e46041
+    .word   0x2a4dc41f
+
+
+    .word   0xa7e73ab1
+    .word   0xd643839c
+    .word   0x4fe1f547
+    .word   0x2526a8f3
+    .word   0xe945add8
+    .word   0x5d82763e
+    .word   0xe0b26ccf
+    .word   0x29137875
+
+
+    .word   0x35d9f8fb
+    .word   0x8410c1c4
+    .word   0x33bf6593
+    .word   0x8490c34f
+    .word   0x36e2b54e
+    .word   0x3971d21
+    .word   0xa2e6c57c
+    .word   0x584453f0
+
+
+    .word   0x13877592
+    .word   0x4e0251f2
+    .word   0xb409c288
+    .word   0xcbf4171
+    .word   0x24129608
+    .word   0x78cafa9e
+    .word   0x115b2ede
+    .word   0x4f656d4f
+
+
+    .word   0x3a919d7a
+    .word   0x61dd3cb1
+    .word   0x56837b2e
+    .word   0x599e12c5
+    .word   0xea323b09
+    .word   0x4350b442
+    .word   0x72e5a26d
+    .word   0xb9064e77
+
+
+    .word   0x877db17c
+    .word   0x47ba7fe3
+    .word   0x9fc424f5
+    .word   0xedf00f54
+    .word   0x86589af1
+    .word   0x3a828f3c
+    .word   0x9e25ebd6
+    .word   0x375b5de4
+
+
+    .word   0x5b2f0ffb
+    .word   0x962c0fd2
+    .word   0xe6b88b8e
+    .word   0x3f90294b
+    .word   0xf0ab6168
+    .word   0xb73873bf
+    .word   0xbfc26da6
+    .word   0x727ad05b
+
+
+    .word   0x551d85af
+    .word   0xb1a2021c
+    .word   0x30575da2
+    .word   0x560f1197
+    .word   0x2dce393f
+    .word   0x74262d24
+    .word   0x3a2b00e9
+    .word   0x5b8828ac
+
+
+    .word   0x61a8bce2
+    .word   0xb5f81aa6
+    .word   0x689c921f
+    .word   0xe79257bf
+    .word   0xfa319868
+    .word   0xa1f4c23f
+    .word   0x74f0f915
+    .word   0xa8408b86
+
+
+    .word   0x57337f6e
+    .word   0x307fc862
+    .word   0xc5a23fc
+    .word   0x87192711
+    .word   0x3ffb01f7
+    .word   0xdc68cd88
+    .word   0x3d97faab
+    .word   0x23a4ebf2
+
+
+    .word   0x6da78ec8
+    .word   0x68fba106
+    .word   0xe3b8d5ae
+    .word   0xf8dd551d
+    .word   0xaf5640f6
+    .word   0x6f7c80fd
+    .word   0xe38166fa
+    .word   0xd8cf74b3
+
+
+    .word   0x4c4d11dd
+    .word   0x935ebb42
+    .word   0x2765cec3
+    .word   0x9eeab5a6
+    .word   0x5f4b0803
+    .word   0x6479dffc
+    .word   0x7f450554
+    .word   0x4704cc87
+
+
+    .word   0xbfa6bd82
+    .word   0x6aa7ee24
+    .word   0xc14cfd3a
+    .word   0x903a11b
+    .word   0xaa8a0c3
+    .word   0xa5cccccb
+    .word   0xb398e096
+    .word   0xb16b8ee1
+
+
+    .word   0x67e5fc46
+    .word   0xeede8e26
+    .word   0xca87204d
+    .word   0x1e802b60
+    .word   0x89eb6849
+    .word   0x413ee55b
+    .word   0x652816f6
+    .word   0xe2b0f51d
+
+
+    .word   0xdef46a59
+    .word   0xf7398412
+    .word   0x9eab71f1
+    .word   0x81e1c866
+    .word   0x6c8e8eb9
+    .word   0xf57fb159
+    .word   0xd281acef
+    .word   0x4edf9aaf
+
+
+    .word   0x1ecd87b8
+    .word   0x61b7f12f
+    .word   0x9a531e2f
+    .word   0x1a10990d
+    .word   0x7c30ff06
+    .word   0x3a98f22a
+    .word   0x27442511
+    .word   0x32d933c7
+
+
+    .word   0xa8e5c4aa
+    .word   0xc287f36a
+    .word   0xee207b90
+    .word   0x5004a892
+    .word   0x1f9d2419
+    .word   0x3c3091f0
+    .word   0x81ffbc06
+    .word   0x4cacd0a4
+
+
+    .word   0x2c801f0c
+    .word   0x23950bc4
+    .word   0x7263f263
+    .word   0x3c39b4f8
+    .word   0xc243dd20
+    .word   0x58ab9c10
+    .word   0xf90bd045
+    .word   0x4bd84603
+
+
+    .word   0x3a04fa09
+    .word   0x61484ea
+    .word   0xcdf02aea
+    .word   0xde10fe98
+    .word   0x45022fbe
+    .word   0x251f2d6d
+    .word   0xc630f49f
+    .word   0x40a3feae
+
+
+    .word   0x3745765f
+    .word   0x5ae93b49
+    .word   0xd9f84c66
+    .word   0xbf7fe870
+    .word   0x9bced30c
+    .word   0x206ad513
+    .word   0xb31e6963
+    .word   0x3e48c64e
+
+
+    .word   0xaa2b9d53
+    .word   0xa4d84441
+    .word   0xdd3dbfe5
+    .word   0x7d683e3d
+    .word   0xd8c79fdb
+    .word   0xf9b947b1
+    .word   0xee71a998
+    .word   0xf45af087
+
+
+    .word   0x21cb6574
+    .word   0x6b2145df
+    .word   0x3939f3ab
+    .word   0xa3e7976c
+    .word   0x8a5a45df
+    .word   0xc430533f
+    .word   0x105cf3a5
+    .word   0x73b344b5
+
+
+    .word   0xbf13fdac
+    .word   0xa2084eb6
+    .word   0x7b7f8632
+    .word   0x59172d85
+    .word   0x88fc6345
+    .word   0xdd94e33e
+    .word   0x76afda25
+    .word   0xa8789948
+
+
+    .word   0xc53d5984
+    .word   0xc2ed2638
+    .word   0x8adb3c27
+    .word   0x4b68bdf5
+    .word   0xcc48eda2
+    .word   0xc0abeaad
+    .word   0x66b808c0
+    .word   0x871c4c68
+
+
+    .word   0xb2a5a4f5
+    .word   0xba816f09
+    .word   0x8e5fa4
+    .word   0x3d9add7b
+    .word   0xa5d70705
+    .word   0xc5aafa08
+    .word   0x3eabb807
+    .word   0x1a4f73db
+
+
+    .word   0x70c9ab83
+    .word   0xa47089a5
+    .word   0x9c16fb34
+    .word   0xca0511c1
+    .word   0x92d75300
+    .word   0xe676761d
+    .word   0x28e694ab
+    .word   0xb5c425d2
+
+
+    .word   0xc8d91ea1
+    .word   0x5f264576
+    .word   0x9ac33da3
+    .word   0xf3a96d9c
+    .word   0x3f89e0bf
+    .word   0x2b643650
+    .word   0x26153943
+    .word   0xff8b9b11
+
+
+    .word   0xa57b9591
+    .word   0x225dbf25
+    .word   0xda34cecf
+    .word   0x286c9c67
+    .word   0xf16809e3
+    .word   0x1694af58
+    .word   0x4a41c7ad
+    .word   0xa9c95d5c
+
+
+    .word   0xeda605f2
+    .word   0xa3b9227b
+    .word   0xd5407ca9
+    .word   0xbf44bc91
+    .word   0x2a6a7558
+    .word   0xdbbb2eda
+    .word   0x3fad06
+    .word   0xa5b93372
+
+
+    .word   0xfb568cfe
+    .word   0xc5b924a5
+    .word   0x84fc0487
+    .word   0x4a4292d9
+    .word   0x962e12a2
+    .word   0x699edbcf
+    .word   0x4cf0f14c
+    .word   0x3ac44dca
+
+
+    .word   0x8f9b0f7c
+    .word   0x37185941
+    .word   0x6638f251
+    .word   0x52307b53
+    .word   0x782a88bd
+    .word   0xe6aee8fb
+    .word   0x4bcebb18
+    .word   0x47f3122a
+
+
+    .word   0x7e6a1f27
+    .word   0x2d283662
+    .word   0x3e4f9dac
+    .word   0xf9e677de
+    .word   0xea4a25dd
+    .word   0xc0db5d00
+    .word   0x98da0474
+    .word   0x41c57761
+
+
+    .word   0xa0f369ec
+    .word   0xbc8cf412
+    .word   0x2ee974de
+    .word   0x44a5ef33
+    .word   0xb6bde69d
+    .word   0x8506d1fa
+    .word   0xdd3906cd
+    .word   0xa4159016
+
+
+    .word   0xc337d865
+    .word   0x359e121e
+    .word   0x8df6f70f
+    .word   0x36994f12
+    .word   0x8c680e0c
+    .word   0x13f22f
+    .word   0xd9eb4803
+    .word   0xdc40b9be
+
+
+    .word   0xc243364
+    .word   0x5fcc0f31
+    .word   0x7ec33274
+    .word   0x2d86e424
+    .word   0x3d6e78b3
+    .word   0x6e411e5
+    .word   0x5c27fa94
+    .word   0x29465fb0
+
+
+    .word   0x9291eee9
+    .word   0x6c795505
+    .word   0x7a391023
+    .word   0x135d6b7e
+    .word   0xa8aaa3a
+    .word   0x9f93a1dd
+    .word   0x8a651ad5
+    .word   0xf86826ff
+
+
+    .word   0xd76ba55a
+    .word   0x9d5c00be
+    .word   0xe60c53db
+    .word   0xe50f31d0
+    .word   0xa04643b5
+    .word   0x46bdd1d7
+    .word   0x318910d4
+    .word   0x1ce229d5
+
+
+    .word   0xb807f94b
+    .word   0x30bdfd5a
+    .word   0xbc0778df
+    .word   0x1604e06c
+    .word   0x1750c182
+    .word   0x3a6fc02
+    .word   0xc08735f1
+    .word   0xe32870c4
+
+
+    .word   0x3abe3b6f
+    .word   0xbfd80344
+    .word   0x5d6f41cc
+    .word   0x4cda94f9
+    .word   0xb82f79f7
+    .word   0xbaa38b90
+    .word   0x9640fa6
+    .word   0xd4aecc60
+
+
+    .word   0x50b9ea64
+    .word   0xc4e94a11
+    .word   0xddd227a1
+    .word   0x18ddef3
+    .word   0x209dcbf
+    .word   0x3e3f3801
+    .word   0x466d241f
+    .word   0x9bacbff4
+
+
+    .word   0xd052389c
+    .word   0xaee1a9b8
+    .word   0x9e5de09
+    .word   0x6fcf7333
+    .word   0x1e7ed261
+    .word   0xbf65f83b
+    .word   0xea670da9
+    .word   0xf088ef39
+
+
+    .word   0x3fb295f1
+    .word   0xce707036
+    .word   0xfe3c4975
+    .word   0x7e3066e0
+    .word   0xdd28b764
+    .word   0xfb2464e5
+    .word   0xda103c89
+    .word   0x26d4785
+
+
+    .word   0x31f525b6
+    .word   0x91754c55
+    .word   0x1dbd8d32
+    .word   0xb6fefe71
+    .word   0xf9e57877
+    .word   0xce7abc2d
+    .word   0x66abf9bd
+    .word   0xb0c4f5f2
+
+
+    .word   0x9b5e3ef3
+    .word   0x9cd38b3f
+    .word   0xf9580a69
+    .word   0xabba2c8b
+    .word   0x8a239626
+    .word   0x2aeb298a
+    .word   0x62b833e4
+    .word   0x2249a56a
+
+
+    .word   0x21d4ed83
+    .word   0x583df349
+    .word   0xe6040818
+    .word   0xb38c8cde
+    .word   0xfc87d9a3
+    .word   0x812487b3
+    .word   0xc067b9bc
+    .word   0x968e1108
+
+
+    .word   0x50122ea7
+    .word   0x3f20ed7b
+    .word   0xd5da4542
+    .word   0x454f43f0
+    .word   0xbe0426a7
+    .word   0xd17eada9
+    .word   0xbd4bc4d7
+    .word   0x3c090357
+
+
+    .word   0x1577d675
+    .word   0xd4bf5993
+    .word   0x4d5d9f81
+    .word   0xed2fd526
+    .word   0x7e1a3af
+    .word   0xde442202
+    .word   0xb76ebf6e
+    .word   0x7da2da2a
+
+
+    .word   0x37e11ca2
+    .word   0x9cdf2109
+    .word   0xf968c75e
+    .word   0xafc39cb0
+    .word   0xe6199c1f
+    .word   0x8700ceaa
+    .word   0x87eb0cc7
+    .word   0xee7032a4
+
+
+    .word   0xbaae4339
+    .word   0x7f177d55
+    .word   0xd7ea38b6
+    .word   0xfc46eb71
+    .word   0xc88f0742
+    .word   0x7741b047
+    .word   0x50401aae
+    .word   0x80b327bf
+
+
+    .word   0x3c79cbbf
+    .word   0xae416c09
+    .word   0x597b417a
+    .word   0x2f3f7a40
+    .word   0xd8ee23af
+    .word   0xeec1417e
+    .word   0x8b490e83
+    .word   0x220d1f04
+
+
+    .word   0x67e2d35b
+    .word   0x68e491a2
+    .word   0xec81b4b4
+    .word   0x53b9f7cd
+    .word   0x8ad339d
+    .word   0x71da8d8d
+    .word   0x4d16ae6d
+    .word   0x7e444099
+
+
+    .word   0xbe62bace
+    .word   0x7c937cef
+    .word   0xa58f9be9
+    .word   0x85571134
+    .word   0xa8c4144f
+    .word   0xfe0afd8
+    .word   0xb3ed7abc
+    .word   0xbd61a0d4
+
+
+    .word   0x93c5ea6f
+    .word   0x8fd7e4ee
+    .word   0xff00d395
+    .word   0xd08dc050
+    .word   0xe124415e
+    .word   0x877db17c
+    .word   0x70522ac6
+    .word   0x47dbf466
+
+
+    .word   0x80401dd
+    .word   0xbfd0a038
+    .word   0x88b9b945
+    .word   0xe5aa6da4
+    .word   0xd00f64da
+    .word   0x3d97faab
+    .word   0xeeb11aeb
+    .word   0xcc7b1f6c
+
+
+    .word   0xe6fb2f69
+    .word   0x973b2def
+    .word   0x4b9000ce
+    .word   0x66fa46c3
+    .word   0x1d5ea231
+    .word   0x8bb97c94
+    .word   0x6cc2a02b
+    .word   0x11739f84
+
+
+    .word   0x33add4f3
+    .word   0x2c743dd9
+    .word   0xed057d9d
+    .word   0xed092db5
+    .word   0x6f5fc80f
+    .word   0x29335dab
+    .word   0xab21658e
+    .word   0xea08ebfd
+
+
+    .word   0xd57997ca
+    .word   0x52b3072b
+    .word   0xc11a85a6
+    .word   0xd36edf05
+    .word   0xee1f1e8e
+    .word   0xe4ec6311
+    .word   0x4ca17fc3
+    .word   0x2b775307
+
+
+    .word   0x6f1cf3f3
+    .word   0x64cd749b
+    .word   0x30b1fd21
+    .word   0x58e14eaf
+    .word   0x376b4807
+    .word   0x2c599abe
+    .word   0xc80ca7f8
+    .word   0x737e0e67
+
+
+    .word   0x281a71b7
+    .word   0xa035fbfc
+    .word   0xc5bc5e61
+    .word   0x28944822
+    .word   0xd8e426a3
+    .word   0xf8d87fc2
+    .word   0xc10767e7
+    .word   0x6bdc796a
+
+
+    .word   0xf6b6ac47
+    .word   0x4f44080d
+    .word   0x6804e15b
+    .word   0x4c56a939
+    .word   0x57e10e4f
+    .word   0x2a685b24
+    .word   0xa5a29ae4
+    .word   0x6095fae5
+
+
+    .word   0xfaa712e4
+    .word   0xcbf490ab
+    .word   0x68fba106
+    .word   0x269d06b0
+    .word   0xedf00f54
+    .word   0xe505d397
+    .word   0x3eb63b36
+    .word   0xf3a78139
+
+
+    .word   0xeec18c16
+    .word   0x43ad2f11
+    .word   0x8bc2bccd
+    .word   0xdc91979c
+    .word   0xea947e52
+    .word   0x76bf1a9c
+    .word   0x314797c1
+    .word   0x10e1e65d
+
+
+    .word   0x39a864a2
+    .word   0x9c4b9fc7
+    .word   0x4605c8b6
+    .word   0x869808be
+    .word   0xb4507108
+    .word   0xde050c34
+    .word   0xc04879af
+    .word   0xe3b8d5ae
+
+
+    .word   0xd2a1e128
+    .word   0xf924a08
+    .word   0x29137875
+    .word   0xba6f3b3d
+    .word   0xe8566cb3
+    .word   0xd0a5ecb
+    .word   0x357c47f6
+    .word   0x112829b2
+
+
+    .word   0x8dfbc928
+    .word   0x1d6a5a31
+    .word   0x38c26cf7
+    .word   0x6cbbbc44
+    .word   0x5833506c
+    .word   0xf22c7de3
+    .word   0x12477f0a
+    .word   0x1dbc9693
+
+
+    .word   0xb7977070
+    .word   0xc988ccc7
+    .word   0xf39979f3
+    .word   0x246aa4cc
+    .word   0x9a792ae9
+    .word   0x7632d66a
+    .word   0xaa7f36b8
+    .word   0x94e46041
+
+
+    .word   0x3f1a79b
+    .word   0x7e4697e5
+    .word   0xfcb6c547
+    .word   0x1e141c3c
+    .word   0x2a016562
+    .word   0x56daf16e
+    .word   0x608ae597
+    .word   0x1f9e4682
+
+
+    .word   0x89eda740
+    .word   0xaf04c4fb
+    .word   0x84a624bc
+    .word   0xa1f91f25
+    .word   0x1b261515
+    .word   0x88d66757
+    .word   0x7e93e12f
+    .word   0x328a6e6c
+
+
+    .word   0x6d95dbe7
+    .word   0xb1bf32fd
+    .word   0x72256093
+    .word   0x8c0e394c
+    .word   0x70742c57
+    .word   0x802a3230
+    .word   0xc51ae4eb
+    .word   0xad57548b
+
+
+    .word   0x723f0211
+    .word   0x122dfc29
+    .word   0x1991b669
+    .word   0x489838fd
+    .word   0xbf31e39a
+    .word   0x87bf226a
+    .word   0xa15e6a7c
+    .word   0x22a1c9c0
+
+
+    .word   0xc0abeaad
+    .word   0xe3ab47e
+    .word   0x9b4d610e
+    .word   0x15bbd3c2
+    .word   0xe87641c0
+    .word   0xf107461e
+    .word   0x9b9f7cd9
+    .word   0xe6d8146c
+
+
+    .word   0xf18281d2
+    .word   0x5dfc978f
+    .word   0x2cedcc2d
+    .word   0x4d3f760a
+    .word   0x30e1160a
+    .word   0x861916bb
+    .word   0x4ce3fe93
+    .word   0x63268667
+
+
+    .word   0x64634841
+    .word   0xb8c659ad
+    .word   0x73964d8d
+    .word   0xf9eecc20
+    .word   0xaca76467
+    .word   0x44a11856
+    .word   0x8eef92e
+    .word   0x45e0959e
+
+
+    .word   0xacff49e1
+    .word   0x997706a8
+    .word   0x6ab431e8
+    .word   0x50a30105
+    .word   0xa17b85c1
+    .word   0x472da718
+    .word   0x4885266d
+    .word   0x41023b8c
+
+
+    .word   0xdeb5a5c6
+    .word   0x11b4f6bf
+    .word   0xb81b3269
+    .word   0x3405796e
+    .word   0x583dc7c
+    .word   0xcbf2cba0
+    .word   0x262a6fa4
+    .word   0xa01b44a2
+
+
+    .word   0x6a3cb0c5
+    .word   0xb4c47ea6
+    .word   0x8898e1bb
+    .word   0x173c2918
+    .word   0xb957bb38
+    .word   0x235466d
+    .word   0x4d3ad93f
+    .word   0x708b143f
+
+
+    .word   0xa9c5b336
+    .word   0xe551d3d2
+    .word   0xd66fc569
+    .word   0x80140a0a
+    .word   0x178be036
+    .word   0xce55a582
+    .word   0x52c255b
+    .word   0x3a04fa09
+
+
+    .word   0x5f482bb0
+    .word   0x5975aed9
+    .word   0x217fee0a
+    .word   0x56a7eee2
+    .word   0xd8c751b
+    .word   0x5333114c
+    .word   0x985121ea
+    .word   0xc2949b28
+
+
+    .word   0x337b43fc
+    .word   0x432b6033
+    .word   0xa60ebec9
+    .word   0x9517e168
+    .word   0x74c2666c
+    .word   0x9fd190d9
+    .word   0x63499cf5
+    .word   0x935c4183
+
+
+    .word   0xfc24eefd
+    .word   0xe5e11e96
+    .word   0xc2e45999
+    .word   0x1cd4c71c
+    .word   0xfab59f55
+    .word   0xe490ad09
+    .word   0xf97a56e7
+    .word   0xf5508291
+
+
+    .word   0x61818d11
+    .word   0x39fedc26
+    .word   0xe080e857
+    .word   0xb3edfbb3
+    .word   0xfde5819b
+    .word   0xffd76daa
+    .word   0xfb82609
+    .word   0x5b1d3738
+
+
+    .word   0xacdb46a3
+    .word   0xbc0def99
+    .word   0xbcff4a5b
+    .word   0xb6bde69d
+    .word   0x1a561153
+    .word   0x253bb339
+    .word   0xb3917d7
+    .word   0x22a86b46
+
+
+    .word   0x24a2f75e
+    .word   0x6c809f12
+    .word   0xcd7e39e7
+    .word   0xc123846b
+    .word   0xd04c43dd
+    .word   0x69d5f804
+    .word   0x116eeaf7
+    .word   0xaa52c3b4
+
+
+    .word   0x967256f7
+    .word   0xec4e2020
+    .word   0x87fb8ad9
+    .word   0x720c7840
+    .word   0xc352ade
+    .word   0x513909eb
+    .word   0x4c809ae9
+    .word   0x44185d71
+
+
+    .word   0x5d9aaca9
+    .word   0x5e5dcd99
+    .word   0xb938f626
+    .word   0xa111bfcd
+    .word   0x7b8f38e9
+    .word   0x585ea781
+    .word   0xa23736c1
+    .word   0x466d241f
+
+
+    .word   0x5606209f
+    .word   0xba2851fd
+    .word   0x108d3e9e
+    .word   0x33f9ebce
+    .word   0xc5b924a5
+    .word   0x475feb31
+    .word   0xc2ed2638
+    .word   0x76695606
+
+
+    .word   0xaa40b02a
+    .word   0x3af307bd
+    .word   0xa42ad20b
+    .word   0xa97dde08
+    .word   0x35b447f7
+    .word   0x3da87cd7
+    .word   0x17295740
+    .word   0x1b436927
+
+
+    .word   0xb72e96f8
+    .word   0xee71a998
+    .word   0xc06df0cf
+    .word   0x1e7bd704
+    .word   0xee8affc
+    .word   0xef3550b2
+    .word   0xe50f31d0
+    .word   0x65df73e
+
+
+    .word   0x8156b59
+    .word   0x52c500b8
+    .word   0xde550551
+    .word   0x9bd49b97
+    .word   0xd5a61c7f
+    .word   0x696cb194
+    .word   0x7383b1b0
+    .word   0x4f0a8586
+
+
+    .word   0x5a60f7e2
+    .word   0x7a391023
+    .word   0x944b5b2c
+    .word   0xdc590da8
+    .word   0x61ddd973
+    .word   0xbc3d44ea
+    .word   0xe7b81210
+    .word   0x73e0c75c
+
+
+    .word   0xcbda5904
+    .word   0xffe13ee7
+    .word   0xb5c86184
+    .word   0xf592211b
+    .word   0xacfaf3e6
+    .word   0x1adaa18b
+    .word   0x131ce3c
+    .word   0xf8932902
+
+
+    .word   0xa10ca2e0
+    .word   0xfcb78a87
+    .word   0xc6fd3879
+    .word   0x39eadb8b
+    .word   0xf874773a
+    .word   0x33348ec0
+    .word   0x4b7a27cf
+    .word   0xf58bbb5d
+
+
+    .word   0xeb8abb9
+    .word   0x129d69c
+    .word   0x66a8236d
+    .word   0xb17d2941
+    .word   0xdbad57b9
+    .word   0x5a22e7b3
+    .word   0x91adbab8
+    .word   0x2b85fbd
+
+
+    .word   0x2c071ed9
+    .word   0xcda72dfd
+    .word   0x92dd243f
+    .word   0xd42f08d3
+    .word   0x9c0ecc9c
+    .word   0x52031224
+    .word   0xe789ac8b
+    .word   0x8eeae759
+
+
+    .word   0x1d374d56
+    .word   0x9f9bd228
+    .word   0x26bb1827
+    .word   0x1d9a28b
+    .word   0x83a7ec0f
+    .word   0x85a16b8e
+    .word   0x67a36dfd
+    .word   0x8aabe1e5
+
+
+    .word   0xdbecfbf1
+    .word   0x94bc886b
+    .word   0xff46ac3f
+    .word   0x84764a0d
+    .word   0xcd4ed916
+    .word   0x81d81c9f
+    .word   0x3c4c35c3
+    .word   0xb990cc8b
+
+
+    .word   0x183c4462
+    .word   0x8a819740
+    .word   0x9cb08439
+    .word   0xf33601be
+    .word   0x50f1e414
+    .word   0x92efe8e0
+    .word   0x1831600
+    .word   0xee9a019a
+
+
+    .word   0x724cabe5
+    .word   0x6cb4dc2b
+    .word   0x27d2f343
+    .word   0xbce46410
+    .word   0x529ce6c2
+    .word   0xb6a4059d
+    .word   0xff7dbb70
+    .word   0x234ef725
+
+
+    .word   0xc81ab036
+    .word   0x2e40286
+    .word   0x87181969
+    .word   0x1e873d48
+    .word   0x421ae6ba
+    .word   0xdcd035d5
+    .word   0x77fa4789
+    .word   0x197ca7f3
+
+
+    .word   0x2c3db927
+    .word   0x2c6e1c1b
+    .word   0xf1b5e6ff
+    .word   0xdfda59ab
+    .word   0x29414a7a
+    .word   0xbed3a588
+    .word   0x2e0761e
+    .word   0x9857924e
+
+
+    .word   0xd08dc050
+    .word   0xb9064e77
+    .word   0xbf92a20f
+    .word   0xd00b0e44
+    .word   0x7c135525
+    .word   0x1e7ed261
+    .word   0xc3d25baa
+    .word   0xe4615f50
+
+
+    .word   0x4efb8293
+    .word   0x9352e241
+    .word   0x5589a603
+    .word   0x2a546dfa
+    .word   0x17a86461
+    .word   0x63bb3eb4
+    .word   0xac556ab3
+    .word   0x77a4adab
+
+
+    .word   0x315c7cc2
+    .word   0x392d30f1
+    .word   0xaa7ca0b8
+    .word   0x673566f5
+    .word   0xf5b142f7
+    .word   0xc3e26dd8
+    .word   0xa41a716d
+    .word   0xe6ce4c4e
+
+
+    .word   0xfc04f27
+    .word   0xa953e56a
+    .word   0xe13158f7
+    .word   0xe5e118d2
+    .word   0xdcf5ee74
+    .word   0xc3c03f98
+    .word   0x663ac260
+    .word   0xf08681e8
+
+
+    .word   0xcddfbcee
+    .word   0x6cc19cdb
+    .word   0x46cd4db0
+    .word   0xafb9db12
+    .word   0x88ae73cb
+    .word   0x63823c80
+    .word   0xf3c5ac19
+    .word   0xda78da02
+
+
+    .word   0x640a12f3
+    .word   0x8196c5d
+    .word   0x909384dc
+    .word   0xbcfe42cb
+    .word   0x847778fe
+    .word   0x61ba596d
+    .word   0x9bff0e1c
+    .word   0x24c7fe08
+
+
+    .word   0xb7404b1d
+    .word   0xfb7c5e2d
+    .word   0x9f6582ab
+    .word   0x28b22c78
+    .word   0x3111cd57
+    .word   0x6865d7ff
+    .word   0xb15a0315
+    .word   0xb8bda637
+
+
+    .word   0xf4cb5523
+    .word   0x39e5ee0a
+    .word   0x6737f6cd
+    .word   0xf5caf14e
+    .word   0x876024c4
+    .word   0x7d75db18
+    .word   0xd0e51eb5
+    .word   0x7300e3ae
+
+
+    .word   0xc82b113
+    .word   0x2e60db25
+    .word   0xb38c8cde
+    .word   0xea670da9
+    .word   0x4adb1e36
+    .word   0x885441ca
+    .word   0x4f4ed805
+    .word   0xf069a683
+
+
+    .word   0x9245822f
+    .word   0x3c223f2a
+    .word   0xf6a12a19
+    .word   0xbb29a0db
+    .word   0x3e4f5755
+    .word   0x9e68111f
+    .word   0x5bbb2722
+    .word   0xd0451f7d
+
+
+    .word   0x60999447
+    .word   0xfaa712e4
+    .word   0x6da78ec8
+    .word   0x9120668a
+    .word   0x47dbf466
+    .word   0x95ef2299
+    .word   0x86e4d5d6
+    .word   0xc8666d5d
+
+
+    .word   0x9841d5cb
+    .word   0xf178e7de
+    .word   0x68097c6b
+    .word   0x8592e892
+    .word   0xc995449d
+    .word   0xfb7a9499
+    .word   0x17a73ef8
+    .word   0x291e9f48
+
+
+    .word   0x646ed78
+    .word   0xda7288aa
+    .word   0xfedc5b48
+    .word   0x1806cb9
+    .word   0x62b4a451
+    .word   0x888fe26a
+    .word   0x54d48aa8
+    .word   0x9171ea89
+
+
+    .word   0x4feef7ba
+    .word   0x6675a6aa
+    .word   0x28b3a027
+    .word   0x7f7218e8
+    .word   0x3ca62f1b
+    .word   0xa4f80296
+    .word   0x2368d95
+    .word   0x5fef3356
+
+
+    .word   0x5e417aab
+    .word   0xe5d6759a
+    .word   0xd8d44dab
+    .word   0x2e11ffa1
+    .word   0x6d24b863
+    .word   0x7c5b08d8
+    .word   0xb0f61d5c
+    .word   0x1c7992a3
+
+
+    .word   0x8870d4bd
+    .word   0x251f2d6d
+    .word   0xde050c34
+    .word   0x68fba106
+    .word   0x9fc424f5
+    .word   0x48091e76
+    .word   0x48de74d9
+    .word   0x2faaeef0
+
+
+    .word   0x13b71844
+    .word   0xa15e6a7c
+    .word   0xcc48eda2
+    .word   0x927dbd5f
+    .word   0x8a663f66
+    .word   0xafad8c01
+    .word   0x5b182c10
+    .word   0xf123c30d
+
+
+    .word   0xc691a85e
+    .word   0x236fc402
+    .word   0xf6885e5
+    .word   0x99aac878
+    .word   0xe3433eeb
+    .word   0xd2660c4f
+    .word   0x7b1deaeb
+    .word   0x11a82a1f
+
+
+    .word   0x67396b34
+    .word   0x48279eb8
+    .word   0xa49cdc38
+    .word   0xd79dbbf9
+    .word   0xd6ee6972
+    .word   0x25452c60
+    .word   0x1d0a6bcf
+    .word   0xc888383d
+
+
+    .word   0x3a94be3c
+    .word   0x5a04f852
+    .word   0x89266c58
+    .word   0x407d1cb3
+    .word   0xea1fe48
+    .word   0x339ca551
+    .word   0xb4bfb957
+    .word   0xa785f8ca
+
+
+    .word   0x4d88a712
+    .word   0x509d850d
+    .word   0xcce95c18
+    .word   0x9724bc5e
+    .word   0x7de3cee9
+    .word   0x6c4afa9f
+    .word   0xf76f4266
+    .word   0x3a946189
+
+
+    .word   0x3c91a0a5
+    .word   0xf0c66eee
+    .word   0xc78e4c6b
+    .word   0x726dd872
+    .word   0xdada18f7
+    .word   0x30151272
+    .word   0xaef5ad2c
+    .word   0xd1990811
+
+
+    .word   0x184226f0
+    .word   0xbe9c5070
+    .word   0x422fde42
+    .word   0xfb33e4db
+    .word   0x18705898
+    .word   0xb296efee
+    .word   0x581bce6d
+    .word   0xa01285f3
+
+
+    .word   0xce8ef7fb
+    .word   0xb73873bf
+    .word   0xea4c6045
+    .word   0x16d5b9e8
+    .word   0x8b4f431f
+    .word   0x9b71b3ad
+    .word   0xea2cf992
+    .word   0x60863cde
+
+
+    .word   0xde86a245
+    .word   0xbbaa6bbb
+    .word   0x61486947
+    .word   0xd2a1e128
+    .word   0xe0b26ccf
+    .word   0xca170e7e
+    .word   0x21ba9a5a
+    .word   0x89c2a01a
+
+
+    .word   0x6238f474
+    .word   0x5e5ec380
+    .word   0xb1b8cb1d
+    .word   0x62e17a19
+    .word   0x2110e4af
+    .word   0x5db14651
+    .word   0x6d5582c9
+    .word   0x4940246e
+
+
+    .word   0x6e22be39
+    .word   0xe491912c
+    .word   0x3b00c76d
+    .word   0xe2a78121
+    .word   0x36d715cc
+    .word   0x8917cb32
+    .word   0x618dccbe
+    .word   0x795e6b11
+
+
+    .word   0xf0a6d146
+    .word   0x7ab6c06e
+    .word   0x36f9b699
+    .word   0x931efb8e
+    .word   0x44af391f
+    .word   0xba2ec4d9
+    .word   0xf778fe1f
+    .word   0x1234f77c
+
+
+    .word   0x4fe2aa3c
+    .word   0xaf3c0290
+    .word   0x713bdc49
+    .word   0xd8fb9858
+    .word   0x7e2890e6
+    .word   0xf01999f0
+    .word   0x4d253bc8
+    .word   0x28838d50
+
+
+    .word   0x4811e789
+    .word   0xdd94e33e
+    .word   0xdc2858c8
+    .word   0x50a8a360
+    .word   0xc1caf06a
+    .word   0x3eb63b36
+    .word   0x4f6ec169
+    .word   0x253c8ff1
+
+
+    .word   0xbc0def99
+    .word   0x44a5ef33
+    .word   0x7bdb8ade
+    .word   0x5c194759
+    .word   0xc954f9fa
+    .word   0x94e31cc9
+    .word   0x7632d66a
+    .word   0x8d259ffa
+
+
+    .word   0xbada29c
+    .word   0x20c45f91
+    .word   0x5fe5de5f
+    .word   0x213d438c
+    .word   0xd8d4df9f
+    .word   0x7696c8e6
+    .word   0x3011e9be
+    .word   0xecd9abf6
+
+
+    .word   0xdc7d8bc0
+    .word   0xc6de306d
+    .word   0x1a8ce6ed
+    .word   0xf1a06a17
+    .word   0x4f0ed779
+    .word   0x3b168b08
+    .word   0xbe9f6f13
+    .word   0x1badea89
+
+
+    .word   0x56eb490
+    .word   0x683fcf99
+    .word   0xfb9b5aae
+    .word   0x834bcd45
+    .word   0xc1e7dfe6
+    .word   0x8f29d6a5
+    .word   0x63880a8f
+    .word   0x4acbefe7
+
+
+    .word   0xe76ab3db
+    .word   0x25c19f8c
+    .word   0x9a409e52
+    .word   0xb288f809
+    .word   0x408003e6
+    .word   0x80c3ebff
+    .word   0x3f660727
+    .word   0x4b1ee489
+
+
+    .word   0xd360027
+    .word   0xc3bf97c2
+    .word   0x21d06595
+    .word   0xfb14b932
+    .word   0xce55a582
+    .word   0x4bd84603
+    .word   0x207cf27d
+    .word   0x83d57ce2
+
+
+    .word   0x3be886d9
+    .word   0x910008e9
+    .word   0xba0258c6
+    .word   0x3518ce72
+    .word   0xd3825524
+    .word   0x681d0873
+    .word   0x5feef951
+    .word   0x8ec8a702
+
+
+    .word   0x7fe95991
+    .word   0x10e6dd3b
+    .word   0x10f07f80
+    .word   0x61e3960d
+    .word   0x1cdf2d83
+    .word   0xf6113994
+    .word   0xe823b481
+    .word   0xc3e640dc
+
+
+    .word   0x9bdd49e5
+    .word   0x346db24
+    .word   0xa521f008
+    .word   0x5887e9dc
+    .word   0x7a98705f
+    .word   0x149cb02e
+    .word   0x556c9c2a
+    .word   0xee8affc
+
+
+    .word   0xe60c53db
+    .word   0x50097fbb
+    .word   0x774edad8
+    .word   0xdbdb45b8
+    .word   0xaeb4f1c8
+    .word   0xf09dbb8d
+    .word   0x4ef53098
+    .word   0xe47f6f50
+
+
+    .word   0x1cb74b30
+    .word   0xcdb4d526
+    .word   0x8df0d1e5
+    .word   0x18f99658
+    .word   0x9e088762
+    .word   0x669537eb
+    .word   0x19902d18
+    .word   0xde858266
+
+
+    .word   0xebe51f46
+    .word   0xf36cd25e
+    .word   0xc3d19c91
+    .word   0x93db31f9
+    .word   0x6dd89d0b
+    .word   0x108d3e9e
+    .word   0xfb568cfe
+    .word   0x43648f5a
+
+
+    .word   0xa3eb2a53
+    .word   0x6f7c80fd
+    .word   0x64b17871
+    .word   0x81ce9028
+    .word   0x509f5818
+    .word   0xee04aedc
+    .word   0x4f0a8586
+    .word   0x6c795505
+
+
+    .word   0x745f7c4d
+    .word   0xd87d0a4f
+    .word   0xade59b1b
+    .word   0xc0e2fba0
+    .word   0xb7dedf9f
+    .word   0xb149d7d4
+    .word   0xa6160a96
+    .word   0xb845f1e
+
+
+    .word   0x45316b3f
+    .word   0x2acb1542
+    .word   0xe4dac8f4
+    .word   0x119724ed
+    .word   0x8a333e79
+    .word   0x78bc71a0
+    .word   0x810e65bb
+    .word   0x47402e44
+
+
+    .word   0x9f3d450e
+    .word   0xd4bf5993
+    .word   0x88eba061
+    .word   0x66ef9897
+    .word   0xaa588221
+    .word   0x7d1b128f
+    .word   0xf5273920
+    .word   0x15a12c00
+
+
+    .word   0x57a2f1e1
+    .word   0xff459fcf
+    .word   0x7c9cd23a
+    .word   0x47ac7dba
+    .word   0x610beeea
+    .word   0x69731100
+    .word   0x363c038
+    .word   0xbcbc8af3
+
+
+    .word   0xbe51d874
+    .word   0xb3eb911
+    .word   0xdcb18855
+    .word   0x2e0761e
+    .word   0xff00d395
+    .word   0x72e5a26d
+    .word   0x770eb664
+    .word   0xb1520582
+
+
+    .word   0xbc6be071
+    .word   0xc5b924a5
+    .word   0xc53d5984
+    .word   0xfc9667a5
+    .word   0xdff234cf
+    .word   0xcd603d3b
+    .word   0x1143cc78
+    .word   0x1cfe6907
+
+
+    .word   0x6e763e88
+    .word   0x400b0049
+    .word   0x868a4c17
+    .word   0x5be0d959
+    .word   0xd7f5c562
+    .word   0xab20b6f6
+    .word   0x78e111fd
+    .word   0xb8357db3
+
+
+    .word   0x99cef4c1
+    .word   0xfc2a4f58
+    .word   0xd643839c
+    .word   0x25423743
+    .word   0xc8a0fb7f
+    .word   0x330a72b6
+    .word   0x25d3710b
+    .word   0xfb82609
+
+
+    .word   0x2f351f9e
+    .word   0x9e1d412d
+    .word   0x2da52327
+    .word   0x2b58b46f
+    .word   0x468a9ec3
+    .word   0x6e835925
+    .word   0x88adeb78
+    .word   0x57a8ac61
+
+
+    .word   0xa550a5f7
+    .word   0xbf9421c1
+    .word   0x29051af7
+    .word   0xcbac2b5c
+    .word   0x9660f557
+    .word   0x261b4200
+    .word   0xe8b46e82
+    .word   0x404ec8dc
+
+
+    .word   0x9753592e
+    .word   0x46403b9c
+    .word   0x1b436927
+    .word   0xf9b947b1
+    .word   0x8aa0996c
+    .word   0x830d6631
+    .word   0x61fddf5c
+    .word   0x463d7f21
+
+
+    .word   0x8f334b56
+    .word   0x3a8f7188
+    .word   0x5ca36df
+    .word   0x738ce9d4
+    .word   0xe9349943
+    .word   0xf66d356c
+    .word   0xf1168009
+    .word   0xaefaf6bd
+
+
+    .word   0x2e2675df
+    .word   0xcef11acc
+    .word   0xdf8ee573
+    .word   0xf7387ae1
+    .word   0x6b76ac9e
+    .word   0xd58c781f
+    .word   0x2d7a37b5
+    .word   0x34a0f922
+
+
+    .word   0x12706d51
+    .word   0x8aad1425
+    .word   0x72b729f3
+    .word   0xed0d869b
+    .word   0xab5e8158
+    .word   0x8700ceaa
+    .word   0x23e14cc7
+    .word   0xd028e337
+
+
+    .word   0x2bfb042c
+    .word   0x30cd2211
+    .word   0xcb7d8459
+    .word   0x93931044
+    .word   0xbee5e0da
+    .word   0xc0b54882
+    .word   0x1e3ef344
+    .word   0x5bdb052d
+
+
+    .word   0x52c5a773
+    .word   0xfe922e3d
+    .word   0x596d3074
+    .word   0xbd4c9ed6
+    .word   0xb077cfbb
+    .word   0xc7f11776
+    .word   0xa092a0de
+    .word   0xbfef6817
+
+
+    .word   0x3777b98c
+    .word   0x62cc57f1
+    .word   0xb831b1c0
+    .word   0xbe38703b
+    .word   0xb1fe8357
+    .word   0xb36d3c5e
+    .word   0xb34d6639
+    .word   0x25178a8
+
+
+    .word   0xd0451f7d
+    .word   0x6095fae5
+    .word   0x23a4ebf2
+    .word   0x84eb06a2
+    .word   0xd00b0e44
+    .word   0x6fcf7333
+    .word   0x8ab32c60
+    .word   0x9cd49976
+
+
+    .word   0xd6efdaaf
+    .word   0x6666c8f6
+    .word   0x4b13b30e
+    .word   0x7ea0bbef
+    .word   0x6edb1265
+    .word   0xd5dc3667
+    .word   0x192972fe
+    .word   0x598518c5
+
+
+    .word   0x26b19bf7
+    .word   0xa7b18e82
+    .word   0xc9ac3ea9
+    .word   0xb1868e
+    .word   0xc9986353
+    .word   0x273b9dc4
+    .word   0xee2b20a3
+    .word   0x2f1b452a
+
+
+    .word   0x101cef7e
+    .word   0xa8fc2d93
+    .word   0xc8c37e42
+    .word   0x383a1d6f
+    .word   0xd88c075b
+    .word   0xea8bd817
+    .word   0x6ca63795
+    .word   0xaca330a4
+
+
+    .word   0xbd778911
+    .word   0x15a02d81
+    .word   0xacb85902
+    .word   0xf0efe552
+    .word   0x25690de0
+    .word   0xe6aee8fb
+    .word   0xb5b6be2
+    .word   0xbb6cba11
+
+
+    .word   0x32439c62
+    .word   0xe2897334
+    .word   0x1b18f6b
+    .word   0xaf86e46
+    .word   0x551f5d7c
+    .word   0x95cd9f4e
+    .word   0x46e07423
+    .word   0xab5efd96
+
+
+    .word   0xf88c28cb
+    .word   0x17202411
+    .word   0x81eaa11a
+    .word   0x1d24984e
+    .word   0x928d3723
+    .word   0xa3f9807b
+    .word   0xc0e4d845
+    .word   0xa7f0f751
+
+
+    .word   0x7df73ab8
+    .word   0xc8d76491
+    .word   0xbe4b707b
+    .word   0x9390e126
+    .word   0x9a7a206b
+    .word   0x8870d4bd
+    .word   0xb4507108
+    .word   0x6da78ec8
+
+
+    .word   0x70522ac6
+    .word   0xe4d28b49
+    .word   0xe1491673
+    .word   0xd21a445f
+    .word   0x843e3682
+    .word   0x360901a9
+    .word   0xda194960
+    .word   0x4640e590
+
+
+    .word   0x3c5cfe5
+    .word   0x3cdd0c7
+    .word   0x65495e07
+    .word   0xb50a9e2f
+    .word   0x436aad6d
+    .word   0x69793c11
+    .word   0x50567d31
+    .word   0x143cb505
+
+
+    .word   0xd7116290
+    .word   0x3190df45
+    .word   0x251f2d6d
+    .word   0xcbf490ab
+    .word   0x47ba7fe3
+    .word   0xbb65fcbf
+    .word   0xe0cc402a
+    .word   0xcc838ffe
+
+
+    .word   0xd1e8fd0a
+    .word   0xc2782979
+    .word   0x9da11c
+    .word   0x5f79af82
+    .word   0x29fa173a
+    .word   0xc29ec354
+    .word   0xfadfec8
+    .word   0xc82b113
+
+
+    .word   0xe6040818
+    .word   0xc3d25baa
+    .word   0x2a438704
+    .word   0x42124d01
+    .word   0x2d5ed025
+    .word   0x5281575e
+    .word   0x4812255c
+    .word   0xb6eb0437
+
+
+    .word   0x18dc15bc
+    .word   0xfe0afd8
+    .word   0x6111588c
+    .word   0x8aeea77f
+    .word   0x350a5e81
+    .word   0xcdea6fef
+    .word   0x23f9a1c2
+    .word   0x5099adb4
+
+
+    .word   0x6eba1c30
+    .word   0x907ca548
+    .word   0x6feb360e
+    .word   0xf2572143
+    .word   0x5cce2d
+    .word   0xbcab1de3
+    .word   0x342c473d
+    .word   0xe82cd739
+
+
+    .word   0x49c1e9f9
+    .word   0x472da718
+    .word   0x696dd016
+    .word   0xd46521a1
+    .word   0x93be9a9d
+    .word   0x7192b915
+    .word   0x2e60db25
+    .word   0xbf65f83b
+
+
+    .word   0x13f825e2
+    .word   0xa99c7674
+    .word   0x988e67f8
+    .word   0x6edaeafa
+    .word   0x7f72eda0
+    .word   0x77df2703
+    .word   0x47ff3a79
+    .word   0xa2e6c57c
+
+
+    .word   0xb6176a6
+    .word   0x457402d0
+    .word   0x5d2e78bb
+    .word   0x8bd7f83f
+    .word   0xd129e051
+    .word   0x868f41d6
+    .word   0x1266cc80
+    .word   0xda8c8d38
+
+
+    .word   0x2b47a26c
+    .word   0x7672f10e
+    .word   0x54f8bec8
+    .word   0xe46103af
+    .word   0xbb4e99ce
+    .word   0x4f6ec169
+    .word   0xacdb46a3
+    .word   0x2ee974de
+
+
+    .word   0x3d1006e
+    .word   0xfc333998
+    .word   0xa31bc40f
+    .word   0xad8560d9
+    .word   0x836b008
+    .word   0x47871a30
+    .word   0x6d51ec69
+    .word   0x6fea8b14
+
+
+    .word   0x16495a45
+    .word   0xeed19931
+    .word   0x286c9c67
+    .word   0xb2261625
+    .word   0x538d35f1
+    .word   0xa605d659
+    .word   0x90cb5e70
+    .word   0x94314550
+
+
+    .word   0x942051b7
+    .word   0x150e663b
+    .word   0x6b6926cd
+    .word   0x47b754c
+    .word   0xbae823b5
+    .word   0x6c7180a6
+    .word   0x58882f61
+    .word   0xef439bca
+
+
+    .word   0x4eee6d72
+    .word   0xa214bcd9
+    .word   0xe17970da
+    .word   0x8ae86f27
+    .word   0xeafddabd
+    .word   0x155cd718
+    .word   0x1ad2b1c3
+    .word   0xfe0865a2
+
+
+    .word   0xff44cf5d
+    .word   0x1afb7d25
+    .word   0x515c5fa0
+    .word   0xf7433cc4
+    .word   0x4387dba5
+    .word   0xad43b179
+    .word   0x960657c5
+    .word   0x8d899185
+
+
+    .word   0xb465c8fc
+    .word   0x44a11856
+    .word   0xf2d1a826
+    .word   0xcd6df8a0
+    .word   0x2956a9a3
+    .word   0xd07e3462
+    .word   0xabb15993
+    .word   0x2371fe4a
+
+
+    .word   0x429794ea
+    .word   0xc680135d
+    .word   0x1d2a1293
+    .word   0x19480179
+    .word   0xbbaa6bbb
+    .word   0xe3b8d5ae
+    .word   0x5d82763e
+    .word   0x4ad992d4
+
+
+    .word   0x29eb7501
+    .word   0x59f8acc
+    .word   0x10a10da6
+    .word   0x3809e61f
+    .word   0x9d21ed3c
+    .word   0x3fbb2bad
+    .word   0x303b7f68
+    .word   0xe017ca9f
+
+
+    .word   0xce439af8
+    .word   0x71da8d8d
+    .word   0xc27b795e
+    .word   0x6779e892
+    .word   0xbf50e3bf
+    .word   0xf2397c79
+    .word   0xfbd07ac9
+    .word   0xe0c42047
+
+
+    .word   0xa1618bda
+    .word   0x6dc73951
+    .word   0xd7fd756b
+    .word   0x49cd682b
+    .word   0xc1b36bf3
+    .word   0x966a1f7b
+    .word   0x128a7430
+    .word   0x43811d44
+
+
+    .word   0xa12c965e
+    .word   0xb9cfa6e1
+    .word   0x9eba45a0
+    .word   0xfc38c1ea
+    .word   0x543d3ab
+    .word   0xdcc2a43
+    .word   0xa249a329
+    .word   0x1c7d1ab
+
+
+    .word   0x149cb02e
+    .word   0x1e7bd704
+    .word   0x9d5c00be
+    .word   0x810b1a68
+    .word   0xc1d7464
+    .word   0xa09efb89
+    .word   0x8ccff294
+    .word   0xa8fe07e2
+
+
+    .word   0xb4915f6c
+    .word   0x6ad86968
+    .word   0x3123684d
+    .word   0x28152fcd
+    .word   0xe1b24322
+    .word   0x233c3462
+    .word   0xfa5e8d14
+    .word   0x9b950b31
+
+
+    .word   0xec57a54a
+    .word   0xecd34cc6
+    .word   0x426bbe1d
+    .word   0xa67a44c5
+    .word   0x85c1c8a0
+    .word   0x59e894b1
+    .word   0x5783a949
+    .word   0x208f876d
+
+
+    .word   0x3c97808
+    .word   0xa672c697
+    .word   0x697bdb89
+    .word   0xf76f4266
+    .word   0x44d5e66e
+    .word   0x6fca167e
+    .word   0xa445f2c6
+    .word   0x317c6507
+
+
+    .word   0xc74ebb36
+    .word   0x21d06595
+    .word   0x178be036
+    .word   0xf90bd045
+    .word   0xb6b59718
+    .word   0xc5779c7a
+    .word   0xeb2dcf6e
+    .word   0x8fddf86d
+
+
+    .word   0x8949148c
+    .word   0x26671285
+    .word   0x81a13fcc
+    .word   0x447d05e5
+    .word   0x352340f1
+    .word   0xc954f9fa
+    .word   0x9a792ae9
+    .word   0x108365bf
+
+
+    .word   0x242ef70
+    .word   0x1f5ce5f8
+    .word   0xe125a030
+    .word   0x509f5818
+    .word   0x7383b1b0
+    .word   0x9291eee9
+    .word   0x747f2d03
+    .word   0xbcddaa0f
+
+
+    .word   0x6fb534fd
+    .word   0xb438af14
+    .word   0xfa5762c8
+    .word   0x9221ec1f
+    .word   0x5a923745
+    .word   0xb018e45
+    .word   0x93db31f9
+    .word   0xba2851fd
+
+
+    .word   0xa5b93372
+    .word   0x11b4f6bf
+    .word   0x50a8a360
+    .word   0xe505d397
+    .word   0x41e06a
+    .word   0x69557a50
+    .word   0xf59e6bc2
+    .word   0xa430108
+
+
+    .word   0x484ba71d
+    .word   0x6d69fb6d
+    .word   0xee90161d
+    .word   0xafb86d33
+    .word   0x31ba2ac3
+    .word   0xa66629ff
+    .word   0x6a3ac76
+    .word   0xee10b33b
+
+
+    .word   0xeaf857f0
+    .word   0x3b8eb8e7
+    .word   0x968e1108
+    .word   0x5e02d317
+    .word   0x10ed85df
+    .word   0x51ca45d5
+    .word   0x5df372f5
+    .word   0x31629de1
+
+
+    .word   0xef9108af
+    .word   0x7ac704a3
+    .word   0xac93b62d
+    .word   0x2e6fecdd
+    .word   0x27aace9
+    .word   0x2adec5a
+    .word   0x1fe96ef9
+    .word   0x6e29a5a1
+
+
+    .word   0x15436db8
+    .word   0xff30a02c
+    .word   0x8a77bf7c
+    .word   0x9f87cc4c
+    .word   0x55c6edfb
+    .word   0x5ae32d1b
+    .word   0x2b003e6c
+    .word   0xfa9c4fd4
+
+
+    .word   0x3d27b40
+    .word   0x9c16fb34
+    .word   0x5c6664f6
+    .word   0x59713496
+    .word   0xeff574fc
+    .word   0xe197e540
+    .word   0x9ad0d9f1
+    .word   0x2736122c
+
+
+    .word   0x1d1314f5
+    .word   0xac326289
+    .word   0x4e9ed95e
+    .word   0xa6559b05
+    .word   0x5a099dc6
+    .word   0x783d5ff9
+    .word   0x53bf99af
+    .word   0x4d3b49c8
+
+
+    .word   0xe3660270
+    .word   0x9352e241
+    .word   0x64c1e794
+    .word   0x2656c76b
+    .word   0x16732b0b
+    .word   0xfc50d371
+    .word   0xd8fc26f6
+    .word   0x35ce6a8b
+
+
+    .word   0x85ea3c79
+    .word   0xddfb67ef
+    .word   0x6b1d3b64
+    .word   0x7b53cd39
+    .word   0x42d879cf
+    .word   0x5bdc39c7
+    .word   0xd6c0ff72
+    .word   0x37394e60
+
+
+    .word   0xb66654b5
+    .word   0x30c670cc
+    .word   0x93d4757d
+    .word   0x829080e2
+    .word   0x2decff36
+    .word   0x8013a692
+    .word   0x2b281408
+    .word   0xcee18c62
+
+
+    .word   0x73b6efa9
+    .word   0xcef8aea
+    .word   0xfb5af918
+    .word   0x44a71989
+    .word   0x8b84f3fe
+    .word   0xa2fa482e
+    .word   0x974fc929
+    .word   0xc5811341
+
+
+    .word   0x131541d
+    .word   0x92ce77dc
+    .word   0xfdeabe91
+    .word   0x14baccbe
+    .word   0xb015cf08
+    .word   0xf107461e
+    .word   0xf2e3a730
+    .word   0xb34d6639
+
+
+    .word   0x5bbb2722
+    .word   0xa5a29ae4
+    .word   0x3d97faab
+    .word   0xfc9a58f9
+    .word   0xb1520582
+    .word   0x33f9ebce
+    .word   0xa8789948
+    .word   0x8ba778db
+
+
+    .word   0xeda2974a
+    .word   0x686447ce
+    .word   0xd1c6841c
+    .word   0xdf7bce51
+    .word   0x38e105f9
+    .word   0xb6a4059d
+    .word   0x8a794056
+    .word   0xdd3906cd
+
+
+    .word   0xbd78b743
+    .word   0xdd28b6be
+    .word   0xb9934c58
+    .word   0xf4e3ad28
+    .word   0x8e9eb836
+    .word   0xfd5d160c
+    .word   0x8502b276
+    .word   0x78cafa9e
+
+
+    .word   0x14e9fb19
+    .word   0x341f5a8
+    .word   0xa6b41595
+    .word   0x11ada0b7
+    .word   0x25c5b920
+    .word   0x83b9f728
+    .word   0xd88ace6d
+    .word   0xd4bd5025
+
+
+    .word   0x82d3756e
+    .word   0x7115d88e
+    .word   0xa888c
+    .word   0x74fab1e9
+    .word   0x327f144c
+    .word   0x19902d18
+    .word   0x8d5b0170
+    .word   0xa6711909
+
+
+    .word   0x7d66982b
+    .word   0xf5132ce
+    .word   0x42009199
+    .word   0x1fd019fa
+    .word   0xec6ee8cd
+    .word   0xa5936673
+    .word   0x4c4bd421
+    .word   0x7114cc08
+
+
+    .word   0x1f87559
+    .word   0x720484fc
+    .word   0xeacc4b17
+    .word   0x6b673f83
+    .word   0x440bf5a6
+    .word   0xca88fec
+    .word   0x68a02a51
+    .word   0xdaa0a3c5
+
+
+    .word   0x7cd126ef
+    .word   0xfcdf901b
+    .word   0x60182110
+    .word   0xf8f55462
+    .word   0xe7593b3c
+    .word   0x36de2b13
+    .word   0x3cd3c57e
+    .word   0xb84ff0cf
+
+
+    .word   0x3f31c933
+    .word   0xa21b3b8
+    .word   0xe121b5a9
+    .word   0x5f6e5a22
+    .word   0x88dc7ebe
+    .word   0xf398579b
+    .word   0x83882d0a
+    .word   0xca25544a
+
+
+    .word   0x3589f76e
+    .word   0xa95c0250
+    .word   0x7b856294
+    .word   0x9753592e
+    .word   0x17295740
+    .word   0xd8c79fdb
+    .word   0x2e207620
+    .word   0xb16f92b4
+
+
+    .word   0x9390e126
+    .word   0x1c7992a3
+    .word   0x869808be
+    .word   0x23a4ebf2
+    .word   0xbf92a20f
+    .word   0x9e5de09
+    .word   0x330a72b6
+    .word   0xffd76daa
+
+
+    .word   0xc9f559dc
+    .word   0x10405742
+    .word   0xee0e822b
+    .word   0x2fd372ab
+    .word   0x3095b6de
+    .word   0xcf52d3ea
+    .word   0x692240c5
+    .word   0x3e1c412c
+
+
+    .word   0x54754b20
+    .word   0xa0903150
+    .word   0xd47615bf
+    .word   0x48c941fd
+    .word   0x94267efb
+    .word   0x31af4d7e
+    .word   0xb78215f0
+    .word   0x4bcab6de
+
+
+    .word   0x5e44d7e7
+    .word   0x92efe8e0
+    .word   0x52368433
+    .word   0x820f7d0d
+    .word   0x3260dd03
+    .word   0x26d4f647
+    .word   0x4f0f291c
+    .word   0xee093f34
+
+
+    .word   0x81bd39b
+    .word   0x986db00f
+    .word   0x7ee0ab46
+    .word   0x6b25e9d7
+    .word   0x6038943b
+    .word   0x35b76097
+    .word   0xc1cbe099
+    .word   0x470ad956
+
+
+    .word   0xf0bd3d90
+    .word   0xd7116290
+    .word   0x8870d4bd
+    .word   0xfaa712e4
+    .word   0x877db17c
+    .word   0xfe25f0e
+    .word   0xafa3846d
+    .word   0x4eb4e660
+
+
+    .word   0x2721009e
+    .word   0x1866e31b
+    .word   0x70aa776a
+    .word   0x80f9c8fb
+    .word   0x458bd818
+    .word   0x2b43c79d
+    .word   0x5e48bf34
+    .word   0x4160127
+
+
+    .word   0xfccda584
+    .word   0x443a426d
+    .word   0x67239a57
+    .word   0x9cca9b4d
+    .word   0x73b0d3ee
+    .word   0x50896666
+    .word   0x763de10e
+    .word   0xc287f36a
+
+
+    .word   0x426157e
+    .word   0xad99cf1b
+    .word   0xdf745e29
+    .word   0x56ea73ae
+    .word   0xff098a93
+    .word   0xa123aabc
+    .word   0x7513bc72
+    .word   0xa284dba6
+
+
+    .word   0x50f7c6aa
+    .word   0x17da0726
+    .word   0xc3c2d9ef
+    .word   0x87eb0cc7
+    .word   0xf017f923
+    .word   0x13e20ffc
+    .word   0xc90eeec3
+    .word   0xd13c747a
+
+
+    .word   0x95849f61
+    .word   0x9a6380fc
+    .word   0x5dfc978f
+    .word   0x1c698a31
+    .word   0x5dcdec09
+    .word   0x77af09e3
+    .word   0x66087e24
+    .word   0x7198a566
+
+
+    .word   0x578d90aa
+    .word   0xb1fbe60e
+    .word   0xd9f69449
+    .word   0x1dc9881
+    .word   0xd520ce12
+    .word   0xd2b3c087
+    .word   0xe32405cf
+    .word   0x94adf87d
+
+
+    .word   0x6c14cbf
+    .word   0x1adaa18b
+    .word   0xe8a0bef7
+    .word   0x30f6ba96
+    .word   0x27193ba1
+    .word   0xa9a25bf7
+    .word   0x491b4097
+    .word   0xc93076bb
+
+
+    .word   0x78d035b1
+    .word   0x458b5dcd
+    .word   0x1e94b13f
+    .word   0x7cd87d95
+    .word   0x2028fb04
+    .word   0x7283fad7
+    .word   0xc7ebb10c
+    .word   0x6d411c2f
+
+
+    .word   0x23651f86
+    .word   0x23ebe591
+    .word   0xfb52e95c
+    .word   0x6b0f9e8c
+    .word   0xeabdcab2
+    .word   0x43356fe4
+    .word   0x5938d02f
+    .word   0x5c5a620a
+
+
+    .word   0x2a8888c
+    .word   0xf01999f0
+    .word   0x748ea7d7
+    .word   0x59172d85
+    .word   0xc29ec354
+    .word   0x7300e3ae
+    .word   0x583df349
+    .word   0x8ab32c60
+
+
+    .word   0xcbd52c18
+    .word   0xbc563e45
+    .word   0xc66ea99
+    .word   0x2e1ccc90
+    .word   0x82623f41
+    .word   0xd37258e
+    .word   0x142654ce
+    .word   0xce5485e4
+
+
+    .word   0x9f157d56
+    .word   0x183017ab
+    .word   0xd331f405
+    .word   0x26db37c8
+    .word   0xe1a04c33
+    .word   0x6c52435b
+    .word   0x9c6ae802
+    .word   0xf85a08d6
+
+
+    .word   0x37017143
+    .word   0xed057d9d
+    .word   0x5d322d64
+    .word   0x88de3a80
+    .word   0xf45af6ff
+    .word   0x36e515b6
+    .word   0x47d39b6d
+    .word   0x7c3dae88
+
+
+    .word   0x41b9b549
+    .word   0xb296efee
+    .word   0x1226ee3f
+    .word   0x3f90294b
+    .word   0x2c0c8fae
+    .word   0xfc192679
+    .word   0x40cc3c5c
+    .word   0xb0c8dc65
+
+
+    .word   0xc2fafc22
+    .word   0xfe159b22
+    .word   0xf5508291
+    .word   0x846228eb
+    .word   0xa15ed20b
+    .word   0x193f2d82
+    .word   0x1fd51e43
+    .word   0x9b4615a9
+
+
+    .word   0x893791c
+    .word   0xa249a329
+    .word   0x7a98705f
+    .word   0xc06df0cf
+    .word   0xd76ba55a
+    .word   0x1cab9488
+    .word   0x971dc1bc
+    .word   0x680f1159
+
+
+    .word   0x49cb6733
+    .word   0xddb29368
+    .word   0xa136784e
+    .word   0x93b3ab4c
+    .word   0xd9a399cc
+    .word   0xe661645
+    .word   0xc287a2d6
+    .word   0xdbbb2eda
+
+
+    .word   0x63f813b3
+    .word   0x93be9a9d
+    .word   0xc82b113
+    .word   0x1e7ed261
+    .word   0x2658c722
+    .word   0x4d968ba8
+    .word   0xebd0b5fd
+    .word   0x19366e51
+
+
+    .word   0xad3f6b1c
+    .word   0x108b03d2
+    .word   0xa976a028
+    .word   0x18735aa3
+    .word   0x12f620ed
+    .word   0xb0135b87
+    .word   0xfd1f5f6e
+    .word   0xb19da955
+
+
+    .word   0xadd9cb9
+    .word   0x8218925a
+    .word   0x43cff9c5
+    .word   0x25b41171
+    .word   0xc92f90cf
+    .word   0x1a9282e
+    .word   0x925f1673
+    .word   0xf052ca35
+
+
+    .word   0xa221be4e
+    .word   0x47f71839
+    .word   0x26e1d1f0
+    .word   0x4e430e10
+    .word   0x123532f5
+    .word   0x1d2a1293
+    .word   0xde86a245
+    .word   0xc04879af
+
+
+    .word   0xe945add8
+    .word   0x995aaaab
+    .word   0xd9cefe95
+    .word   0x939333c4
+    .word   0x101fb2b0
+    .word   0xd990f012
+    .word   0x9245ea24
+    .word   0xe9f419b1
+
+
+    .word   0x88c34569
+    .word   0x5a04f852
+    .word   0x980aa5a5
+    .word   0xb7d4fa1f
+    .word   0x2e08396c
+    .word   0xa9d0f522
+    .word   0xcd12ea46
+    .word   0xc26ff333
+
+
+    .word   0x8a85de23
+    .word   0xa7c965c9
+    .word   0xf27bda97
+    .word   0xbe8bf343
+    .word   0xb6a10502
+    .word   0x5f995dd2
+    .word   0x6fb02f80
+    .word   0xa5d39fd4
+
+
+    .word   0x1f5ce5f8
+    .word   0x81ce9028
+    .word   0x696cb194
+    .word   0x29465fb0
+    .word   0x3c8a1049
+    .word   0xd586a169
+    .word   0x5b66448b
+    .word   0x6cf2a009
+
+
+    .word   0xe9bcda22
+    .word   0xb07a1abd
+    .word   0x57330e2c
+    .word   0x1100350d
+    .word   0xc8821bc3
+    .word   0xc47f3ef6
+    .word   0x738213e0
+    .word   0xdd71c6e0
+
+
+    .word   0x729978fd
+    .word   0x68f7111a
+    .word   0x9235fbc4
+    .word   0xfd83b05
+    .word   0x41e78c7e
+    .word   0x5edb06fc
+    .word   0x317c6507
+    .word   0xc3bf97c2
+
+
+    .word   0x80140a0a
+    .word   0x58ab9c10
+    .word   0xbcbdd6c8
+    .word   0x350989c
+    .word   0xffe92711
+    .word   0x1db106e0
+    .word   0xd0dfcd48
+    .word   0x5a923745
+
+
+    .word   0xc3d19c91
+    .word   0x5606209f
+    .word   0x3fad06
+    .word   0xacb29c8a
+    .word   0xa9947cad
+    .word   0x95ef2299
+    .word   0x635150a3
+    .word   0x14659adc
+
+
+    .word   0xd2cc7c6f
+    .word   0x2937262e
+    .word   0x273847ed
+    .word   0x1dbba1b4
+    .word   0x23183d4c
+    .word   0x9b4d610e
+    .word   0x2c7eb51c
+    .word   0x8696989d
+
+
+    .word   0x6edd390f
+    .word   0x81391f60
+    .word   0x2b90fc67
+    .word   0x4bef006
+    .word   0xa8b29e6e
+    .word   0x3b4ab10d
+    .word   0xdc5152c9
+    .word   0x83795899
+
+
+    .word   0x8565e2d2
+    .word   0x90cb5e70
+    .word   0xd7392213
+    .word   0xdbda695
+    .word   0xd2019c0c
+    .word   0xeda00586
+    .word   0xa3a247f6
+    .word   0xce707036
+
+
+    .word   0x9d0caa4b
+    .word   0x27b8d00
+    .word   0xd8371561
+    .word   0x9f58c71a
+    .word   0x3aebab22
+    .word   0x4edab433
+    .word   0xe76d7a1
+    .word   0x57cc3d1
+
+
+    .word   0xdccaeb11
+    .word   0x56c0fc34
+    .word   0x82b8deba
+    .word   0x3977f6c7
+    .word   0x6a216824
+    .word   0xc5edd1d5
+    .word   0xdda0ad7d
+    .word   0xd4ac629a
+
+
+    .word   0xa49b5421
+    .word   0x8c1013fc
+    .word   0xbce46410
+    .word   0x81200bcd
+    .word   0x447d05e5
+    .word   0x5c194759
+    .word   0x246aa4cc
+    .word   0xa3d0f22f
+
+
+    .word   0x3f694ce7
+    .word   0xf1c0354b
+    .word   0x32a0f791
+    .word   0xf85b9616
+    .word   0xfbb2a167
+    .word   0xd4550cb
+    .word   0x9b4bf82c
+    .word   0xddbb4e10
+
+
+    .word   0x1d353f3d
+    .word   0x2a307e5
+    .word   0x8c6ca50f
+    .word   0xff87a7d8
+    .word   0x5dc5e705
+    .word   0x7415cfc9
+    .word   0xeef7d57
+    .word   0x88883a97
+
+
+    .word   0x86b71ae3
+    .word   0xfa4b7767
+    .word   0xe444143b
+    .word   0xff95cafd
+    .word   0xad29d500
+    .word   0xca90bd19
+    .word   0x99226589
+    .word   0x358bfb60
+
+
+    .word   0x3b58a925
+    .word   0xde584456
+    .word   0x1165f9ea
+    .word   0x985121ea
+    .word   0x5253a2ba
+    .word   0x66a97db0
+    .word   0xe3a463e3
+    .word   0x182c9f88
+
+
+    .word   0x1054ad8d
+    .word   0x8aad1425
+    .word   0x33aa8917
+    .word   0xafc39cb0
+    .word   0xfa8547e1
+    .word   0x67ee1086
+    .word   0xa672c697
+    .word   0x6c4afa9f
+
+
+    .word   0x4585a86f
+    .word   0x876cc895
+    .word   0xb339d368
+    .word   0x72173e22
+    .word   0x3a69e870
+    .word   0x72e5a26d
+    .word   0xb9c6c86d
+    .word   0xa5b93372
+
+
+    .word   0xdc2858c8
+    .word   0xedf00f54
+    .word   0x66b5e346
+    .word   0x87b8ba24
+    .word   0x6096b303
+    .word   0x3d529211
+    .word   0x6837a45c
+    .word   0x5f76f965
+
+
+    .word   0x353d77c5
+    .word   0x360e153d
+    .word   0x606d0480
+    .word   0x242855c4
+    .word   0x887747d9
+    .word   0x50242d9e
+    .word   0xd9714e6f
+    .word   0xfc23252c
+
+
+    .word   0xd1f4ab4f
+    .word   0xf739f24a
+    .word   0x74b301e5
+    .word   0x8b1809fd
+    .word   0x82cbef6d
+    .word   0xfdd7ae2
+    .word   0xfd9dcfb5
+    .word   0xc347972b
+
+
+    .word   0x8810e224
+    .word   0xc66599f7
+    .word   0xfb7c5e2d
+    .word   0xa15d309e
+    .word   0x3f5b40ef
+    .word   0x9b658853
+    .word   0x5dce8e43
+    .word   0x8218be15
+
+
+    .word   0xf44de7db
+    .word   0x99956b27
+    .word   0xa7d515ee
+    .word   0x9099ccfb
+    .word   0xfaa765b2
+    .word   0x51c14abb
+    .word   0x36c6b4d5
+    .word   0x5d28ca3c
+
+
+    .word   0xf6c065ab
+    .word   0x700a758c
+    .word   0xb3fe64f5
+    .word   0x2e207620
+    .word   0xbe4b707b
+    .word   0xb0f61d5c
+    .word   0x4605c8b6
+    .word   0x3d97faab
+
+
+    .word   0x770eb664
+    .word   0x108d3e9e
+    .word   0x76afda25
+    .word   0xf8dd551d
+    .word   0x1b9514fb
+    .word   0x86024fb4
+    .word   0x83dcffad
+    .word   0xacb72b0e
+
+
+    .word   0x62703114
+    .word   0x2c2d3492
+    .word   0x5bddcd68
+    .word   0x42ea99cf
+    .word   0x870b1cd
+    .word   0x694ad3d3
+    .word   0xee6c389f
+    .word   0xd8682f76
+
+
+    .word   0xd7f8c656
+    .word   0xb2ed923
+    .word   0x46c1938f
+    .word   0x925849ac
+    .word   0xc577b0d7
+    .word   0xf1a5174d
+    .word   0xa99df804
+    .word   0x5a6b7d1e
+
+
+    .word   0x92f4c8f0
+    .word   0xe5e5ff25
+    .word   0x1933bd1b
+    .word   0xb7af6df5
+    .word   0xfb86e885
+    .word   0x7c5af194
+    .word   0xf5faa57a
+    .word   0x40077a12
+
+
+    .word   0x443e2e1b
+    .word   0x94e31cc9
+    .word   0x2e8053ac
+    .word   0x53474633
+    .word   0x358d4d64
+    .word   0xb4d59a1e
+    .word   0x1f3f7f40
+    .word   0xf0af1aed
+
+
+    .word   0xeb45eb3
+    .word   0x7dd86ca2
+    .word   0xd24f6dd9
+    .word   0x5df372f5
+    .word   0xb6a3f2f1
+    .word   0x4871a986
+    .word   0xbd1abd48
+    .word   0xe0ae430a
+
+
+    .word   0xbb5b43e
+    .word   0xd281acef
+    .word   0xd1bb6f07
+    .word   0x31159a40
+    .word   0x59ed2d34
+    .word   0x1a10990d
+    .word   0x146cce55
+    .word   0xb7e99fd7
+
+
+    .word   0x470ad956
+    .word   0x143cb505
+    .word   0x1c7992a3
+    .word   0x6095fae5
+    .word   0xb9064e77
+    .word   0xaee1a9b8
+    .word   0xf9f9cfda
+    .word   0xd4ce9162
+
+
+    .word   0x3ef76651
+    .word   0x7aac5f88
+    .word   0x3dac8c98
+    .word   0xda021b1a
+    .word   0x8c13a2aa
+    .word   0x33e79fc7
+    .word   0x8381f6
+    .word   0x91adbab8
+
+
+    .word   0xff4e051a
+    .word   0x95894062
+    .word   0x7aa65449
+    .word   0x1096dbee
+    .word   0xdfe95368
+    .word   0xf0bd3d90
+    .word   0x9a7a206b
+    .word   0x60999447
+
+
+    .word   0xe124415e
+    .word   0x6ee33ed2
+    .word   0xc138b041
+    .word   0x39e2861d
+    .word   0x2a9fa5fc
+    .word   0x344f8175
+    .word   0xd15ae7ae
+    .word   0x9a261209
+
+
+    .word   0x70c5c977
+    .word   0x53c5b101
+    .word   0x74661abb
+    .word   0xe7900bbe
+    .word   0x701e2e72
+    .word   0xa2c416f5
+    .word   0xda798bd9
+    .word   0x10c12e57
+
+
+    .word   0x2a41b70c
+    .word   0x2e12ac49
+    .word   0x52876047
+    .word   0xb31e6963
+    .word   0xa95c0250
+    .word   0x404ec8dc
+    .word   0x3da87cd7
+    .word   0x7d683e3d
+
+
+    .word   0x914e6a90
+    .word   0x5d8d3a99
+    .word   0xc5c767fd
+    .word   0xcf5d345e
+    .word   0x95fdb9b5
+    .word   0x184dd157
+    .word   0xf816de67
+    .word   0x3856b784
+
+
+    .word   0xb080a4c9
+    .word   0x346da0a1
+    .word   0xbcbeb686
+    .word   0x3e756822
+    .word   0xb6eee15a
+    .word   0x8f2f7c36
+    .word   0xb141eb37
+    .word   0x7e4697e5
+
+
+    .word   0xd3dfc409
+    .word   0x146b7e0
+    .word   0x74fab1e9
+    .word   0x669537eb
+    .word   0xd2aaae60
+    .word   0xb8524515
+    .word   0xe44c2448
+    .word   0x3f4451d1
+
+
+    .word   0x374a3079
+    .word   0x4d3275ce
+    .word   0x1f230128
+    .word   0xb0f3e7b1
+    .word   0x19ffc584
+    .word   0x270fc41d
+    .word   0xca5bfb85
+    .word   0x2e8f79b0
+
+
+    .word   0x2fdc6d9c
+    .word   0x1e36d63f
+    .word   0x9b71b3ad
+    .word   0x8ce9dae7
+    .word   0x80dc1995
+    .word   0xbf92a20f
+    .word   0xc8a0fb7f
+    .word   0xfde5819b
+
+
+    .word   0x7b6c4b75
+    .word   0xf08a14a9
+    .word   0x2c0f04e3
+    .word   0xcd0b174a
+    .word   0x67ecc31a
+    .word   0x3eabb807
+    .word   0x1e3ae98b
+    .word   0xdfb21ea5
+
+
+    .word   0x271bd688
+    .word   0xca0511c1
+    .word   0x2445ee3f
+    .word   0x91f58549
+    .word   0xf915019d
+    .word   0x93329fb7
+    .word   0x305f253a
+    .word   0xe4053331
+
+
+    .word   0xfa90ba2b
+    .word   0x6c9a169f
+    .word   0xca47f50e
+    .word   0x6aab9162
+    .word   0x37cd0013
+    .word   0x4fb2a279
+    .word   0x65ec5681
+    .word   0x56514325
+
+
+    .word   0x9737affd
+    .word   0x5281575e
+    .word   0xc034e7f
+    .word   0x85571134
+    .word   0x5f60fed2
+    .word   0xd1916f7e
+    .word   0x21fec00c
+    .word   0x311c5bf9
+
+
+    .word   0x353e0429
+    .word   0xad43b179
+    .word   0x17869e6b
+    .word   0xf9eecc20
+    .word   0xb1440409
+    .word   0xd73e05c0
+    .word   0xb759b595
+    .word   0xdb8290a2
+
+
+    .word   0x73636885
+    .word   0xd3cb8b73
+    .word   0x39e81b3d
+    .word   0xf7387696
+    .word   0x71ee8fc3
+    .word   0x2bd3fe37
+    .word   0xa19600aa
+    .word   0xd570f3f4
+
+
+    .word   0x5bceb7fe
+    .word   0xd1693800
+    .word   0x4d7d004f
+    .word   0x347ccd14
+    .word   0xfc78bb64
+    .word   0xa36a6908
+    .word   0x9462a92a
+    .word   0x4cf0f14c
+
+
+    .word   0x8caf4d00
+    .word   0x15a02d81
+    .word   0x31e64084
+    .word   0x52307b53
+    .word   0x9c814609
+    .word   0x8c5474b9
+    .word   0xe6a01f51
+    .word   0xdd76ff9f
+
+
+    .word   0x17a9c01f
+    .word   0x748ea7d7
+    .word   0x29fa173a
+    .word   0xd0e51eb5
+    .word   0x21d4ed83
+    .word   0x330a72b6
+    .word   0xa5229b12
+    .word   0x8f3526e0
+
+
+    .word   0x2eb86422
+    .word   0x46bc608
+    .word   0xf1a06a17
+    .word   0x74636d22
+    .word   0x7005875a
+    .word   0xe4e23c4
+    .word   0xde0a79fa
+    .word   0x2004a6dc
+
+
+    .word   0xb355aaaf
+    .word   0x36b45247
+    .word   0x45041b58
+    .word   0xbb9c9d03
+    .word   0xcd177fd6
+    .word   0x90bb667f
+    .word   0x2d47a7b4
+    .word   0x96cbf26e
+
+
+    .word   0xb80d3fb4
+    .word   0x719183f2
+    .word   0xd808ed8d
+    .word   0x4f2e8ddd
+    .word   0xf9748c9f
+    .word   0xef82ea8a
+    .word   0xf44b618a
+    .word   0x9fd190d9
+
+
+    .word   0xa120e7ba
+    .word   0xaa2a116
+    .word   0xf60513c
+    .word   0x7d761e3c
+    .word   0x392d76e7
+    .word   0x6fb02f80
+    .word   0x242ef70
+    .word   0x64b17871
+
+
+    .word   0xd5a61c7f
+    .word   0x5c27fa94
+    .word   0xd4f669a7
+    .word   0x20475ad7
+    .word   0x770eb070
+    .word   0x135d6b7e
+    .word   0x81b60232
+    .word   0x23956b38
+
+
+    .word   0x3eb87c10
+    .word   0x86aaa298
+    .word   0x892bb812
+    .word   0x78a4031e
+    .word   0x91e45dba
+    .word   0xa84ca1db
+    .word   0xf1b916d2
+    .word   0x2685f89a
+
+
+    .word   0x41b46989
+    .word   0x9c516012
+    .word   0x6ad44494
+    .word   0xb964252d
+    .word   0x27e15aab
+    .word   0x874c9cc3
+    .word   0xa7fddc87
+    .word   0x1660fd1a
+
+
+    .word   0x119fbcf3
+    .word   0x3201ad6c
+    .word   0x2663427b
+    .word   0xc9b502d3
+    .word   0xd9dbf505
+    .word   0x9b901133
+    .word   0x4e430e10
+    .word   0xc680135d
+
+
+    .word   0x60863cde
+    .word   0xde050c34
+    .word   0x2526a8f3
+    .word   0xef02dad4
+    .word   0x4330ffc3
+    .word   0xba28bf5d
+    .word   0x3c0ae9dd
+    .word   0xf8f11138
+
+
+    .word   0x809e5fea
+    .word   0x8cb24e0
+    .word   0xc7818049
+    .word   0xfd7d1552
+    .word   0xcbfa840
+    .word   0x7d56ca45
+    .word   0x426cab42
+    .word   0x2c03e0ba
+
+
+    .word   0x1db106e0
+    .word   0x9221ec1f
+    .word   0xf36cd25e
+    .word   0x466d241f
+    .word   0xdbbb2eda
+    .word   0xd46521a1
+    .word   0x7300e3ae
+    .word   0x6fcf7333
+
+
+    .word   0x51490255
+    .word   0xa466c1c4
+    .word   0xf5c2c005
+    .word   0x41e78c7e
+    .word   0xa445f2c6
+    .word   0xd360027
+    .word   0xd66fc569
+    .word   0xc243dd20
+
+
+    .word   0x80beba86
+    .word   0xea9cc2c2
+    .word   0xf0618907
+    .word   0x3e596afa
+    .word   0xfa2e14f8
+    .word   0x3e32e3d8
+    .word   0xc158eefd
+    .word   0x84fadf18
+
+
+    .word   0xf3c43e0d
+    .word   0x6f6d9036
+    .word   0x2339cfa3
+    .word   0xc54f9d0e
+    .word   0xd5b1e19c
+    .word   0x5d9a6fdd
+    .word   0x5aba42
+    .word   0x8c61c869
+
+
+    .word   0xa381c784
+    .word   0xe0d58254
+    .word   0x4ae2b55d
+    .word   0x63f813b3
+    .word   0xfadfec8
+    .word   0x7c135525
+    .word   0x24b825ed
+    .word   0xc6f764e3
+
+
+    .word   0x4fa08e6
+    .word   0xa9653d9
+    .word   0x95a08eb6
+    .word   0xe953552d
+    .word   0xa10e7911
+    .word   0xf14e20f8
+    .word   0x3492d8b5
+    .word   0x2b37027f
+
+
+    .word   0xba3fc826
+    .word   0xa31269ab
+    .word   0x131eed6
+    .word   0x6c49503a
+    .word   0xe8f3a272
+    .word   0xc067b9bc
+    .word   0xab25177f
+    .word   0x581bce6d
+
+
+    .word   0xe3778aab
+    .word   0x454f43f0
+    .word   0xebd7188
+    .word   0x6255c8fb
+    .word   0x550605c8
+    .word   0xd3cee5b1
+    .word   0x84829ca2
+    .word   0xfcb78a87
+
+
+    .word   0x191f53a4
+    .word   0x67e7ccaf
+    .word   0xfcbf3acf
+    .word   0x59df58e6
+    .word   0xd065ff1d
+    .word   0xa9a74ad9
+    .word   0x15d1eb6c
+    .word   0x84c0dfc6
+
+
+    .word   0x15c54b47
+    .word   0x55021b71
+    .word   0x141db930
+    .word   0x29a1a8a0
+    .word   0x1de7709f
+    .word   0xa064acf9
+    .word   0xdfc3a59f
+    .word   0x54fab0b3
+
+
+    .word   0x5b56a175
+    .word   0x7f749c9c
+    .word   0xb8357db3
+    .word   0x210c2db6
+    .word   0x7da6c484
+    .word   0x55afda53
+    .word   0x5d11c2ce
+    .word   0x1fd51e43
+
+
+    .word   0x1720ae89
+    .word   0x71352aa5
+    .word   0xfdb07a63
+    .word   0x27c2b222
+    .word   0x8b091ece
+    .word   0xb018e45
+    .word   0xe206be51
+    .word   0x41023b8c
+
+
+    .word   0xc72991b7
+    .word   0xbb65fcbf
+    .word   0x7ab9a515
+    .word   0x8ae27e0
+    .word   0x538167de
+    .word   0xafc2ef20
+    .word   0xe6e89f3a
+    .word   0x8b490e83
+
+
+    .word   0xa1029472
+    .word   0x3fbb2bad
+    .word   0xe2091e40
+    .word   0x53b9f7cd
+    .word   0x234eb051
+    .word   0xd335ab1
+    .word   0xdfe74b50
+    .word   0xdf3f73ad
+
+
+    .word   0x64819e2
+    .word   0x89f95614
+    .word   0x967c7d03
+    .word   0xbccfd878
+    .word   0x58654e44
+    .word   0xa85bc934
+    .word   0xce48ae91
+    .word   0x487e18a4
+
+
+    .word   0x72f1f131
+    .word   0x686447ce
+    .word   0xa5ce7bff
+    .word   0xbce46410
+    .word   0x81a13fcc
+    .word   0x7bdb8ade
+    .word   0xf39979f3
+    .word   0x971391f3
+
+
+    .word   0x9b276e08
+    .word   0x3bc4f728
+    .word   0x8e676480
+    .word   0x98283138
+    .word   0x46e107da
+    .word   0x8a328792
+    .word   0x234ac76
+    .word   0x138ae76e
+
+
+    .word   0x7e7a023b
+    .word   0xe9aa17a9
+    .word   0x3b43a1b4
+    .word   0x3886b300
+    .word   0x540cfd31
+    .word   0x5ffe658e
+    .word   0xb5992301
+    .word   0x1e799660
+
+
+    .word   0xbbdec1eb
+    .word   0x1ace7963
+    .word   0x8741e710
+    .word   0xc169ccde
+    .word   0xb91f92de
+    .word   0x4c2e7979
+    .word   0xb241e9dd
+    .word   0x40f2f05b
+
+
+    .word   0x136b2c77
+    .word   0x6cc2a02b
+    .word   0x6a611cb6
+    .word   0xcb5ed3f3
+    .word   0x4dedcb6f
+    .word   0xed092db5
+    .word   0xa1921039
+    .word   0xfa7e49bd
+
+
+    .word   0xb194d8c5
+    .word   0x2c8a54e4
+    .word   0xc7f11776
+    .word   0xd1dfa3e8
+    .word   0xc07fecbf
+    .word   0xe65faf87
+    .word   0x9baf75e3
+    .word   0xf12cb0e2
+
+
+    .word   0xf8d468b
+    .word   0xf2cf450b
+    .word   0x956d632e
+    .word   0xc4654b11
+    .word   0xfce0a454
+    .word   0x16824c6b
+    .word   0x39e770a
+    .word   0xa9d6f928
+
+
+    .word   0xb99e9970
+    .word   0x7ae5637f
+    .word   0x7094b29b
+    .word   0xa0405f55
+    .word   0x833d59ea
+    .word   0x2500baf1
+    .word   0x41150838
+    .word   0xc3c03f98
+
+
+    .word   0x8438a47a
+    .word   0xe2b692ec
+    .word   0x83795899
+    .word   0xa605d659
+    .word   0x86534de4
+    .word   0x83077140
+    .word   0xba776876
+    .word   0x2cc80a5b
+
+
+    .word   0x71435fa5
+    .word   0xcb41b8d2
+    .word   0x4846061b
+    .word   0xe823b481
+    .word   0xaeea7fd8
+    .word   0xcb79628d
+    .word   0x2dd3bea
+    .word   0x146cce55
+
+
+    .word   0xc1cbe099
+    .word   0x50567d31
+    .word   0xb0f61d5c
+    .word   0xa5a29ae4
+    .word   0x72e5a26d
+    .word   0xba2851fd
+    .word   0xdd94e33e
+    .word   0x269d06b0
+
+
+    .word   0xc6136732
+    .word   0xc83b24f8
+    .word   0x385e6ca4
+    .word   0x11026c0a
+    .word   0xcedf2ad7
+    .word   0x4af07d4d
+    .word   0x2582d15a
+    .word   0x336b261c
+
+
+    .word   0xe5c5d228
+    .word   0x28c771af
+    .word   0xb2353a45
+    .word   0x99cdeb1d
+    .word   0xfae9d02f
+    .word   0xf8a339f5
+    .word   0x655bd054
+    .word   0xce5c30a0
+
+
+    .word   0x99e341fc
+    .word   0xfa8547e1
+    .word   0x3c97808
+    .word   0x7de3cee9
+    .word   0x2b72c9fe
+    .word   0x8d9fa242
+    .word   0xe1c3b22c
+    .word   0xa44db433
+
+
+    .word   0xfd0f8455
+    .word   0xcfcf12dc
+    .word   0x259b42b
+    .word   0xba728b4d
+    .word   0xb08fcc1a
+    .word   0xdcc80697
+    .word   0xa04ce5bc
+    .word   0x4eb969f0
+
+
+    .word   0x1096dbee
+    .word   0x470ad956
+    .word   0x9390e126
+    .word   0xd0451f7d
+    .word   0xd08dc050
+    .word   0xd052389c
+    .word   0x250979b
+    .word   0x9e0c81be
+
+
+    .word   0xad399009
+    .word   0x786669e6
+    .word   0x91763d30
+    .word   0xda8c248c
+    .word   0x8718a9e9
+    .word   0x12477f0a
+    .word   0x470d2cc2
+    .word   0x736d70cf
+
+
+    .word   0x38c41947
+    .word   0x246aa4cc
+    .word   0xcef51c51
+    .word   0x5717229a
+    .word   0xc94a3617
+    .word   0x27ee0f37
+    .word   0x93c72b8d
+    .word   0x1825aa33
+
+
+    .word   0x2fba61f6
+    .word   0x88eba061
+    .word   0x9e3e9d12
+    .word   0xf6f51473
+    .word   0xf678ef47
+    .word   0xa860781d
+    .word   0xf39634bb
+    .word   0x9f050f1
+
+
+    .word   0xb5b18cd5
+    .word   0x672f012d
+    .word   0x7f4b5a22
+    .word   0xca4a743f
+    .word   0xb94e7964
+    .word   0xa09efb89
+    .word   0xf1ac1032
+    .word   0x80af2406
+
+
+    .word   0x7c9fdfae
+    .word   0x882ca6f3
+    .word   0x98db89c4
+    .word   0xf0391e38
+    .word   0xca61e389
+    .word   0x5eedee09
+    .word   0x4387c9fc
+    .word   0x3b050644
+
+
+    .word   0x2fcda15f
+    .word   0x54b2864
+    .word   0x10a21da8
+    .word   0x6de8e703
+    .word   0x574c811c
+    .word   0x4a001c7f
+    .word   0x25023ec6
+    .word   0xe45c983c
+
+
+    .word   0xb0190809
+    .word   0x86b81805
+    .word   0xc9ee2a21
+    .word   0xe7df0f39
+    .word   0x89395a90
+    .word   0x316c37e0
+    .word   0x614d0cb8
+    .word   0xa15e6a7c
+
+
+    .word   0xc124ecda
+    .word   0x92ce77dc
+    .word   0x2f3af71
+    .word   0x15bbd3c2
+    .word   0xefec6b1b
+    .word   0x4960dda5
+    .word   0x9f516d57
+    .word   0x14245a4a
+
+
+    .word   0xd345daaa
+    .word   0x31af4d7e
+    .word   0x76b46dfb
+    .word   0xf33601be
+    .word   0x84b4bd0e
+    .word   0xbf7d1442
+    .word   0x5afe7ffe
+    .word   0xa01b90fb
+
+
+    .word   0x571b536
+    .word   0x29f225a0
+    .word   0xa99c7674
+    .word   0x80744d3c
+    .word   0x5e5d2e5e
+    .word   0x8490c34f
+    .word   0x40853fe
+    .word   0xe24f1bcf
+
+
+    .word   0xd3c3a285
+    .word   0x221e01e1
+    .word   0xf11e32ab
+    .word   0xf015b750
+    .word   0x8e46b97c
+    .word   0x52876047
+    .word   0x3589f76e
+    .word   0xe8b46e82
+
+
+    .word   0x35b447f7
+    .word   0xdd3dbfe5
+    .word   0xd5f64ebd
+    .word   0x932fad37
+    .word   0x8c52beb0
+    .word   0x84905aad
+    .word   0xc96b6078
+    .word   0x9018b1da
+
+
+    .word   0x73fda2b2
+    .word   0xb2e6d700
+    .word   0xd4994fe2
+    .word   0x82a30c37
+    .word   0x5d7c4bb
+    .word   0x745a5c64
+    .word   0x895d5fa8
+    .word   0x3321042d
+
+
+    .word   0x61f73f46
+    .word   0x262a6fa4
+    .word   0x24a5ad09
+    .word   0x92e55538
+    .word   0x9554a1f7
+    .word   0x173c2918
+    .word   0xfb37aabf
+    .word   0x1315dde
+
+
+    .word   0x987dce1f
+    .word   0x36e515b6
+    .word   0x3fec4b66
+    .word   0xfb33e4db
+    .word   0x50fa0dc
+    .word   0x962c0fd2
+    .word   0x7dd86ca2
+    .word   0x51ca45d5
+
+
+    .word   0x8608b978
+    .word   0x6ef07d4d
+    .word   0x565c0753
+    .word   0xd7ce584f
+    .word   0x61d28a52
+    .word   0xfff78662
+    .word   0x144ebde
+    .word   0xc6c14e7b
+
+
+    .word   0x55fcb9f3
+    .word   0xdc0fc5b2
+    .word   0x2b04ad13
+    .word   0x3446e5d7
+    .word   0x7a7f7eae
+    .word   0xef13b071
+    .word   0x396479fb
+    .word   0x76c28fff
+
+
+    .word   0x9af38804
+    .word   0x283df006
+    .word   0x2724ccd5
+    .word   0x77030cc1
+    .word   0x459ea8c
+    .word   0x67579049
+    .word   0x20fba945
+    .word   0xfb634c49
+
+
+    .word   0x8df537c0
+    .word   0x63c8bd2e
+    .word   0xa3550a15
+    .word   0x34998b00
+    .word   0xfe51db98
+    .word   0xccbee5ca
+    .word   0x66e198ed
+    .word   0x473486ce
+
+
+    .word   0xbf39c084
+    .word   0x26275113
+    .word   0x2371fe4a
+    .word   0xf97a56e7
+    .word   0x8ce9dae7
+    .word   0x23a4ebf2
+    .word   0x25423743
+    .word   0xb3edfbb3
+
+
+    .word   0x7f2905e3
+    .word   0x65d37adc
+    .word   0x513a4985
+    .word   0xb7f8ec31
+    .word   0x27c09718
+    .word   0x1ca49b24
+    .word   0x6600594a
+    .word   0xd3dfc409
+
+
+    .word   0xa888c
+    .word   0x9e088762
+    .word   0xf033aeca
+    .word   0x81caf351
+    .word   0x18252dd4
+    .word   0x442871a2
+    .word   0xdd76ff9f
+    .word   0xf01999f0
+
+
+    .word   0x5f79af82
+    .word   0x7d75db18
+    .word   0x2249a56a
+    .word   0xf9f9cfda
+    .word   0x367b6e05
+    .word   0x6e7abb15
+    .word   0x7fd2aa5c
+    .word   0x2b45292a
+
+
+    .word   0xcbf639a9
+    .word   0xc51bd2b9
+    .word   0x30ffb0e8
+    .word   0x9fd1b68b
+    .word   0x3a9d6d40
+    .word   0x95805179
+    .word   0x399808c2
+    .word   0x407a2996
+
+
+    .word   0x79f8443b
+    .word   0xba4e8eb1
+    .word   0x94787cc2
+    .word   0xa88e8277
+    .word   0x32eb7cf7
+    .word   0x413ee55b
+    .word   0x54522820
+    .word   0x45b1661e
+
+
+    .word   0xbc014360
+    .word   0x426cab42
+    .word   0xffe92711
+    .word   0xfa5762c8
+    .word   0xebe51f46
+    .word   0xa23736c1
+    .word   0x2a6a7558
+    .word   0x38de5560
+
+
+    .word   0xbdf98426
+    .word   0x33f9ebce
+    .word   0xe7b79bd8
+    .word   0xe6f3c18
+    .word   0xe427f91a
+    .word   0x559149ba
+    .word   0x5d3b3ed2
+    .word   0x6568cf9c
+
+
+    .word   0x6ed83c03
+    .word   0xacb3c21
+    .word   0xcb22693
+    .word   0x4f94a414
+    .word   0x2979d757
+    .word   0x99b87ad4
+    .word   0x2da167f4
+    .word   0xd9dbf505
+
+
+    .word   0x26e1d1f0
+    .word   0x429794ea
+    .word   0xea2cf992
+    .word   0xb4507108
+    .word   0x4fe1f547
+    .word   0x4a1ac406
+    .word   0x5dce8c60
+    .word   0x9c39fbb4
+
+
+    .word   0xa466c1c4
+    .word   0xfd83b05
+    .word   0x6fca167e
+    .word   0x4b1ee489
+    .word   0xe551d3d2
+    .word   0x3c39b4f8
+    .word   0x8eb0f011
+    .word   0x3be9896a
+
+
+    .word   0x8538ac91
+    .word   0x5a4f7a54
+    .word   0x3413f4c5
+    .word   0xedc45af9
+    .word   0x3902d1b4
+    .word   0x6e055caa
+    .word   0x5bea2d2c
+    .word   0xb3cc5ac3
+
+
+    .word   0x3f28518b
+    .word   0xba744b6f
+    .word   0xff1b7539
+    .word   0xe3c0bdf3
+    .word   0xc82b24bb
+    .word   0xd2442aff
+    .word   0x6339affb
+    .word   0xe7b81210
+
+
+    .word   0x2a369b79
+    .word   0xd2b3c087
+    .word   0x5dc341c6
+    .word   0xf592211b
+    .word   0xf0e94f64
+    .word   0xe65af17
+    .word   0xbca951e9
+    .word   0x4e195ba7
+
+
+    .word   0xdd15d07
+    .word   0x90d370c1
+    .word   0x27a6ee4c
+    .word   0x3ec71492
+    .word   0x67bcc3b3
+    .word   0xab7cdda2
+    .word   0x996a624b
+    .word   0x822dec53
+
+
+    .word   0x367632d9
+    .word   0x3cf3a4
+    .word   0x21f4e4e4
+    .word   0xfff73d67
+    .word   0x43f2bb79
+    .word   0x6b2145df
+    .word   0x107441d8
+    .word   0xf13af67d
+
+
+    .word   0xa49ffd2
+    .word   0xc87ba7ba
+    .word   0xe9e9d2d3
+    .word   0x864bbaa2
+    .word   0xc70f6381
+    .word   0xd990f012
+    .word   0x804f7ced
+    .word   0xc888383d
+
+
+    .word   0x8a6999d7
+    .word   0x668e6728
+    .word   0x678731d
+    .word   0x7fce8861
+    .word   0x98d4172b
+    .word   0x2a6d3a75
+    .word   0x82c7d661
+    .word   0xf36cd25e
+
+
+    .word   0xc287a2d6
+    .word   0x696dd016
+    .word   0xd0e51eb5
+    .word   0x9e5de09
+    .word   0xa2f7737e
+    .word   0xd5da30bf
+    .word   0x72ce77a5
+    .word   0xf411c388
+
+
+    .word   0xfd8573e2
+    .word   0x67a36dfd
+    .word   0x66832856
+    .word   0xd3ab10a6
+    .word   0x15fb9004
+    .word   0x84764a0d
+    .word   0x35c57948
+    .word   0x66c59ad6
+
+
+    .word   0x4ffb5abc
+    .word   0xb2348739
+    .word   0x9f87cc4c
+    .word   0xf54ba5e9
+    .word   0xb62c4ff6
+    .word   0x1a4f73db
+    .word   0x8aaaa464
+    .word   0xb3b0c30e
+
+
+    .word   0xde3e5491
+    .word   0xebd7f35e
+    .word   0x668c6831
+    .word   0xd9e8e1f9
+    .word   0x1d9d2d56
+    .word   0x7194ea2f
+    .word   0xea7284
+    .word   0xa763fd34
+
+
+    .word   0x3a27ead2
+    .word   0x62a37ab3
+    .word   0x7e35213e
+    .word   0x5b25360d
+    .word   0xcb8a39c4
+    .word   0x8938fdfc
+    .word   0xe21f0b8a
+    .word   0xedb61954
+
+
+    .word   0x387220e
+    .word   0xf794be58
+    .word   0xa7a88fbe
+    .word   0xfedfcdb2
+    .word   0xe175af63
+    .word   0xf1878938
+    .word   0x9ac98ea8
+    .word   0x43b6fe1b
+
+
+    .word   0xfdc86196
+    .word   0x1ab3ccab
+    .word   0xbe030a0b
+    .word   0x41306ea5
+    .word   0xdfcfff93
+    .word   0xde0a79fa
+    .word   0xd77e3a6b
+    .word   0xa3ad60c9
+
+
+    .word   0x4e3664f0
+    .word   0x876cc895
+    .word   0xd77832eb
+    .word   0x2e0761e
+    .word   0xe0d58254
+    .word   0xdbbb2eda
+    .word   0xc29ec354
+    .word   0xd00b0e44
+
+
+    .word   0xae5e3b65
+    .word   0x944315ee
+    .word   0x7fc367a4
+    .word   0x3fe08986
+    .word   0xad84403e
+    .word   0x994b657a
+    .word   0x421c434
+    .word   0x1ad2b1c3
+
+
+    .word   0x801c851d
+    .word   0xe4e378d1
+    .word   0xad45f6f2
+    .word   0x1ccea7a
+    .word   0x14caa14d
+    .word   0x3f86fa18
+    .word   0xe4225a8c
+    .word   0x28fe8244
+
+
+    .word   0xe62199f6
+    .word   0x8e90a1af
+    .word   0x75d10c1b
+    .word   0x4a1978e3
+    .word   0xf4dc0b05
+    .word   0xc3608e1c
+    .word   0xbce6ead4
+    .word   0x8064d595
+
+
+    .word   0x40ac577f
+    .word   0xe0dcb44
+    .word   0x6056ab06
+    .word   0xd7db7535
+    .word   0xa00040be
+    .word   0x77af09e3
+    .word   0xe00e4921
+    .word   0x5889b74
+
+
+    .word   0xfbfea6b5
+    .word   0xb09fcb9d
+    .word   0x686447ce
+    .word   0x8c1013fc
+    .word   0x26671285
+    .word   0x44a5ef33
+    .word   0xc988ccc7
+    .word   0x1887e4d9
+
+
+    .word   0xe454535
+    .word   0xd7a6df1e
+    .word   0xb1e2dc65
+    .word   0xa02635eb
+    .word   0x56464a37
+    .word   0xf3c5ac19
+    .word   0x8d1602c4
+    .word   0x90476bb2
+
+
+    .word   0xdf1327cb
+    .word   0xbcfe42cb
+    .word   0xde2b49f3
+    .word   0x1aa2d996
+    .word   0x949f28bd
+    .word   0xe540e158
+    .word   0x8e04674a
+    .word   0x830d6631
+
+
+    .word   0x3f5e73ab
+    .word   0x9d025332
+    .word   0x30d767e8
+    .word   0xb53528f6
+    .word   0xca86add3
+    .word   0x18ddc058
+    .word   0x837552eb
+    .word   0x513658d
+
+
+    .word   0xd891c47c
+    .word   0x5b99af24
+    .word   0x71de207b
+    .word   0xd09624c
+    .word   0x4ea5b056
+    .word   0xdaca577a
+    .word   0xbbbfcda7
+    .word   0xd8d6a35f
+
+
+    .word   0x5e23faa7
+    .word   0xfb9f35e4
+    .word   0x30cb5ed
+    .word   0x8619f414
+    .word   0xb381c966
+    .word   0x9d5c00be
+    .word   0x2c931f04
+    .word   0x4b3703f3
+
+
+    .word   0x555ca141
+    .word   0x52f24fb2
+    .word   0x886641f8
+    .word   0xc42d0732
+    .word   0xb67c1804
+    .word   0x27acf5d3
+    .word   0xcb7c6bc3
+    .word   0x55fc5e69
+
+
+    .word   0xfa35335d
+    .word   0xd85439d8
+    .word   0xba4b8412
+    .word   0xa04ce5bc
+    .word   0x7aa65449
+    .word   0xc1cbe099
+    .word   0xbe4b707b
+    .word   0x5bbb2722
+
+
+    .word   0xff00d395
+    .word   0x5606209f
+    .word   0x88fc6345
+    .word   0x9120668a
+    .word   0x4ceea75d
+    .word   0x7b42200
+    .word   0x378d90e2
+    .word   0x2efa949c
+
+
+    .word   0xd029d113
+    .word   0x5ee28f1a
+    .word   0xe936b33b
+    .word   0x7ee54bd1
+    .word   0x937836ce
+    .word   0x71ecaf1e
+    .word   0xacdeed0e
+    .word   0x5d33cc8b
+
+
+    .word   0x4eb969f0
+    .word   0xb7e99fd7
+    .word   0xb16f92b4
+    .word   0x25178a8
+    .word   0x9857924e
+    .word   0x9bacbff4
+    .word   0x55afda53
+    .word   0x193f2d82
+
+
+    .word   0xcce8b581
+    .word   0x532cebc
+    .word   0xe406a2ed
+    .word   0x699dbe65
+    .word   0x3e430439
+    .word   0x98832b62
+    .word   0x25affb1a
+    .word   0xd1266621
+
+
+    .word   0x2880406d
+    .word   0x35773139
+    .word   0x339c17f2
+    .word   0xcfa5904c
+    .word   0x6333a1b1
+    .word   0xd4b73d18
+    .word   0xc6522991
+    .word   0xd3f24da2
+
+
+    .word   0x5cc3bd25
+    .word   0x2fa6557b
+    .word   0x72dabb56
+    .word   0x3e8d01e0
+    .word   0x62c963e8
+    .word   0x8f4462e0
+    .word   0x7a33066
+    .word   0xeea278e4
+
+
+    .word   0xb918bbde
+    .word   0xb0f61d5c
+    .word   0x3a69e870
+    .word   0x93db31f9
+    .word   0x4811e789
+    .word   0x68fba106
+    .word   0xb04a9803
+    .word   0x508e873b
+
+
+    .word   0xc339bc69
+    .word   0x9ce0d55b
+    .word   0x238a589f
+    .word   0x984765e7
+    .word   0x58a229f5
+    .word   0x2aeb298a
+    .word   0x3e384101
+    .word   0x5d11c2ce
+
+
+    .word   0x7f07b2d5
+    .word   0x4f850552
+    .word   0xefb5c105
+    .word   0x2fa59974
+    .word   0xba6423b2
+    .word   0x2d0c9c80
+    .word   0xeca9d52
+    .word   0x7f537147
+
+
+    .word   0x403ceed2
+    .word   0x6e529c51
+    .word   0x6a429177
+    .word   0x37a27425
+    .word   0x96de9058
+    .word   0x453639dd
+    .word   0x646e3f07
+    .word   0x17202411
+
+
+    .word   0x14497abc
+    .word   0xaef55ba8
+    .word   0xdc851c78
+    .word   0xd290ee4
+    .word   0x235bdad7
+    .word   0xedf42b05
+    .word   0xe7d3bae6
+    .word   0x5076c0f6
+
+
+    .word   0x1d0852f7
+    .word   0x82f5133
+    .word   0xde3feb5d
+    .word   0x8438a47a
+    .word   0xdc5152c9
+    .word   0x538d35f1
+    .word   0x64bb78d2
+    .word   0x5591d8de
+
+
+    .word   0xea13501
+    .word   0xb9e8a8f8
+    .word   0xa123aabc
+    .word   0xb4bfb957
+    .word   0xce5c30a0
+    .word   0xafc39cb0
+    .word   0x208f876d
+    .word   0x9724bc5e
+
+
+    .word   0xbd89ba25
+    .word   0x5d29c88b
+    .word   0xf8d38533
+    .word   0x4270d594
+    .word   0x692bfb5
+    .word   0x27fd0971
+    .word   0xb108c30f
+    .word   0x423957f5
+
+
+    .word   0xb91699fd
+    .word   0xd586a169
+    .word   0x9796414b
+    .word   0x99ab5905
+    .word   0xa4843110
+    .word   0x77af5623
+    .word   0xedbf229a
+    .word   0xa03c2dd6
+
+
+    .word   0x69911b72
+    .word   0x64c1e794
+    .word   0x93da6c30
+    .word   0x45ad7c95
+    .word   0xf46a3a22
+    .word   0x25b36bd8
+    .word   0x8f2970be
+    .word   0x54707fe8
+
+
+    .word   0x76bc876b
+    .word   0xd40e7730
+    .word   0x112cd6b
+    .word   0x19c685d5
+    .word   0xb86a263a
+    .word   0x93d8d390
+    .word   0x76b708ec
+    .word   0xe5596bdc
+
+
+    .word   0xd9d770b9
+    .word   0x4fb2a279
+    .word   0x513e7556
+    .word   0x42124d01
+    .word   0xcbc47b4f
+    .word   0x7c937cef
+    .word   0x5f75c95f
+    .word   0x727098d
+
+
+    .word   0x30b0ac50
+    .word   0xa458cf57
+    .word   0x3a33a7a5
+    .word   0xa596b410
+    .word   0x940f05b8
+    .word   0x21ba9a5a
+    .word   0x85d401cd
+    .word   0x7bd4273b
+
+
+    .word   0xea9c0a81
+    .word   0x62e17a19
+    .word   0x43e8a0d8
+    .word   0x9bdd90c5
+    .word   0xf233e93e
+    .word   0xabab83c5
+    .word   0xf015b750
+    .word   0x2e12ac49
+
+
+    .word   0xca25544a
+    .word   0x261b4200
+    .word   0xa97dde08
+    .word   0xa4d84441
+    .word   0xc261ea8b
+    .word   0x6a2dcbcf
+    .word   0xa21a1ea7
+    .word   0xa3b46501
+
+
+    .word   0x23c6bf46
+    .word   0xe6bf48b6
+    .word   0xa7ea1894
+    .word   0x968d1d32
+    .word   0xfdde1cf1
+    .word   0x1b83ea8
+    .word   0x4e918e12
+    .word   0x7b36acdf
+
+
+    .word   0x7f2cd61b
+    .word   0xdb0b8f43
+    .word   0x26db37c8
+    .word   0x381f670
+    .word   0x98c7ed7f
+    .word   0x11739f84
+    .word   0xc28f37ca
+    .word   0x2a4c63fd
+
+
+    .word   0xbdd90533
+    .word   0xaff1292
+    .word   0xd423a7d5
+    .word   0xa432dca
+    .word   0x82e83957
+    .word   0x199732b2
+    .word   0xb5ca49da
+    .word   0x8502b276
+
+
+    .word   0xd7a4f5e1
+    .word   0x41542ed7
+    .word   0x6ae0b8bb
+    .word   0xea5f7e7d
+    .word   0xb3c3507b
+    .word   0x58b01c72
+    .word   0x326d6e9
+    .word   0x4f6ec169
+
+
+    .word   0xebcb63b8
+    .word   0x7c5af194
+    .word   0x736d70cf
+    .word   0x5c194759
+    .word   0x65b87928
+    .word   0xfcf34b86
+    .word   0xc4e23db6
+    .word   0x39edf29f
+
+
+    .word   0xdf1a9430
+    .word   0xaa38dae
+    .word   0xad40c87d
+    .word   0x6bd8ee1e
+    .word   0xc02afc2e
+    .word   0xf64e5f94
+    .word   0xd39ccf66
+    .word   0xf6b9732f
+
+
+    .word   0xaf11e1ec
+    .word   0x8d0f3255
+    .word   0x9e7c5f4c
+    .word   0xbe6c9774
+    .word   0xb7b5333c
+    .word   0xf8d87fc2
+    .word   0xf69988c8
+    .word   0xef53ae97
+
+
+    .word   0x10b25edc
+    .word   0xd479c69a
+    .word   0x6ef504d9
+    .word   0x18252dd4
+    .word   0xe6a01f51
+    .word   0x2a8888c
+    .word   0x9da11c
+    .word   0x876024c4
+
+
+    .word   0x62b833e4
+    .word   0x250979b
+    .word   0x2dbe1ff9
+    .word   0x80265ce5
+    .word   0x350c8a4b
+    .word   0x19cec05d
+    .word   0x46834416
+    .word   0x6b3aa7e9
+
+
+    .word   0xcb911d8f
+    .word   0x61d4c95a
+    .word   0xde17e440
+    .word   0xac30eb1a
+    .word   0x638031ad
+    .word   0x5dce8c60
+    .word   0x51490255
+    .word   0x9235fbc4
+
+
+    .word   0x44d5e66e
+    .word   0x3f660727
+    .word   0xa9c5b336
+    .word   0x7263f263
+    .word   0xf7f94d71
+    .word   0xfb14b932
+    .word   0xcefddd76
+    .word   0x5ef28258
+
+
+    .word   0x99b87ad4
+    .word   0xc9b502d3
+    .word   0x47f71839
+    .word   0x2371fe4a
+    .word   0x9b71b3ad
+    .word   0x869808be
+    .word   0xd643839c
+    .word   0xe080e857
+
+
+    .word   0x88eab3d
+    .word   0xe094bbc2
+    .word   0xa302ffb2
+    .word   0x3a3d081
+    .word   0xbd9ba569
+    .word   0xa36a6908
+    .word   0xbafa6cac
+    .word   0xaca330a4
+
+
+    .word   0xe307b67d
+    .word   0x37185941
+    .word   0xfe2d096f
+    .word   0x59443d63
+    .word   0x81b48b02
+    .word   0x9d8dc33a
+    .word   0x497bd50b
+    .word   0x65c9fea5
+
+
+    .word   0x2ea58f09
+    .word   0x50fa0dc
+    .word   0xeb45eb3
+    .word   0x10ed85df
+    .word   0x18942037
+    .word   0xae4fda56
+    .word   0xea9624ee
+    .word   0x2e15f8b0
+
+
+    .word   0x58861720
+    .word   0x21d34008
+    .word   0xad0a4ae3
+    .word   0x6211e025
+    .word   0xe5ec7191
+    .word   0x9b658853
+    .word   0x69ccaa34
+    .word   0xd32eee4e
+
+
+    .word   0x184b0bbb
+    .word   0xb408b85
+    .word   0x607fb6e3
+    .word   0x4ef53098
+    .word   0x1ca49b24
+    .word   0x7e4697e5
+    .word   0x7115d88e
+    .word   0x18f99658
+
+
+    .word   0xf2d2ce4a
+    .word   0x407b4962
+    .word   0xab4acce3
+    .word   0xf04ca1b
+    .word   0x6fb3368e
+    .word   0x9a0cbbe5
+    .word   0x134a5643
+    .word   0x99be5ea9
+
+
+    .word   0x33983b94
+    .word   0x32094d7e
+    .word   0x52fe18d3
+    .word   0x2cfc0abe
+    .word   0xde57e698
+    .word   0x7f059ac5
+    .word   0x2cc205a4
+    .word   0x6ad86968
+
+
+    .word   0xbd05bb52
+    .word   0x7416e2ac
+    .word   0xd83f6c15
+    .word   0xa2abe6ff
+    .word   0x4f9f7a97
+    .word   0xfc4ff1ef
+    .word   0x3150a707
+    .word   0x2cfb2d19
+
+
+    .word   0x88195858
+    .word   0x2be362d5
+    .word   0x9f573279
+    .word   0x763de10e
+    .word   0xd68b2196
+    .word   0x3789e289
+    .word   0xc9097b9b
+    .word   0x1004f38
+
+
+    .word   0x32ab843d
+    .word   0x759a1781
+    .word   0x14659adc
+    .word   0xff53ad24
+    .word   0xaa016454
+    .word   0x22a1c9c0
+    .word   0x20e9df27
+    .word   0xf0b189eb
+
+
+    .word   0x3f07d37c
+    .word   0xe08b27a5
+    .word   0xc4a02fd9
+    .word   0xa5cd20ab
+    .word   0xb153029f
+    .word   0x810e65bb
+    .word   0xa2009533
+    .word   0x522e7174
+
+
+    .word   0xcf3794f7
+    .word   0x66ef9897
+    .word   0x67ec7ff6
+    .word   0x54c69c88
+    .word   0x4ca32bb1
+    .word   0x2fbd454
+    .word   0x8906e07
+    .word   0x3268e37e
+
+
+    .word   0x7cd7ea89
+    .word   0x87bad3b5
+    .word   0xd71c18be
+    .word   0xb47beaf0
+    .word   0xd02246e9
+    .word   0xa4bdc44a
+    .word   0x344627e
+    .word   0xebcc8050
+
+
+    .word   0xa6af2090
+    .word   0xb77bdbb
+    .word   0x4f84040d
+    .word   0x3d145208
+    .word   0x9cadf815
+    .word   0x49f06f7d
+    .word   0xc35e4351
+    .word   0x3085d1eb
+
+
+    .word   0xb47429e1
+    .word   0x71352aa5
+    .word   0x2a6d3a75
+    .word   0x9221ec1f
+    .word   0xe661645
+    .word   0x472da718
+    .word   0x7d75db18
+    .word   0xaee1a9b8
+
+
+    .word   0xbafd47e5
+    .word   0x753076ef
+    .word   0x991a423f
+    .word   0xbfac50fc
+    .word   0x572e65d4
+    .word   0x71e61698
+    .word   0xe7943bd6
+    .word   0x7d88b9e4
+
+
+    .word   0x7fa6538e
+    .word   0x167c3724
+    .word   0x2c266b7b
+    .word   0xdc3b1bb6
+    .word   0xa7176b4
+    .word   0xfb565528
+    .word   0xadd1f251
+    .word   0x78e111fd
+
+
+    .word   0x600198da
+    .word   0x748ea7d7
+    .word   0x3cd1fdac
+    .word   0x25423743
+    .word   0x2416b964
+    .word   0xbdabf2ea
+    .word   0xb33a638e
+    .word   0x942b213
+
+
+    .word   0x64bc4ea2
+    .word   0x96fd5a95
+    .word   0x919919d9
+    .word   0x5121ee1b
+    .word   0x464453eb
+    .word   0xad312982
+    .word   0xbc94e80e
+    .word   0xe18865d0
+
+
+    .word   0xd64c0f57
+    .word   0x53650ee2
+    .word   0xca90bd19
+    .word   0xae4c7d08
+    .word   0x1bb41522
+    .word   0x56a7eee2
+    .word   0xcf35112c
+    .word   0x6f05fa79
+
+
+    .word   0x8ee5c2fe
+    .word   0xfefaaa3
+    .word   0x686268
+    .word   0xf5ae112d
+    .word   0x32c25c16
+    .word   0xd0090542
+    .word   0x8d56d8b3
+    .word   0x51c547af
+
+
+    .word   0xe20ecccc
+    .word   0xb4f17662
+    .word   0x6756a0cc
+    .word   0x8322bf6b
+    .word   0x16f9e91
+    .word   0x3708f212
+    .word   0xe6ceb36c
+    .word   0xe197e540
+
+
+    .word   0xc1dc2305
+    .word   0xd1658257
+    .word   0x9ee72e33
+    .word   0xf90b85cb
+    .word   0xd7223bf
+    .word   0x355e78eb
+    .word   0xdc94b663
+    .word   0x63e6341f
+
+
+    .word   0x85abfcf2
+    .word   0xf1168009
+    .word   0x428b9ae9
+    .word   0xf111707c
+    .word   0xaac394d1
+    .word   0xf7387ae1
+    .word   0xa54dccb
+    .word   0x5e07b30
+
+
+    .word   0x6b2ab49b
+    .word   0xfbfea6b5
+    .word   0x72f1f131
+    .word   0xa49b5421
+    .word   0x8949148c
+    .word   0xbc0def99
+    .word   0xb7977070
+    .word   0xaffe22e2
+
+
+    .word   0x92039c2d
+    .word   0x16341197
+    .word   0xbfe315be
+    .word   0x5edd267c
+    .word   0x48fd4b2d
+    .word   0xd77832eb
+    .word   0xa381c784
+    .word   0xc287a2d6
+
+
+    .word   0x29fa173a
+    .word   0xbf92a20f
+    .word   0xf49dc031
+    .word   0xee308ee5
+    .word   0xc3b2661f
+    .word   0x3d5ecb63
+    .word   0x99f56dbb
+    .word   0xea01a9b5
+
+
+    .word   0x55431c8a
+    .word   0x64d5532f
+    .word   0x86eb807c
+    .word   0x5ddd52a1
+    .word   0xa04bd93f
+    .word   0x4aec4efb
+    .word   0x1b1744e9
+    .word   0xf6b3ef2f
+
+
+    .word   0x91118d4b
+    .word   0xafc2ef20
+    .word   0x6221e519
+    .word   0x3809e61f
+    .word   0xa68efbdd
+    .word   0x68e491a2
+    .word   0x2236127
+    .word   0xacdeed0e
+
+
+    .word   0xa04ce5bc
+    .word   0x146cce55
+    .word   0x2e207620
+    .word   0xb34d6639
+    .word   0x2e0761e
+    .word   0x466d241f
+    .word   0x59172d85
+    .word   0x84eb06a2
+
+
+    .word   0xb9cf597e
+    .word   0x47c09f89
+    .word   0x29ed12f3
+    .word   0xb916bbe0
+    .word   0xa85f7bb7
+    .word   0x85ca930
+    .word   0x1b315dbf
+    .word   0x3918d093
+
+
+    .word   0x65fdc48
+    .word   0xa60d0cdb
+    .word   0xcb23e758
+    .word   0x4cd7164
+    .word   0x41b368e3
+    .word   0x3c98b046
+    .word   0x818ff8f2
+    .word   0xf3b17867
+
+
+    .word   0x87eea7f0
+    .word   0x3c514e9
+    .word   0x2c80ec72
+    .word   0x267b9faf
+    .word   0x9258be94
+    .word   0xd5a71af0
+    .word   0x13726024
+    .word   0x3b94b89b
+
+
+    .word   0xcee84057
+    .word   0x923933a0
+    .word   0xaf51f770
+    .word   0xcbabf44d
+    .word   0x9fbbea48
+    .word   0xb2963b81
+    .word   0xf2673a8f
+    .word   0x277f6c9c
+
+
+    .word   0x2a4c9bf3
+    .word   0x5779fded
+    .word   0xd5aa03e2
+    .word   0x87231ffd
+    .word   0xc11feb79
+    .word   0x696cb194
+    .word   0x53164dc0
+    .word   0x75fdfa43
+
+
+    .word   0x88a2f51e
+    .word   0xd2055534
+    .word   0xd3f3526d
+    .word   0xf3dba2ee
+    .word   0xba79d6b2
+    .word   0xb5b6be2
+    .word   0x36335f3e
+    .word   0x48901aa5
+
+
+    .word   0x38ffc26d
+    .word   0xaf86e46
+    .word   0x309b5aaa
+    .word   0xd93d3122
+    .word   0xf79f764c
+    .word   0xc771bbbe
+    .word   0x6d44b7d7
+    .word   0x720484fc
+
+
+    .word   0x6faa26ed
+    .word   0xb3bcd382
+    .word   0x41306ea5
+    .word   0xe4e23c4
+    .word   0x6d220c6
+    .word   0xe1e84b73
+    .word   0xcd0f8d17
+    .word   0x248fb057
+
+
+    .word   0xd64739ee
+    .word   0xe250a19
+    .word   0x43b7bea6
+    .word   0x390120a8
+    .word   0xf265977f
+    .word   0x8aaaa464
+    .word   0xd987c903
+    .word   0xe3a0c6f
+
+
+    .word   0xfe7622e5
+    .word   0xba265482
+    .word   0x7aac5f88
+    .word   0x2c4934c6
+    .word   0x51caf99c
+    .word   0xb17d2941
+    .word   0x2b707239
+    .word   0xc929d643
+
+
+    .word   0xc171f609
+    .word   0x80499e60
+    .word   0xb3b99ffb
+    .word   0x332db2b
+    .word   0xedf7b278
+    .word   0xd7839018
+    .word   0xfa1b18c1
+    .word   0xa6fe070b
+
+
+    .word   0xffa8b5dc
+    .word   0x5dd44c8c
+    .word   0xb385256
+    .word   0xc64eb669
+    .word   0xd34b4ca7
+    .word   0x50f9bb40
+    .word   0xeea278e4
+    .word   0x50567d31
+
+
+    .word   0x72173e22
+    .word   0xb018e45
+    .word   0x28838d50
+    .word   0xcbf490ab
+    .word   0x8bf9bb97
+    .word   0x828a21
+    .word   0xbcb9b5d7
+    .word   0x34390d86
+
+
+    .word   0x13480cca
+    .word   0x7f618fb7
+    .word   0x6e1f8d52
+    .word   0xa3a247f6
+    .word   0x337ce6e
+    .word   0x36dbba0
+    .word   0x7645ed4
+    .word   0x9b239ed8
+
+
+    .word   0xe8fffdfa
+    .word   0x4960dda5
+    .word   0xc1a80bfa
+    .word   0x48c941fd
+    .word   0xf5b503cc
+    .word   0x8a819740
+    .word   0x20ecc228
+    .word   0xb39c5176
+
+
+    .word   0xd67800bd
+    .word   0xa0b5f556
+    .word   0xc62f9f74
+    .word   0x40c03afc
+    .word   0xb2c78db7
+    .word   0xfc9663a4
+    .word   0xfd295f2
+    .word   0x2473afaa
+
+
+    .word   0x947e47b2
+    .word   0x19b049c3
+    .word   0x21179645
+    .word   0x6c793533
+    .word   0x2ec18c97
+    .word   0xa4e718b7
+    .word   0x67b119fb
+    .word   0x87d5c162
+
+
+    .word   0x2a81b118
+    .word   0xb804dd48
+    .word   0x66e1489e
+    .word   0xa9302a4d
+    .word   0xc2f6de56
+    .word   0xb317c8c7
+    .word   0xc39db9e6
+    .word   0xd332d1fb
+
+
+    .word   0x51b47444
+    .word   0x342c473d
+    .word   0x2e453c8e
+    .word   0x258f1b5b
+    .word   0xd9a9dd6a
+    .word   0xd46521a1
+    .word   0xb4d76e28
+    .word   0x4ae520cf
+
+
+    .word   0x26997a5d
+    .word   0xde4f0864
+    .word   0x2e8f79b0
+    .word   0xdb08a43d
+    .word   0xc51760a7
+    .word   0x9857924e
+    .word   0x7da6c484
+    .word   0xa15ed20b
+
+
+    .word   0x1a91b696
+    .word   0xaadae106
+    .word   0x8c24b27e
+    .word   0x3688a60d
+    .word   0x48c5f397
+    .word   0xe2419679
+    .word   0x667522f0
+    .word   0xa4ea8912
+
+
+    .word   0xbbc6575c
+    .word   0x77e37a1
+    .word   0x85516a61
+    .word   0x330186fe
+    .word   0xb681d0c1
+    .word   0x94af4049
+    .word   0xff8af59f
+    .word   0xa123aabc
+
+
+    .word   0x655bd054
+    .word   0x33aa8917
+    .word   0x5783a949
+    .word   0xcce95c18
+    .word   0x909722b2
+    .word   0xd35e69bf
+    .word   0x5a190af
+    .word   0xf233e93e
+
+
+    .word   0xf11e32ab
+    .word   0x2a41b70c
+    .word   0x83882d0a
+    .word   0x9660f557
+    .word   0xa42ad20b
+    .word   0xaa2b9d53
+    .word   0x1cbf096b
+    .word   0x5a40a542
+
+
+    .word   0x91c46383
+    .word   0x23bc53c7
+    .word   0x9d670e41
+    .word   0x6d51ec69
+    .word   0x82f5133
+    .word   0xc3c03f98
+    .word   0x3b4ab10d
+    .word   0xb2261625
+
+
+    .word   0xbe4ae380
+    .word   0xb8c02b98
+    .word   0x1b23d591
+    .word   0x90f18bd8
+    .word   0xf4c4bb40
+    .word   0x316c37e0
+    .word   0x2dba7bf
+    .word   0xc5811341
+
+
+    .word   0x33c16da2
+    .word   0xe3ab47e
+    .word   0xaa861400
+    .word   0x387ddf62
+    .word   0xbe52048f
+    .word   0xe94eb8ca
+    .word   0x3276975a
+    .word   0x6cc43885
+
+
+    .word   0xdd3605b
+    .word   0xcf711cdb
+    .word   0x5510028
+    .word   0x118197db
+    .word   0xdd10ce0d
+    .word   0xa734378d
+    .word   0xc288669f
+    .word   0x99f05774
+
+
+    .word   0xca732733
+    .word   0x499a1cd0
+    .word   0x49cb7467
+    .word   0xfc5ba0c5
+    .word   0xfae52111
+    .word   0xe4f03b14
+    .word   0xec6e3df6
+    .word   0x2b0e6d80
+
+
+    .word   0xd479c69a
+    .word   0x81caf351
+    .word   0x8c5474b9
+    .word   0x5c5a620a
+    .word   0xc2782979
+    .word   0xf5caf14e
+    .word   0x2aeb298a
+    .word   0x55afda53
+
+
+    .word   0x79aab4d7
+    .word   0xcefddd76
+    .word   0x2979d757
+    .word   0x2663427b
+    .word   0xa221be4e
+    .word   0xabb15993
+    .word   0x8b4f431f
+    .word   0x4605c8b6
+
+
+    .word   0xa7e73ab1
+    .word   0x19480179
+    .word   0x3645dd66
+    .word   0xa3518139
+    .word   0x9ac05ed7
+    .word   0x1ba9a973
+    .word   0x4b6c79de
+    .word   0xd853868e
+
+
+    .word   0xcaf701cb
+    .word   0xa775235a
+    .word   0xf3a4d4b2
+    .word   0x7701bee4
+    .word   0x39de2c71
+    .word   0xdd96287f
+    .word   0x5971b819
+    .word   0x66183f34
+
+
+    .word   0x73e3847
+    .word   0x9a208a37
+    .word   0x8ef86b6d
+    .word   0x23b41cae
+    .word   0xeef15740
+    .word   0xe00a47b7
+    .word   0x96385fac
+    .word   0xffd33ea4
+
+
+    .word   0x5eb03218
+    .word   0xe6c3ccde
+    .word   0x719d3c0c
+    .word   0x260f7e96
+    .word   0xdb7c52fb
+    .word   0xf178e7de
+    .word   0xacea938e
+    .word   0xf069a881
+
+
+    .word   0x90c7ff87
+    .word   0xb8a5611d
+    .word   0x81f055fe
+    .word   0xd415a16d
+    .word   0xaa4098bc
+    .word   0xeeffff0d
+    .word   0x7625ac8f
+    .word   0xbc6a4934
+
+
+    .word   0x48741fc6
+    .word   0x5176b5b8
+    .word   0x72d8c1d1
+    .word   0xdaefb857
+    .word   0x766ad316
+    .word   0x6e6dd4bf
+    .word   0x2adf4f44
+    .word   0xa249a329
+
+
+    .word   0xe2c273c8
+    .word   0x672f012d
+    .word   0xa405dbc3
+    .word   0x810b1a68
+    .word   0x176f932a
+    .word   0x46037727
+    .word   0x3fa7e1bb
+    .word   0xd4722518
+
+
+    .word   0x2886abe6
+    .word   0x20ff936
+    .word   0xe6531098
+    .word   0xd270c132
+    .word   0x3319dd7e
+    .word   0xb878be67
+    .word   0x69d1ea96
+    .word   0xdc9bee4c
+
+
+    .word   0x9377c07f
+    .word   0x561eccef
+    .word   0xc9b502d3
+    .word   0x26275113
+    .word   0x1e36d63f
+    .word   0x1c7992a3
+    .word   0xfc2a4f58
+    .word   0x39fedc26
+
+
+    .word   0xed91a956
+    .word   0x7d4a3ccf
+    .word   0x899f28ee
+    .word   0x8f303fc9
+    .word   0xbe03ba42
+    .word   0xda8a169f
+    .word   0x3e2e7e2d
+    .word   0x94ae1d57
+
+
+    .word   0x3fbe1aaa
+    .word   0xe65faf87
+    .word   0x4d183dd7
+    .word   0xeda8a0ee
+    .word   0x524c0db4
+    .word   0x18535df
+    .word   0x28f16f27
+    .word   0x933ab85e
+
+
+    .word   0xbfb6d7f1
+    .word   0x6f83a03f
+    .word   0x627775e9
+    .word   0xd9b827b4
+    .word   0x4062d3c6
+    .word   0x43f735ce
+    .word   0xb66e2ba2
+    .word   0xe6c75ca4
+
+
+    .word   0x2c0d18bf
+    .word   0xeb2dcf6e
+    .word   0x5f30e40d
+    .word   0xebcb63b8
+    .word   0x470d2cc2
+    .word   0x447d05e5
+    .word   0x6445856c
+    .word   0xd7335ba
+
+
+    .word   0x81c469a0
+    .word   0xc87ba7ba
+    .word   0xcb672776
+    .word   0x939333c4
+    .word   0x18df246
+    .word   0x25452c60
+    .word   0xdf63f264
+    .word   0xc4c95056
+
+
+    .word   0x1c8f5394
+    .word   0x3f676861
+    .word   0xe587ad73
+    .word   0x4d18316c
+    .word   0x40abb95
+    .word   0x1b5d352b
+    .word   0xa9d96071
+    .word   0x4840afaf
+
+
+    .word   0xd0488bcf
+    .word   0xf44a5c2f
+    .word   0xc73a6d79
+    .word   0x60ee021d
+    .word   0xda43f95e
+    .word   0x396d1d05
+    .word   0x6716f200
+    .word   0x90d84107
+
+
+    .word   0x6cd863a1
+    .word   0x3b9387f0
+    .word   0x5b36757f
+    .word   0x5a328507
+    .word   0xdfbe8fbf
+    .word   0xaf4681d4
+    .word   0x554d1c0c
+    .word   0x10a34f83
+
+
+    .word   0xe17436c1
+    .word   0x607fb6e3
+    .word   0x27c09718
+    .word   0xb141eb37
+    .word   0x82d3756e
+    .word   0x8df0d1e5
+    .word   0x9238a2a
+    .word   0xf2be1f89
+
+
+    .word   0x4b9f1cd1
+    .word   0xbf0a5074
+    .word   0xa31269ab
+    .word   0x6a3ac76
+    .word   0x65c9fea5
+    .word   0xfb33e4db
+    .word   0xf0af1aed
+    .word   0x5e02d317
+
+
+    .word   0xdba50806
+    .word   0xe2c2787b
+    .word   0xbfa5153d
+    .word   0x14c81558
+    .word   0xe33a3ccf
+    .word   0x6f2846e4
+    .word   0xfab6f431
+    .word   0xef3ef3ab
+
+
+    .word   0x8f9cbff7
+    .word   0xc28f37ca
+    .word   0xb9eaac86
+    .word   0x349aa7d
+    .word   0x34cbfede
+    .word   0xb47429e1
+    .word   0x98d4172b
+    .word   0x1db106e0
+
+
+    .word   0xd9a399cc
+    .word   0x49c1e9f9
+    .word   0x876024c4
+    .word   0xd052389c
+    .word   0xe56e3392
+    .word   0xc6d7f805
+    .word   0xd01545c9
+    .word   0xba93fc78
+
+
+    .word   0xbbfe6b3b
+    .word   0xd2442aff
+    .word   0xf7665446
+    .word   0x1dc9881
+    .word   0x568f3b2c
+    .word   0xffe13ee7
+    .word   0x3272be4b
+    .word   0xc42d3639
+
+
+    .word   0xe45d0426
+    .word   0xa71ff400
+    .word   0x96ad72a0
+    .word   0xf091907e
+    .word   0xf5a9376a
+    .word   0xe491912c
+    .word   0x6a233d8f
+    .word   0xb8933dc5
+
+
+    .word   0xec045c68
+    .word   0x4e5969da
+    .word   0xf486ede9
+    .word   0xd571cecd
+    .word   0x5f71f91a
+    .word   0x53bf99af
+    .word   0x7e0530cb
+    .word   0x30cef0a6
+
+
+    .word   0x9ab02bcf
+    .word   0x2656c76b
+    .word   0x144559
+    .word   0x5ce46fb6
+    .word   0x1b354225
+    .word   0x7e679707
+    .word   0xaf1f82f6
+    .word   0x6aa011a4
+
+
+    .word   0x70445af9
+    .word   0x17869e6b
+    .word   0xc44cfdac
+    .word   0x4556f173
+    .word   0x65f2ae19
+    .word   0xd11aa7d6
+    .word   0xe81e14b5
+    .word   0x3b31ba00
+
+
+    .word   0xbfed4474
+    .word   0x10fda925
+    .word   0xd4522dc5
+    .word   0xf56ea3c3
+    .word   0x2968ff91
+    .word   0xc28a6064
+    .word   0xb3d68fc3
+    .word   0xb46b62f2
+
+
+    .word   0x5e07b30
+    .word   0x5889b74
+    .word   0x487e18a4
+    .word   0xd4ac629a
+    .word   0x8fddf86d
+    .word   0x253c8ff1
+    .word   0x1dbc9693
+    .word   0x602fe2e8
+
+
+    .word   0x118cb3c4
+    .word   0xeefe4d7b
+    .word   0x2ccfd6c2
+    .word   0x451a290
+    .word   0xe5fae3e3
+    .word   0xae3ff716
+    .word   0xf94f5f7d
+    .word   0xa6fe65f3
+
+
+    .word   0x78fd9636
+    .word   0xb2ad0faa
+    .word   0x34110fa3
+    .word   0x2236127
+    .word   0xba4b8412
+    .word   0x2dd3bea
+    .word   0xb3fe64f5
+    .word   0xf2e3a730
+
+
+    .word   0xdcb18855
+    .word   0xa23736c1
+    .word   0x7b7f8632
+    .word   0xfc9a58f9
+    .word   0xb62a4d0e
+    .word   0xb735530b
+    .word   0x920ee9b4
+    .word   0x6ba90950
+
+
+    .word   0xe26d9fd7
+    .word   0x147732d4
+    .word   0xa1df3221
+    .word   0x59282498
+    .word   0x3761b90f
+    .word   0x8490c34f
+    .word   0xd6e68053
+    .word   0x8674e0e5
+
+
+    .word   0x66170552
+    .word   0x81edb231
+    .word   0x3d77b760
+    .word   0xa15f02df
+    .word   0xc6b61848
+    .word   0x8f29d6a5
+    .word   0xe8d2ed49
+    .word   0x57aacde
+
+
+    .word   0x92dec659
+    .word   0xd9be4ef3
+    .word   0x115f2813
+    .word   0x8f1d374
+    .word   0xbcf5b714
+    .word   0x89f2ff25
+    .word   0x38e12d6
+    .word   0xf44b618a
+
+
+    .word   0x2dba5140
+    .word   0x215f5646
+    .word   0x858ef6fc
+    .word   0xcf227464
+    .word   0xafed1726
+    .word   0x6716d3d8
+    .word   0x5edd267c
+    .word   0x876cc895
+
+
+    .word   0x8c61c869
+    .word   0xe661645
+    .word   0x5f79af82
+    .word   0xb9064e77
+    .word   0xd9a34817
+    .word   0xca2caaf0
+    .word   0x234f40db
+    .word   0x4551e047
+
+
+    .word   0x5186c778
+    .word   0x8d5b0170
+    .word   0x473f34ac
+    .word   0xb588d8f0
+    .word   0x621d9864
+    .word   0x1fd019fa
+    .word   0xbaa4e64e
+    .word   0x3cdfbe6a
+
+
+    .word   0x1cef03c7
+    .word   0x96e5544c
+    .word   0x83077140
+    .word   0xa13832e8
+    .word   0xac0d1507
+    .word   0x61e3960d
+    .word   0x6383c544
+    .word   0xe799da88
+
+
+    .word   0xd4fad9f3
+    .word   0x81cfbec4
+    .word   0xc0d0a897
+    .word   0xbc0ccc4b
+    .word   0x3f3c6f16
+    .word   0xdd396fb
+    .word   0x920a85f8
+    .word   0x39a1a677
+
+
+    .word   0xa859d046
+    .word   0x560f1197
+    .word   0xd28ebe1
+    .word   0xd3037a3d
+    .word   0xa780becd
+    .word   0x5b7fe6e8
+    .word   0xb88b544d
+    .word   0x35ac68b2
+
+
+    .word   0x2d2ef8aa
+    .word   0x27897e3f
+    .word   0x4e583028
+    .word   0x20e9df27
+    .word   0x2046cd48
+    .word   0x9b982e13
+    .word   0xa552543b
+    .word   0x4e39d055
+
+
+    .word   0x4927ac6f
+    .word   0xbce2849
+    .word   0xf4648167
+    .word   0x17c546c6
+    .word   0x995b4a0b
+    .word   0xd95a2c4c
+    .word   0x89410102
+    .word   0x88d5faa0
+
+
+    .word   0xb4944e8b
+    .word   0x8f4462e0
+    .word   0x7994b220
+    .word   0x2e207620
+    .word   0xd77832eb
+    .word   0xf36cd25e
+    .word   0x748ea7d7
+    .word   0x23a4ebf2

--- a/crc/aarch64/crc32_iscsi_x6.S
+++ b/crc/aarch64/crc32_iscsi_x6.S
@@ -1,0 +1,410 @@
+/**************************************************************
+  Copyright (c) 2026 Huawei Technologies Co., Ltd.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Huawei Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+.text
+.align    6
+.arch     armv8-a+crc+crypto
+
+.macro crc32_u64    dst,src,data
+     crc32cx     \dst, \src, \data
+.endm
+
+.macro crc32_u32    dst,src,data
+     crc32cw     \dst, \src, \data
+.endm
+
+.macro crc32_u16    dst,src,data
+     crc32ch     \dst, \src, \data
+.endm
+
+.macro crc32_u8     dst,src,data
+     crc32cb     \dst, \src, \data
+.endm
+
+.set stack_size, 160
+.macro  push_stack
+        stp     d8,  d9,  [sp, -stack_size]!
+		stp     d10, d11, [sp, 16]
+		stp     d12, d13, [sp, 32]
+		stp     d14, d15, [sp, 48]
+		stp     x19, x20, [sp, 64]
+		stp     x21, x22, [sp, 80]
+		stp     x23, x24, [sp, 96]
+		stp     x25, x26, [sp, 112]
+		stp     x27, x28, [sp, 128]
+		stp     x29, x30, [sp, 144]
+.endm
+
+.macro  pop_stack
+		ldp     d10, d11, [sp, 16]
+		ldp     d12, d13, [sp, 32]
+		ldp     d14, d15, [sp, 48]
+		ldp     x19, x20, [sp, 64]
+		ldp     x21, x22, [sp, 80]
+		ldp     x23, x24, [sp, 96]
+		ldp     x25, x26, [sp, 112]
+		ldp     x27, x28, [sp, 128]
+		ldp     x29, x30, [sp, 144]
+		ldp     d8,  d9,  [sp], stack_size
+.endm
+
+.macro declare_var_vector_reg name:req,reg:req
+     q\name   .req   q\reg
+     v\name   .req   v\reg
+     s\name   .req   s\reg
+     d\name   .req   d\reg
+.endm
+
+    BUF       .req   x0
+    LEN       .req   x1
+    wCRC      .req   w2
+    crc0      .req   w2
+    crc1      .req   w3
+    crc2      .req   w4
+    crc3      .req   w5
+    crc4      .req   w6
+    crc5      .req   w7
+    xcrc0     .req   x2
+    xcrc1     .req   x3
+    xcrc2     .req   x4
+    xcrc3     .req   x5
+    xcrc4     .req   x6
+    xcrc5     .req   x7
+
+    const_adr .req   x8
+    ptr_crc0  .req   x0
+    ptr_crc1  .req   x9
+    ptr_crc2  .req   x10
+    ptr_crc3  .req   x11
+    ptr_crc4  .req   x12
+    ptr_crc5  .req   x13
+
+    crc0_data0  .req  x14
+    crc0_data1  .req  x15
+    crc0_data2  .req  x24
+    crc0_data3  .req  x25
+    crc0_data4  .req  x22
+    crc0_data5  .req  x23
+
+    crc0_data6  .req  x16
+    crc0_data7  .req  x17
+    crc0_data8  .req  x18
+    crc0_data9  .req  x19
+    crc0_data10 .req  x20
+    crc0_data11 .req  x26
+
+    wdata       .req  w8
+    data0       .req  x8
+    data1       .req  x4
+    data2       .req  x21
+    data3       .req  x9
+
+    declare_var_vector_reg tmp0, 0
+    declare_var_vector_reg tmp1, 1
+    declare_var_vector_reg tmp2, 2
+    declare_var_vector_reg tmp3, 3
+    declare_var_vector_reg tmp4, 4
+
+    declare_var_vector_reg const0, 5
+    declare_var_vector_reg const1, 6
+    declare_var_vector_reg const2, 7
+    declare_var_vector_reg const3, 8
+    declare_var_vector_reg const4, 9
+
+/**
+    unsigned int crc32_iscsi_x6(
+        unsigned char *BUF,
+        int LEN,
+        unsigned int wCRC
+    );
+
+*/
+
+.global crc32_iscsi_x6
+.type   crc32_iscsi_x6, %function
+crc32_iscsi_x6:
+     
+    push_stack
+    cbz      LEN, .zero_length_ret
+
+.align_finish:
+    cmp LEN,1024
+    bls 1f
+    adrp     const_adr, .Lconstants
+    add      const_adr, const_adr, #:lo12:.Lconstants
+    ldp      dconst0,dconst1,[const_adr]
+    ldp      dconst2,dconst3,[const_adr, 16]
+    ldr      dconst4,[const_adr, 32]
+2:
+    mov      crc1,0
+    mov      crc2,0
+    mov      crc3,0
+    mov      crc4,0
+    mov      crc5,0
+
+    ldr      crc0_data0, [ptr_crc0], 8
+    crc32_u64   crc0, crc0, crc0_data0
+
+    add      ptr_crc1,ptr_crc0,168
+    add      ptr_crc2,ptr_crc0,168*2
+    add      ptr_crc3,ptr_crc0,168*3
+    add      ptr_crc4,ptr_crc0,168*4
+    add      ptr_crc5,ptr_crc0,168*5
+
+    ldp      crc0_data0,crc0_data6,[ptr_crc0],16
+    ldp      crc0_data1,crc0_data7,[ptr_crc1],16
+    ldp      crc0_data2,crc0_data8,[ptr_crc2],16
+    ldp      crc0_data3,crc0_data9,[ptr_crc3],16
+    ldp      crc0_data4,crc0_data10,[ptr_crc4],16
+    ldp      crc0_data5,crc0_data11,[ptr_crc5],16
+
+.rept 4
+    crc32_u64    crc0,crc0,crc0_data0
+    crc32_u64    crc1,crc1,crc0_data1
+    crc32_u64    crc2,crc2,crc0_data2
+    crc32_u64    crc3,crc3,crc0_data3
+    crc32_u64    crc4,crc4,crc0_data4
+    crc32_u64    crc5,crc5,crc0_data5
+
+    ldp     crc0_data0, crc0_data3,[ptr_crc0],16
+    ldp     crc0_data1, crc0_data4,[ptr_crc1],16
+    ldp     crc0_data2, crc0_data5,[ptr_crc2],16
+
+    crc32_u64    crc0,crc0,crc0_data6
+    crc32_u64    crc1,crc1,crc0_data7
+    crc32_u64    crc2,crc2,crc0_data8
+    crc32_u64    crc3,crc3,crc0_data9
+    crc32_u64    crc4,crc4,crc0_data10
+    crc32_u64    crc5,crc5,crc0_data11
+
+    ldp     crc0_data6, crc0_data9,[ptr_crc3],16
+    ldp     crc0_data7, crc0_data10,[ptr_crc4],16
+    ldp     crc0_data8, crc0_data11,[ptr_crc5],16
+
+    crc32_u64    crc0,crc0,crc0_data0
+    crc32_u64    crc1,crc1,crc0_data1
+    crc32_u64    crc2,crc2,crc0_data2
+    crc32_u64    crc3,crc3,crc0_data6
+    crc32_u64    crc4,crc4,crc0_data7
+    crc32_u64    crc5,crc5,crc0_data8
+
+    ldp     crc0_data0, crc0_data6,[ptr_crc0],16
+    ldp     crc0_data1, crc0_data7,[ptr_crc1],16
+    ldp     crc0_data2, crc0_data8,[ptr_crc2],16
+
+    crc32_u64    crc0,crc0,crc0_data3
+    crc32_u64    crc1,crc1,crc0_data4
+    crc32_u64    crc2,crc2,crc0_data5
+    crc32_u64    crc3,crc3,crc0_data9
+    crc32_u64    crc4,crc4,crc0_data10
+    crc32_u64    crc5,crc5,crc0_data11
+
+    ldp     crc0_data3, crc0_data9,[ptr_crc3],16
+    ldp     crc0_data4, crc0_data10,[ptr_crc4],16
+    ldp     crc0_data5, crc0_data11,[ptr_crc5],16
+.endr
+ 
+    crc32_u64    crc0,crc0,crc0_data0
+    crc32_u64    crc1,crc1,crc0_data1
+    crc32_u64    crc2,crc2,crc0_data2
+    crc32_u64    crc3,crc3,crc0_data3
+    crc32_u64    crc4,crc4,crc0_data4
+    crc32_u64    crc5,crc5,crc0_data5
+
+    ldp     crc0_data0, crc0_data3,[ptr_crc0],16
+    ldp     crc0_data1, crc0_data4,[ptr_crc1],16
+    ldp     crc0_data2, crc0_data5,[ptr_crc2],16
+
+    crc32_u64    crc0,crc0,crc0_data6
+    crc32_u64    crc1,crc1,crc0_data7
+    crc32_u64    crc2,crc2,crc0_data8
+    crc32_u64    crc3,crc3,crc0_data9
+    crc32_u64    crc4,crc4,crc0_data10
+    crc32_u64    crc5,crc5,crc0_data11
+
+    ldp     crc0_data6, crc0_data9,[ptr_crc3],16
+    ldp     crc0_data7, crc0_data10,[ptr_crc4],16
+    ldp     crc0_data8, crc0_data11,[ptr_crc5],16
+
+    crc32_u64    crc0,crc0,crc0_data0
+    crc32_u64    crc1,crc1,crc0_data1
+    crc32_u64    crc2,crc2,crc0_data2
+    crc32_u64    crc3,crc3,crc0_data6
+    crc32_u64    crc4,crc4,crc0_data7
+    crc32_u64    crc5,crc5,crc0_data8
+
+    ldr     crc0_data0,[ptr_crc0],8
+    ldr     crc0_data1,[ptr_crc1],8
+    ldr     crc0_data2,[ptr_crc2],8
+
+    crc32_u64    crc0,crc0,crc0_data3
+    crc32_u64    crc1,crc1,crc0_data4
+    crc32_u64    crc2,crc2,crc0_data5
+    crc32_u64    crc3,crc3,crc0_data9
+    crc32_u64    crc4,crc4,crc0_data10
+    crc32_u64    crc5,crc5,crc0_data11
+
+    ldr     crc0_data3,[ptr_crc3],8
+    ldr     crc0_data4,[ptr_crc4],8
+    ldr     crc0_data5,[ptr_crc5],8
+
+    crc32_u64    crc0,crc0,crc0_data0
+    crc32_u64    crc1,crc1,crc0_data1
+    crc32_u64    crc2,crc2,crc0_data2
+    crc32_u64    crc3,crc3,crc0_data3
+    crc32_u64    crc4,crc4,crc0_data4
+    crc32_u64    crc5,crc5,crc0_data5
+
+    ldr     crc0_data5, [ptr_crc5], 8
+    crc32_u64  crc5, crc5, crc0_data5
+
+    fmov    dtmp0,xcrc0
+    fmov    dtmp1,xcrc1
+    fmov    dtmp2,xcrc2
+    fmov    dtmp3,xcrc3
+    fmov    dtmp4,xcrc4
+
+    mov     ptr_crc0,ptr_crc5
+    pmull   vtmp0.1q,vtmp0.1d,vconst0.1d
+    sub     LEN,LEN,1024
+    pmull   vtmp1.1q,vtmp1.1d,vconst1.1d
+    pmull   vtmp2.1q,vtmp2.1d,vconst2.1d
+    pmull   vtmp3.1q,vtmp3.1d,vconst3.1d
+    pmull   vtmp4.1q,vtmp4.1d,vconst4.1d
+    cmp     LEN,1024
+    fmov    xcrc0, dtmp0
+    fmov    xcrc1, dtmp1
+    fmov    xcrc2, dtmp2
+    fmov    xcrc3, dtmp3
+    fmov    xcrc4, dtmp4
+
+    crc32_u64  crc0,wzr,xcrc0
+    crc32_u64  crc1,wzr,xcrc1
+    crc32_u64  crc2,wzr,xcrc2
+    crc32_u64  crc3,wzr,xcrc3
+    crc32_u64  crc4,wzr,xcrc4
+
+    eor   crc0,crc0,crc1
+    eor   crc2,crc2,crc3
+    eor   crc4,crc4,crc5
+    eor   crc2,crc2,crc4
+    eor   crc0,crc0,crc2
+    bhs 2b
+
+1:
+    cmp   LEN, 63
+    bls   .loop_16B
+.loop_64B:
+    ldp   data0,data1,[BUF],#16
+    sub   LEN,LEN,#64
+    ldp   data2,data3,[BUF],#16
+    cmp   LEN,#64
+    crc32_u64  wCRC, wCRC, data0
+    crc32_u64  wCRC, wCRC, data1
+    ldp   data0,data1,[BUF],#16
+    crc32_u64  wCRC, wCRC, data2
+    crc32_u64  wCRC, wCRC, data3
+    ldp   data2,data3,[BUF],#16
+    crc32_u64  wCRC, wCRC, data0
+    crc32_u64  wCRC, wCRC, data1
+    crc32_u64  wCRC, wCRC, data2
+    crc32_u64  wCRC, wCRC, data3
+    bge     .loop_64B
+
+.loop_16B:
+    cmp    LEN, 15
+    bls    .less_16B
+    ldp    data0, data1, [BUF], #16
+    sub    LEN, LEN, #16
+    cmp    LEN,15
+    crc32_u64  wCRC, wCRC, data0
+    crc32_u64  wCRC, wCRC, data1
+    bls    .less_16B
+    ldp    data0, data1, [BUF], #16
+    sub    LEN,LEN,#16
+    cmp    LEN,15
+    crc32_u64 wCRC,wCRC,data0
+    crc32_u64 wCRC,wCRC,data1
+    bls   .less_16B
+    ldp    data0, data1, [BUF], #16
+    sub    LEN,LEN,#16
+    crc32_u64 wCRC,wCRC,data0
+    crc32_u64 wCRC,wCRC,data1
+.less_16B:
+    cmp    LEN, 7
+    bls    .less_8B
+    ldr    data0, [BUF], 8
+    sub    LEN, LEN, #8
+    crc32_u64 wCRC, wCRC,data0
+.less_8B:
+    cmp    LEN, 3
+    bls    .less_4B
+    ldr    wdata, [BUF], 4
+    sub    LEN, LEN, #4
+    crc32_u32 wCRC, wCRC, wdata
+.less_4B:
+    cmp    LEN, 1
+    bls    .less_2B
+    ldrh   wdata, [BUF], 2
+    sub    LEN, LEN, #2
+    crc32_u16  wCRC, wCRC, wdata
+.less_2B:
+    cbz    LEN, .zero_length_ret
+    ldrb   wdata, [BUF]
+    crc32_u8  wCRC,wCRC,wdata
+
+.zero_length_ret:
+    mov    w0, wCRC
+    pop_stack
+    ret
+
+.align_short_2:
+    ldrh    wdata, [BUF], 2
+    sub     LEN, LEN, 2
+    tst     BUF, 4
+    crc32_u16 wCRC, wCRC, wdata
+    ccmp    LEN, 3, 0, ne
+    bls     .align_finish
+.align_word:
+    ldr     wdata, [BUF], 4
+    sub     LEN, LEN, #4
+    crc32_u32   wCRC, wCRC, wdata
+    b       .align_finish
+
+.size  crc32_iscsi_x6, .-crc32_iscsi_x6
+
+.section .rodata
+.align 4
+.Lconstants:
+    .quad     0xa741c1bf
+    .quad     0xe417f38a
+    .quad     0xdd7e3b0c
+    .quad     0x8f158014
+    .quad     0xdaece73e
+

--- a/crc/aarch64/crc_aarch64_dispatcher.c
+++ b/crc/aarch64/crc_aarch64_dispatcher.c
@@ -46,6 +46,11 @@ crc32_iscsi_3crc_fold(unsigned char *, int, unsigned int);
 extern unsigned int
 crc32_iscsi_refl_pmull(unsigned char *, int, unsigned int);
 
+extern unsigned int
+crc32_iscsi_x6(unsigned char *, int, unsigned int);
+extern unsigned int
+crc32_iscsi_fusion_p8_c10_asm(unsigned char *, int, unsigned int);
+
 extern uint32_t
 crc32_gzip_refl_crc_ext(uint32_t, uint8_t *, uint64_t);
 extern uint32_t
@@ -121,6 +126,7 @@ DEFINE_INTERFACE_DISPATCHER(crc32_iscsi)
 {
 #if defined(__linux__)
         unsigned long auxval = getauxval(AT_HWCAP);
+        unsigned long auxval2 = getauxval(AT_HWCAP2);
         if (auxval & HWCAP_CRC32) {
                 switch (get_micro_arch_id()) {
                 case MICRO_ARCH_ID(ARM, NEOVERSE_N1):
@@ -129,8 +135,13 @@ DEFINE_INTERFACE_DISPATCHER(crc32_iscsi)
                         return crc32_iscsi_crc_ext;
                 }
         }
+
+        if ((HWCAP_CRC32) == (auxval & HWCAP_CRC32) &&
+            (HWCAP2_SVE2) == (auxval2 & HWCAP2_SVE2)) {
+                return crc32_iscsi_fusion_p8_c10_asm;
+        }
         if ((HWCAP_CRC32 | HWCAP_PMULL) == (auxval & (HWCAP_CRC32 | HWCAP_PMULL))) {
-                return crc32_iscsi_3crc_fold;
+                return crc32_iscsi_x6;
         }
 
         if (auxval & HWCAP_PMULL) {

--- a/include/aarch64_multibinary.h
+++ b/include/aarch64_multibinary.h
@@ -254,6 +254,10 @@ static inline int sysctlEnabled(const char* name){
 #define HWCAP_CPUID (1<<11)
 #endif
 
+#ifndef HWCAP2_SVE2
+#define HWCAP2_SVE2 (1<<1)
+#endif
+
 /**
  * @brief  get_micro_arch_id
  *


### PR DESCRIPTION
Optimize CRC32 iSCSI implementation for ARM platforms with two new accelerated code paths:

1. Optimized PMULL Path (crc32_iscsi_x6)

For platforms with PMULL support (CRC32+PMULL but no SVE2):

 - Extended parallel folding from 3-way to 6-way computation
 - Improved loop structure and register utilization
 - Better throughput on PMULL-capable CPUs

2. SVE2 Fusion Path (crc32_iscsi_fusion_p8_c10_asm)

For platforms with SVE2 support:

 - Hybrid scalar-vector parallel computation approach
 - Scalar path: 10-way parallel using crc32cx instructions
 - Vector path: 8-way parallel using pmullt/pmullb instructions
 - Results merged and folded using SVE2 eor3 instruction
 - Optimal for CPUs with SVE2 support


Performance Results:

Kunpeng-920 (SVE, no SVE2):
+------------+------------+------------+--------+
| Data Size  | Before     | After      | Speedup|
+------------+------------+------------+--------+
| 4KB        | 33 GB/s    | 37 GB/s    | 1.12x  |
| 8KB        | 33 GB/s    | 38 GB/s    | 1.15x  |
+------------+------------+------------+--------+

Kunpeng-950 (SVE2):
+------------+------------+------------+--------+
| Data Size  | Before     | After      | Speedup|
+------------+------------+------------+--------+
| 4KB        | 24 GB/s    | 45 GB/s    | 1.88x  |
| 8KB        | 23 GB/s    | 57 GB/s    | 2.48x  |
+------------+------------+------------+--------+

Measured using crc32_iscsi_perf tool on Huawei Kunpeng platforms.

Files modified:
- crc/aarch64/crc_aarch64_dispatcher.c
- crc/aarch64/crc32_iscsi_p8c10.S (new)
- crc/aarch64/crc32_iscsi_p8c10_clmul_const.S (new)
- crc/aarch64/crc32_iscsi_x6.S (new)
- include/aarch64_multibinary.h