### PR TITLE
fix: strip path components from gzip `NAME` field on decompress

### DIFF
--- a/programs/igzip_cli.c
+++ b/programs/igzip_cli.c
@@ -894,6 +894,15 @@ decompress_file(void)
         if (outfile_type == implicit)
                 file_time = gz_hdr.time;
 
+        /* RFC 1952 §2.3.1: the NAME field stores a bare filename with any
+         * directory components already removed by the compressor. Strip any
+         * path prefix here to prevent path-traversal. */
+        if (outfile_type == implicit && outfile_name != NULL && outfile_name[0] != 0) {
+                char *base = strrchr(outfile_name, '/');
+                if (base != NULL)
+                        memmove(outfile_name, base + 1, strlen(base + 1) + 1);
+        }
+
         if (outfile_name != NULL && infile_name != NULL &&
             (outfile_type == stripped || (outfile_type == implicit && outfile_name[0] == 0))) {
                 outfile_name_len = infile_name_len - suffix_len;

--- a/programs/igzip_cli_check.sh
+++ b/programs/igzip_cli_check.sh
@@ -257,5 +257,45 @@ if command -V md5sum >/dev/null 2>&1 && command -V dd >/dev/null 2>&1; then
     fi
 fi
 
+# Path-traversal via gzip NAME field
+# A crafted .gz whose NAME is an absolute path must decompress to a file
+# named only by the basename in the CWD, never to the absolute path.
+#
+# evil_traversal.gz is a hand-crafted gzip stream whose FNAME header field
+# is the absolute path /tmp/igzip_traversal_baked.  Embedded as base64 to
+# avoid build-time dependencies.  To regenerate, run:
+#
+# { printf '\x1f\x8b\x08\x08\x00\x00\x00\x00\x00\xff'  # fixed header (FLG=0x08=FNAME)
+#   printf '/tmp/igzip_traversal_baked\x00'              # FNAME, NUL-terminated
+#   printf 'TRAVERSAL\n' | gzip -cn | tail -c +11 | head -c -8  # raw DEFLATE
+#   printf 'TRAVERSAL\n' | gzip -cn | tail -c 8          # CRC32 + ISIZE
+# } > evil_traversal.gz && base64 evil_traversal.gz
+ret=0
+traversal_target=/tmp/igzip_traversal_baked
+rm -f "$traversal_target"
+
+base64 -d <<'B64' > evil_traversal.gz
+H4sICAAAAAAA/y90bXAvaWd6aXBfdHJhdmVyc2FsX2Jha2VkAAsJcgxzDQp29OECAJKQXKMKAAAA
+B64
+
+# Run igzip -d -N: must write basename only, not the absolute path
+$IGZIP -d -N evil_traversal.gz || ret=1
+
+# The absolute path must NOT have been created
+if [ -f "$traversal_target" ]; then
+    echo "FAIL: path traversal succeeded — file written to $traversal_target"
+    ret=1
+fi
+
+# The basename must exist in the CWD
+if [ ! -f "igzip_traversal_baked" ]; then
+    echo "FAIL: expected igzip_traversal_baked in CWD but it was not found"
+    ret=1
+fi
+
+rm -f "$traversal_target" igzip_traversal_baked evil_traversal.gz
+pass_check $ret "Path traversal: gzip NAME absolute path stripped to basename"
+clear_dir
+
 echo "Passed all cli checks"
 cleanup 0


### PR DESCRIPTION
## What is this PR?

This PR fixes an arbitrary file write arising from using the raw `NAME` when decompressing, without checking whether it is a valid `NAME` entry, or something that would escape the current working directory.   
The proposed fix is to ensure the `outfile_name` does not contain a `/`, or if it does to strip everything that comes before the last `/`. 

This matches what should be expected from a correct input per [RFC 1952 §2.3.1](https://www.rfc-editor.org/rfc/rfc1952.html#section-2.3.1), which states that the `NAME` field stores the original filename "with any directory components removed".  It also is consistent with how GNU `gzip` handles the same case ([here](https://cgit.git.savannah.gnu.org/cgit/gzip.git/tree/gzip.c#n1570)).

The PR also adds a regression check to confirm the issue is fixed (with an example of an ill-formed input).  

**Note** merged as part of 721649c4c931dee294432d4c7219c94a202f9a26. 