### PR TITLE
Erasure Code:  Extend ec_encode_data_avx2_gfni and ec_encode_data_update_avx2_gfni to support parity blocks k+1 through k+6

### DIFF
--- a/Makefile.nmake
+++ b/Makefile.nmake
@@ -94,6 +94,7 @@ objs = \
 	bin\gf_3vect_mad_avx2_gfni.obj \
 	bin\gf_4vect_mad_avx2_gfni.obj \
 	bin\gf_5vect_mad_avx2_gfni.obj \
+	bin\gf_6vect_mad_avx2_gfni.obj \
 	bin\gf_vect_dot_prod_avx512.obj \
 	bin\gf_2vect_dot_prod_avx512.obj \
 	bin\gf_3vect_dot_prod_avx512.obj \
@@ -104,6 +105,9 @@ objs = \
 	bin\gf_vect_dot_prod_avx2_gfni.obj \
 	bin\gf_2vect_dot_prod_avx2_gfni.obj \
 	bin\gf_3vect_dot_prod_avx2_gfni.obj \
+	bin\gf_4vect_dot_prod_avx2_gfni.obj \
+	bin\gf_5vect_dot_prod_avx2_gfni.obj \
+	bin\gf_6vect_dot_prod_avx2_gfni.obj \
 	bin\gf_2vect_dot_prod_avx512_gfni.obj \
 	bin\gf_3vect_dot_prod_avx512_gfni.obj \
 	bin\gf_4vect_dot_prod_avx512_gfni.obj \

--- a/cmake/erasure_code.cmake
+++ b/cmake/erasure_code.cmake
@@ -82,6 +82,7 @@ set(ERASURE_CODE_X86_64_SOURCES
     erasure_code/gf_3vect_mad_avx2_gfni.asm
     erasure_code/gf_4vect_mad_avx2_gfni.asm
     erasure_code/gf_5vect_mad_avx2_gfni.asm
+    erasure_code/gf_6vect_mad_avx2_gfni.asm
     erasure_code/gf_vect_dot_prod_avx512.asm
     erasure_code/gf_2vect_dot_prod_avx512.asm
     erasure_code/gf_3vect_dot_prod_avx512.asm
@@ -92,6 +93,9 @@ set(ERASURE_CODE_X86_64_SOURCES
     erasure_code/gf_vect_dot_prod_avx2_gfni.asm
     erasure_code/gf_2vect_dot_prod_avx2_gfni.asm
     erasure_code/gf_3vect_dot_prod_avx2_gfni.asm
+    erasure_code/gf_4vect_dot_prod_avx2_gfni.asm
+    erasure_code/gf_5vect_dot_prod_avx2_gfni.asm
+    erasure_code/gf_6vect_dot_prod_avx2_gfni.asm
     erasure_code/gf_2vect_dot_prod_avx512_gfni.asm
     erasure_code/gf_3vect_dot_prod_avx512_gfni.asm
     erasure_code/gf_4vect_dot_prod_avx512_gfni.asm

--- a/erasure_code/Makefile.am
+++ b/erasure_code/Makefile.am
@@ -85,6 +85,7 @@ lsrc_x86_64  += \
 		erasure_code/gf_3vect_mad_avx2_gfni.asm \
 		erasure_code/gf_4vect_mad_avx2_gfni.asm \
 		erasure_code/gf_5vect_mad_avx2_gfni.asm \
+		erasure_code/gf_6vect_mad_avx2_gfni.asm \
 		erasure_code/gf_vect_dot_prod_avx512.asm \
 		erasure_code/gf_2vect_dot_prod_avx512.asm \
 		erasure_code/gf_3vect_dot_prod_avx512.asm \
@@ -95,6 +96,9 @@ lsrc_x86_64  += \
 		erasure_code/gf_vect_dot_prod_avx2_gfni.asm \
 		erasure_code/gf_2vect_dot_prod_avx2_gfni.asm \
 		erasure_code/gf_3vect_dot_prod_avx2_gfni.asm \
+		erasure_code/gf_4vect_dot_prod_avx2_gfni.asm \
+		erasure_code/gf_5vect_dot_prod_avx2_gfni.asm \
+		erasure_code/gf_6vect_dot_prod_avx2_gfni.asm \
 		erasure_code/gf_2vect_dot_prod_avx512_gfni.asm \
 		erasure_code/gf_3vect_dot_prod_avx512_gfni.asm \
 		erasure_code/gf_4vect_dot_prod_avx512_gfni.asm \

--- a/erasure_code/ec_highlevel_func.c
+++ b/erasure_code/ec_highlevel_func.c
@@ -424,6 +424,15 @@ extern void
 gf_3vect_dot_prod_avx2_gfni(int len, int k, unsigned char *g_tbls, unsigned char **data,
                             unsigned char **coding);
 extern void
+gf_4vect_dot_prod_avx2_gfni(int len, int k, unsigned char *g_tbls, unsigned char **data,
+                            unsigned char **coding);
+extern void
+gf_5vect_dot_prod_avx2_gfni(int len, int k, unsigned char *g_tbls, unsigned char **data,
+                            unsigned char **coding);
+extern void
+gf_6vect_dot_prod_avx2_gfni(int len, int k, unsigned char *g_tbls, unsigned char **data,
+                            unsigned char **coding);
+extern void
 gf_vect_mad_avx2_gfni(int len, int vec, int vec_i, unsigned char *gftbls, unsigned char *src,
                       unsigned char *dest);
 extern void
@@ -437,6 +446,9 @@ gf_4vect_mad_avx2_gfni(int len, int vec, int vec_i, unsigned char *gftbls, unsig
                        unsigned char **dest);
 extern void
 gf_5vect_mad_avx2_gfni(int len, int vec, int vec_i, unsigned char *gftbls, unsigned char *src,
+                       unsigned char **dest);
+extern void
+gf_6vect_mad_avx2_gfni(int len, int vec, int vec_i, unsigned char *gftbls, unsigned char *src,
                        unsigned char **dest);
 
 // Calculates 32-byte const table gftbl in GF(2^8) from single input A,
@@ -500,13 +512,22 @@ void
 ec_encode_data_avx2_gfni(int len, int k, int rows, unsigned char *g_tbls, unsigned char **data,
                          unsigned char **coding)
 {
-        while (rows >= 3) {
-                gf_3vect_dot_prod_avx2_gfni(len, k, g_tbls, data, coding);
-                g_tbls += 3 * k * 32;
-                coding += 3;
-                rows -= 3;
+        while (rows >= 6) {
+                gf_6vect_dot_prod_avx2_gfni(len, k, g_tbls, data, coding);
+                g_tbls += 6 * k * 32;
+                coding += 6;
+                rows -= 6;
         }
         switch (rows) {
+        case 5:
+                gf_5vect_dot_prod_avx2_gfni(len, k, g_tbls, data, coding);
+                break;
+        case 4:
+                gf_4vect_dot_prod_avx2_gfni(len, k, g_tbls, data, coding);
+                break;
+        case 3:
+                gf_3vect_dot_prod_avx2_gfni(len, k, g_tbls, data, coding);
+                break;
         case 2:
                 gf_2vect_dot_prod_avx2_gfni(len, k, g_tbls, data, coding);
                 break;
@@ -555,13 +576,16 @@ void
 ec_encode_data_update_avx2_gfni(int len, int k, int rows, int vec_i, unsigned char *g_tbls,
                                 unsigned char *data, unsigned char **coding)
 {
-        while (rows >= 5) {
-                gf_5vect_mad_avx2_gfni(len, k, vec_i, g_tbls, data, coding);
-                g_tbls += 5 * k * 32;
-                coding += 5;
-                rows -= 5;
+        while (rows >= 6) {
+                gf_6vect_mad_avx2_gfni(len, k, vec_i, g_tbls, data, coding);
+                g_tbls += 6 * k * 32;
+                coding += 6;
+                rows -= 6;
         }
         switch (rows) {
+        case 5:
+                gf_5vect_mad_avx2_gfni(len, k, vec_i, g_tbls, data, coding);
+                break;
         case 4:
                 gf_4vect_mad_avx2_gfni(len, k, vec_i, g_tbls, data, coding);
                 break;

--- a/erasure_code/gf_2vect_dot_prod_avx2_gfni.asm
+++ b/erasure_code/gf_2vect_dot_prod_avx2_gfni.asm
@@ -286,11 +286,12 @@ section .text
 %%next_vect:
         mov     ptr, [src + vec_i]
         simd_load_avx2 x0, ptr + pos, %%LEN, tmp, tmp4 ;Get next source vector
+
+        lea     tmp, [mul_array + vec_i*4]
         add     vec_i, 8
 
-        vmovdqu xgft1, [mul_array]
-        vmovdqu xgft2, [mul_array + vec*4]
-        add     mul_array, 32
+        vmovdqu xgft1, [tmp]
+        vmovdqu xgft2, [tmp + vec*4]
 
         GF_MUL_XOR VEX, x0, xgft1, xgft1, xp1, xgft2, xgft2, xp2
 

--- a/erasure_code/gf_4vect_dot_prod_avx2_gfni.asm
+++ b/erasure_code/gf_4vect_dot_prod_avx2_gfni.asm
@@ -1,5 +1,5 @@
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;1;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;  Copyright(c) 2023 Intel Corporation All rights reserved.
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;  Copyright(c) 2026 Alibaba Group All rights reserved.
 ;
 ;  Redistribution and use in source and binary forms, with or without
 ;  modification, are permitted provided that the following conditions
@@ -10,7 +10,7 @@
 ;      notice, this list of conditions and the following disclaimer in
 ;      the documentation and/or other materials provided with the
 ;      distribution.
-;    * Neither the name of Intel Corporation nor the names of its
+;    * Neither the name of Alibaba Group nor the names of its
 ;      contributors may be used to endorse or promote products derived
 ;      from this software without specific prior written permission.
 ;
@@ -28,7 +28,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;
-;;; gf_3vect_dot_prod_avx2_gfni(len, vec, *g_tbls, **buffs, **dests);
+;;; gf_4vect_dot_prod_avx2_gfni(len, vec, *g_tbls, **buffs, **dests);
 ;;;
 
 %include "reg_sizes.asm"
@@ -36,11 +36,11 @@
 %include "memcpy.asm"
 
 %ifidn __OUTPUT_FORMAT__, elf64
- %define arg0  rdi
- %define arg1  rsi
- %define arg2  rdx
- %define arg3  rcx
- %define arg4  r8
+ %define arg0  rdi      ; len
+ %define arg1  rsi      ; vec
+ %define arg2  rdx      ; g_tbls
+ %define arg3  rcx      ; buffs
+ %define arg4  r8       ; dests
  %define arg5  r9
 
  %define tmp   r11
@@ -53,7 +53,7 @@
  %define stack_size  4*8
  %define func(x) x: endbranch
  %macro FUNC_SAVE 0
-    sub	    rsp, stack_size
+    sub     rsp, stack_size
     mov     [rsp + 0*8], r12
     mov     [rsp + 1*8], r13
     mov     [rsp + 2*8], r14
@@ -82,7 +82,7 @@
  %define tmp4   r14     ; must be saved and restored
  %define tmp5   rdi     ; must be saved and restored
  %define tmp6   rsi     ; must be saved and restored
- %define stack_size  8*16 + 7*8     ; must be an odd multiple of 8
+ %define stack_size  10*16 + 7*8     ; must be an odd multiple of 8
  %define arg(x)      [rsp + stack_size + 8 + 8*x]
 
  %define func(x) proc_frame x
@@ -96,31 +96,35 @@
     vmovdqa [rsp + 5*16], xmm11
     vmovdqa [rsp + 6*16], xmm12
     vmovdqa [rsp + 7*16], xmm13
-    mov     [rsp + 8*16 + 0*8], r12
-    mov     [rsp + 8*16 + 1*8], r13
-    mov     [rsp + 8*16 + 2*8], r14
-    mov     [rsp + 8*16 + 3*8], r15
-    mov     [rsp + 8*16 + 4*8], rdi
-    mov     [rsp + 8*16 + 5*8], rsi
+    vmovdqa [rsp + 8*16], xmm14
+    vmovdqa [rsp + 9*16], xmm15
+    mov     [rsp + 10*16 + 0*8], r12
+    mov     [rsp + 10*16 + 1*8], r13
+    mov     [rsp + 10*16 + 2*8], r14
+    mov     [rsp + 10*16 + 3*8], r15
+    mov     [rsp + 10*16 + 4*8], rdi
+    mov     [rsp + 10*16 + 5*8], rsi
     end_prolog
     mov     arg4, arg(4)
  %endmacro
 
  %macro FUNC_RESTORE 0
-    vmovdqa xmm6, [rsp + 0*16]
-    vmovdqa xmm7, [rsp + 1*16]
-    vmovdqa xmm8, [rsp + 2*16]
-    vmovdqa xmm9, [rsp + 3*16]
+    vmovdqa xmm6,  [rsp + 0*16]
+    vmovdqa xmm7,  [rsp + 1*16]
+    vmovdqa xmm8,  [rsp + 2*16]
+    vmovdqa xmm9,  [rsp + 3*16]
     vmovdqa xmm10, [rsp + 4*16]
     vmovdqa xmm11, [rsp + 5*16]
     vmovdqa xmm12, [rsp + 6*16]
     vmovdqa xmm13, [rsp + 7*16]
-    mov     r12,  [rsp + 8*16 + 0*8]
-    mov     r13,  [rsp + 8*16 + 1*8]
-    mov     r14,  [rsp + 8*16 + 2*8]
-    mov     r15,  [rsp + 8*16 + 3*8]
-    mov     rdi,  [rsp + 8*16 + 4*8]
-    mov     rsi,  [rsp + 8*16 + 5*8]
+    vmovdqa xmm14, [rsp + 8*16]
+    vmovdqa xmm15, [rsp + 9*16]
+    mov     r12,  [rsp + 10*16 + 0*8]
+    mov     r13,  [rsp + 10*16 + 1*8]
+    mov     r14,  [rsp + 10*16 + 2*8]
+    mov     r15,  [rsp + 10*16 + 3*8]
+    mov     rdi,  [rsp + 10*16 + 4*8]
+    mov     rsi,  [rsp + 10*16 + 5*8]
     add     rsp, stack_size
  %endmacro
 %endif
@@ -130,12 +134,13 @@
 %define vec    arg1
 %define mul_array arg2
 %define src    arg3
-%define dest   arg4
+%define dest1  arg4
 %define ptr    arg5
 %define vec_i  tmp2
 %define dest2  tmp3
 %define dest3  tmp4
-%define dest1  tmp5
+%define dest4  tmp5
+%define vskip3 tmp6
 %define pos    rax
 
 %ifndef EC_ALIGNED_ADDR
@@ -153,28 +158,29 @@
  %endif
 %endif
 
-%define x0l ymm0
-%define x0h ymm1
-
-%define xgft1   ymm8
-%define xgft2   ymm9
-%define xgft3   ymm10
-
-%define xtmp1   ymm11
-%define xtmp2   ymm12
-%define xtmp3   ymm13
+%define x0l     ymm0
+%define x0h     ymm1
 
 %define xp1l    ymm2
 %define xp2l    ymm3
 %define xp3l    ymm4
-%define xp1h    ymm5
-%define xp2h    ymm6
-%define xp3h    ymm7
+%define xp4l    ymm5
+%define xp1h    ymm6
+%define xp2h    ymm7
+%define xp3h    ymm8
+%define xp4h    ymm9
+%define xgft1   ymm10
+%define xgft2   ymm11
+%define xgft3   ymm12
+%define xgft4   ymm13
+%define xtmp1   ymm14
+%define xtmp2   ymm15
 
 %define x0      x0l
 %define xp1     xp1l
 %define xp2     xp2l
 %define xp3     xp3l
+%define xp4     xp4l
 
 default rel
 [bits 64]
@@ -182,15 +188,17 @@ default rel
 section .text
 
 ;;
-;; Encodes 64 bytes of all "k" sources into 3x 64 bytes (parity disks)
+;; Encodes 64 bytes of all "k" sources into 4x 64 bytes (parity disks)
 ;;
-%macro ENCODE_64B_3 0
+%macro ENCODE_64B_4 0
     vpxor   xp1l, xp1l, xp1l
     vpxor   xp1h, xp1h, xp1h
     vpxor   xp2l, xp2l, xp2l
     vpxor   xp2h, xp2h, xp2h
     vpxor   xp3l, xp3l, xp3l
     vpxor   xp3h, xp3h, xp3h
+    vpxor   xp4l, xp4l, xp4l
+    vpxor   xp4h, xp4h, xp4h
     mov     tmp, mul_array
     xor     vec_i, vec_i
 
@@ -203,10 +211,14 @@ section .text
     vmovdqu xgft1, [tmp]
     vmovdqu xgft2, [tmp + vec*4]
     vmovdqu xgft3, [tmp + vec*8]
+    vmovdqu xgft4, [tmp + vskip3]
     add     tmp, 32
 
-    GF_MUL_XOR VEX, x0l, xgft1, xtmp1, xp1l, xgft2, xtmp2, xp2l, xgft3, xtmp3, xp3l
-    GF_MUL_XOR VEX, x0h, xgft1, xgft1, xp1h, xgft2, xgft2, xp2h, xgft3, xgft3, xp3h
+    GF_MUL_XOR VEX, x0l, xgft1, xtmp1, xp1l, xgft2, xtmp2, xp2l
+    GF_MUL_XOR VEX, x0l, xgft3, xtmp1, xp3l, xgft4, xtmp2, xp4l
+
+    GF_MUL_XOR VEX, x0h, xgft1, xgft1, xp1h, xgft2, xgft2, xp2h, \
+                         xgft3, xgft3, xp3h, xgft4, xgft4, xp4h
 
     cmp     vec_i, vec
     jl      %%next_vect
@@ -217,29 +229,34 @@ section .text
     XSTR    [dest2 + pos + 32], xp2h
     XSTR    [dest3 + pos], xp3l
     XSTR    [dest3 + pos + 32], xp3h
+    XSTR    [dest4 + pos], xp4l
+    XSTR    [dest4 + pos + 32], xp4h
 %endmacro
 
 ;;
-;; Encodes 32 bytes of all "k" sources into 3x 32 bytes (parity disks)
+;; Encodes 32 bytes of all "k" sources into 4x 32 bytes (parity disks)
 ;;
-%macro ENCODE_32B_3 0
+%macro ENCODE_32B_4 0
     vpxor   xp1, xp1, xp1
     vpxor   xp2, xp2, xp2
     vpxor   xp3, xp3, xp3
+    vpxor   xp4, xp4, xp4
     mov     tmp, mul_array
     xor     vec_i, vec_i
 
 %%next_vect:
     mov     ptr, [src + vec_i]
     XLDR    x0, [ptr + pos]     ;Get next source vector (32 bytes)
-    add	    vec_i, 8
+    add     vec_i, 8
 
     vmovdqu xgft1, [tmp]
     vmovdqu xgft2, [tmp + vec*4]
     vmovdqu xgft3, [tmp + vec*8]
+    vmovdqu xgft4, [tmp + vskip3]
     add     tmp, 32
 
-    GF_MUL_XOR VEX, x0, xgft1, xgft1, xp1, xgft2, xgft2, xp2, xgft3, xgft3, xp3
+    GF_MUL_XOR VEX, x0, xgft1, xgft1, xp1, xgft2, xgft2, xp2, \
+                       xgft3, xgft3, xp3, xgft4, xgft4, xp4
 
     cmp     vec_i, vec
     jl      %%next_vect
@@ -247,31 +264,36 @@ section .text
     XSTR    [dest1 + pos], xp1
     XSTR    [dest2 + pos], xp2
     XSTR    [dest3 + pos], xp3
+    XSTR    [dest4 + pos], xp4
 %endmacro
 
 ;;
-;; Encodes less than 32 bytes of all "k" sources into 3 parity disks
+;; Encodes less than 32 bytes of all "k" sources into 4 parity disks.
 ;;
-%macro ENCODE_LT_32B_3 1
+%macro ENCODE_LT_32B_4 1
 %define %%LEN   %1
 
     vpxor   xp1, xp1, xp1
     vpxor   xp2, xp2, xp2
     vpxor   xp3, xp3, xp3
+    vpxor   xp4, xp4, xp4
     xor     vec_i, vec_i
 
 %%next_vect:
     mov     ptr, [src + vec_i]
-    simd_load_avx2 x0, ptr + pos, %%LEN, tmp, tmp6 ;Get next source vector
-
+    simd_load_avx2 x0, ptr + pos, %%LEN, tmp, vskip3
+    imul    vskip3, vec, 12             ;; restore vskip3 (clobbered by simd_load);
+                                        ;; vec is pre-shifted by 3, so vec*12 = parity-row-3 stride.
     lea     tmp, [mul_array + vec_i*4]
     add     vec_i, 8
 
     vmovdqu xgft1, [tmp]
     vmovdqu xgft2, [tmp + vec*4]
     vmovdqu xgft3, [tmp + vec*8]
+    vmovdqu xgft4, [tmp + vskip3]
 
-    GF_MUL_XOR VEX, x0, xgft1, xgft1, xp1, xgft2, xgft2, xp2, xgft3, xgft3, xp3
+    GF_MUL_XOR VEX, x0, xgft1, xgft1, xp1, xgft2, xgft2, xp2, \
+                       xgft3, xgft3, xp3, xgft4, xgft4, xp4
 
     cmp     vec_i, vec
     jl      %%next_vect
@@ -285,24 +307,30 @@ section .text
 
     lea     ptr, [dest3 + pos]
     simd_store_avx2 ptr, xp3, %%LEN, tmp, vec_i
+
+    lea     ptr, [dest4 + pos]
+    simd_store_avx2 ptr, xp4, %%LEN, tmp, vec_i
 %endmacro
 
 align 16
-mk_global gf_3vect_dot_prod_avx2_gfni, function
-func(gf_3vect_dot_prod_avx2_gfni)
+mk_global gf_4vect_dot_prod_avx2_gfni, function
+func(gf_4vect_dot_prod_avx2_gfni)
     FUNC_SAVE
 
     xor     pos, pos
-    shl     vec, 3      ;; vec *= 8. Make vec_i count by 8
-    mov     dest1, [dest]
-    mov     dest2, [dest + 8]
-    mov     dest3, [dest + 2*8]
+    mov     vskip3, vec
+    imul    vskip3, 32*3                ;; vskip3 = vec*96 (parity-row-3 stride)
+    shl     vec, 3                      ;; vec *= 8. Make vec_i count by 8
+    mov     dest2, [dest1 + 8]
+    mov     dest3, [dest1 + 2*8]
+    mov     dest4, [dest1 + 3*8]
+    mov     dest1, [dest1]
 
     cmp     len, 64
     jl      .len_lt_64
 
 .loop64:
-    ENCODE_64B_3
+    ENCODE_64B_4
 
     add     pos, 64     ;; Loop on 64 bytes at a time first
     sub     len, 64
@@ -313,7 +341,7 @@ func(gf_3vect_dot_prod_avx2_gfni)
     cmp     len, 32
     jl      .len_lt_32
 
-    ENCODE_32B_3
+    ENCODE_32B_4
 
     add     pos, 32     ;; encode next 32 bytes
     sub     len, 32
@@ -322,7 +350,7 @@ func(gf_3vect_dot_prod_avx2_gfni)
     or     len, len
     jz     .exit
 
-    ENCODE_LT_32B_3 len
+    ENCODE_LT_32B_4 len
 
 .exit:
     vzeroupper

--- a/erasure_code/gf_5vect_dot_prod_avx2_gfni.asm
+++ b/erasure_code/gf_5vect_dot_prod_avx2_gfni.asm
@@ -1,5 +1,5 @@
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;1;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;  Copyright(c) 2023 Intel Corporation All rights reserved.
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;  Copyright(c) 2026 Alibaba Group All rights reserved.
 ;
 ;  Redistribution and use in source and binary forms, with or without
 ;  modification, are permitted provided that the following conditions
@@ -10,7 +10,7 @@
 ;      notice, this list of conditions and the following disclaimer in
 ;      the documentation and/or other materials provided with the
 ;      distribution.
-;    * Neither the name of Intel Corporation nor the names of its
+;    * Neither the name of Alibaba Group nor the names of its
 ;      contributors may be used to endorse or promote products derived
 ;      from this software without specific prior written permission.
 ;
@@ -28,7 +28,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;
-;;; gf_3vect_dot_prod_avx2_gfni(len, vec, *g_tbls, **buffs, **dests);
+;;; gf_5vect_dot_prod_avx2_gfni(len, vec, *g_tbls, **buffs, **dests);
 ;;;
 
 %include "reg_sizes.asm"
@@ -36,11 +36,11 @@
 %include "memcpy.asm"
 
 %ifidn __OUTPUT_FORMAT__, elf64
- %define arg0  rdi
- %define arg1  rsi
- %define arg2  rdx
- %define arg3  rcx
- %define arg4  r8
+ %define arg0  rdi      ; len
+ %define arg1  rsi      ; vec
+ %define arg2  rdx      ; g_tbls
+ %define arg3  rcx      ; buffs
+ %define arg4  r8       ; dests
  %define arg5  r9
 
  %define tmp   r11
@@ -49,21 +49,27 @@
  %define tmp4  r12      ; must be saved and restored
  %define tmp5  r14      ; must be saved and restored
  %define tmp6  r15      ; must be saved and restored
+ %define tmp7  rbp      ; must be saved and restored
+ %define tmp8  rbx      ; must be saved and restored
 
- %define stack_size  4*8
+ %define stack_size  6*8
  %define func(x) x: endbranch
  %macro FUNC_SAVE 0
-    sub	    rsp, stack_size
+    sub     rsp, stack_size
     mov     [rsp + 0*8], r12
     mov     [rsp + 1*8], r13
     mov     [rsp + 2*8], r14
     mov     [rsp + 3*8], r15
+    mov     [rsp + 4*8], rbp
+    mov     [rsp + 5*8], rbx
  %endmacro
  %macro FUNC_RESTORE 0
     mov     r12, [rsp + 0*8]
     mov     r13, [rsp + 1*8]
     mov     r14, [rsp + 2*8]
     mov     r15, [rsp + 3*8]
+    mov     rbp, [rsp + 4*8]
+    mov     rbx, [rsp + 5*8]
     add     rsp, stack_size
  %endmacro
 %endif
@@ -82,7 +88,9 @@
  %define tmp4   r14     ; must be saved and restored
  %define tmp5   rdi     ; must be saved and restored
  %define tmp6   rsi     ; must be saved and restored
- %define stack_size  8*16 + 7*8     ; must be an odd multiple of 8
+ %define tmp7   rbp     ; must be saved and restored
+ %define tmp8   rbx     ; must be saved and restored
+ %define stack_size  5*16 + 9*8      ; must be an odd multiple of 8
  %define arg(x)      [rsp + stack_size + 8 + 8*x]
 
  %define func(x) proc_frame x
@@ -93,34 +101,32 @@
     vmovdqa [rsp + 2*16], xmm8
     vmovdqa [rsp + 3*16], xmm9
     vmovdqa [rsp + 4*16], xmm10
-    vmovdqa [rsp + 5*16], xmm11
-    vmovdqa [rsp + 6*16], xmm12
-    vmovdqa [rsp + 7*16], xmm13
-    mov     [rsp + 8*16 + 0*8], r12
-    mov     [rsp + 8*16 + 1*8], r13
-    mov     [rsp + 8*16 + 2*8], r14
-    mov     [rsp + 8*16 + 3*8], r15
-    mov     [rsp + 8*16 + 4*8], rdi
-    mov     [rsp + 8*16 + 5*8], rsi
+    mov     [rsp + 5*16 + 0*8], r12
+    mov     [rsp + 5*16 + 1*8], r13
+    mov     [rsp + 5*16 + 2*8], r14
+    mov     [rsp + 5*16 + 3*8], r15
+    mov     [rsp + 5*16 + 4*8], rdi
+    mov     [rsp + 5*16 + 5*8], rsi
+    mov     [rsp + 5*16 + 6*8], rbp
+    mov     [rsp + 5*16 + 7*8], rbx
     end_prolog
     mov     arg4, arg(4)
  %endmacro
 
  %macro FUNC_RESTORE 0
-    vmovdqa xmm6, [rsp + 0*16]
-    vmovdqa xmm7, [rsp + 1*16]
-    vmovdqa xmm8, [rsp + 2*16]
-    vmovdqa xmm9, [rsp + 3*16]
+    vmovdqa xmm6,  [rsp + 0*16]
+    vmovdqa xmm7,  [rsp + 1*16]
+    vmovdqa xmm8,  [rsp + 2*16]
+    vmovdqa xmm9,  [rsp + 3*16]
     vmovdqa xmm10, [rsp + 4*16]
-    vmovdqa xmm11, [rsp + 5*16]
-    vmovdqa xmm12, [rsp + 6*16]
-    vmovdqa xmm13, [rsp + 7*16]
-    mov     r12,  [rsp + 8*16 + 0*8]
-    mov     r13,  [rsp + 8*16 + 1*8]
-    mov     r14,  [rsp + 8*16 + 2*8]
-    mov     r15,  [rsp + 8*16 + 3*8]
-    mov     rdi,  [rsp + 8*16 + 4*8]
-    mov     rsi,  [rsp + 8*16 + 5*8]
+    mov     r12,  [rsp + 5*16 + 0*8]
+    mov     r13,  [rsp + 5*16 + 1*8]
+    mov     r14,  [rsp + 5*16 + 2*8]
+    mov     r15,  [rsp + 5*16 + 3*8]
+    mov     rdi,  [rsp + 5*16 + 4*8]
+    mov     rsi,  [rsp + 5*16 + 5*8]
+    mov     rbp,  [rsp + 5*16 + 6*8]
+    mov     rbx,  [rsp + 5*16 + 7*8]
     add     rsp, stack_size
  %endmacro
 %endif
@@ -130,12 +136,15 @@
 %define vec    arg1
 %define mul_array arg2
 %define src    arg3
-%define dest   arg4
+%define dest1  arg4
 %define ptr    arg5
 %define vec_i  tmp2
 %define dest2  tmp3
 %define dest3  tmp4
-%define dest1  tmp5
+%define dest4  tmp5
+%define vskip3 tmp6
+%define dest5  tmp7
+%define vskip4 tmp8
 %define pos    rax
 
 %ifndef EC_ALIGNED_ADDR
@@ -153,28 +162,19 @@
  %endif
 %endif
 
-%define x0l ymm0
-%define x0h ymm1
+%define x0      ymm0
 
-%define xgft1   ymm8
-%define xgft2   ymm9
-%define xgft3   ymm10
+%define xp1     ymm1
+%define xp2     ymm2
+%define xp3     ymm3
+%define xp4     ymm4
+%define xp5     ymm5
 
-%define xtmp1   ymm11
-%define xtmp2   ymm12
-%define xtmp3   ymm13
-
-%define xp1l    ymm2
-%define xp2l    ymm3
-%define xp3l    ymm4
-%define xp1h    ymm5
-%define xp2h    ymm6
-%define xp3h    ymm7
-
-%define x0      x0l
-%define xp1     xp1l
-%define xp2     xp2l
-%define xp3     xp3l
+%define xgft1   ymm6
+%define xgft2   ymm7
+%define xgft3   ymm8
+%define xgft4   ymm9
+%define xgft5   ymm10
 
 default rel
 [bits 64]
@@ -182,64 +182,32 @@ default rel
 section .text
 
 ;;
-;; Encodes 64 bytes of all "k" sources into 3x 64 bytes (parity disks)
+;; Encodes 32 bytes of all "k" sources into 5x 32 bytes (parity disks).
 ;;
-%macro ENCODE_64B_3 0
-    vpxor   xp1l, xp1l, xp1l
-    vpxor   xp1h, xp1h, xp1h
-    vpxor   xp2l, xp2l, xp2l
-    vpxor   xp2h, xp2h, xp2h
-    vpxor   xp3l, xp3l, xp3l
-    vpxor   xp3h, xp3h, xp3h
+%macro ENCODE_32B_5 0
+    vpxor   xp1, xp1, xp1
+    vpxor   xp2, xp2, xp2
+    vpxor   xp3, xp3, xp3
+    vpxor   xp4, xp4, xp4
+    vpxor   xp5, xp5, xp5
     mov     tmp, mul_array
     xor     vec_i, vec_i
 
 %%next_vect:
     mov     ptr, [src + vec_i]
-    XLDR    x0l, [ptr + pos]        ;; Get next source vector low 32 bytes
-    XLDR    x0h, [ptr + pos + 32]   ;; Get next source vector high 32 bytes
+    XLDR    x0, [ptr + pos]             ;Get next source vector (32 bytes)
     add     vec_i, 8
 
     vmovdqu xgft1, [tmp]
     vmovdqu xgft2, [tmp + vec*4]
     vmovdqu xgft3, [tmp + vec*8]
+    vmovdqu xgft4, [tmp + vskip3]
+    vmovdqu xgft5, [tmp + vskip4]
     add     tmp, 32
 
-    GF_MUL_XOR VEX, x0l, xgft1, xtmp1, xp1l, xgft2, xtmp2, xp2l, xgft3, xtmp3, xp3l
-    GF_MUL_XOR VEX, x0h, xgft1, xgft1, xp1h, xgft2, xgft2, xp2h, xgft3, xgft3, xp3h
-
-    cmp     vec_i, vec
-    jl      %%next_vect
-
-    XSTR    [dest1 + pos], xp1l
-    XSTR    [dest1 + pos + 32], xp1h
-    XSTR    [dest2 + pos], xp2l
-    XSTR    [dest2 + pos + 32], xp2h
-    XSTR    [dest3 + pos], xp3l
-    XSTR    [dest3 + pos + 32], xp3h
-%endmacro
-
-;;
-;; Encodes 32 bytes of all "k" sources into 3x 32 bytes (parity disks)
-;;
-%macro ENCODE_32B_3 0
-    vpxor   xp1, xp1, xp1
-    vpxor   xp2, xp2, xp2
-    vpxor   xp3, xp3, xp3
-    mov     tmp, mul_array
-    xor     vec_i, vec_i
-
-%%next_vect:
-    mov     ptr, [src + vec_i]
-    XLDR    x0, [ptr + pos]     ;Get next source vector (32 bytes)
-    add	    vec_i, 8
-
-    vmovdqu xgft1, [tmp]
-    vmovdqu xgft2, [tmp + vec*4]
-    vmovdqu xgft3, [tmp + vec*8]
-    add     tmp, 32
-
-    GF_MUL_XOR VEX, x0, xgft1, xgft1, xp1, xgft2, xgft2, xp2, xgft3, xgft3, xp3
+    GF_MUL_XOR VEX, x0, xgft1, xgft1, xp1, xgft2, xgft2, xp2, \
+                       xgft3, xgft3, xp3, xgft4, xgft4, xp4, \
+                       xgft5, xgft5, xp5
 
     cmp     vec_i, vec
     jl      %%next_vect
@@ -247,22 +215,27 @@ section .text
     XSTR    [dest1 + pos], xp1
     XSTR    [dest2 + pos], xp2
     XSTR    [dest3 + pos], xp3
+    XSTR    [dest4 + pos], xp4
+    XSTR    [dest5 + pos], xp5
 %endmacro
 
 ;;
-;; Encodes less than 32 bytes of all "k" sources into 3 parity disks
+;; Encodes less than 32 bytes of all "k" sources into 5 parity disks.
 ;;
-%macro ENCODE_LT_32B_3 1
+%macro ENCODE_LT_32B_5 1
 %define %%LEN   %1
 
     vpxor   xp1, xp1, xp1
     vpxor   xp2, xp2, xp2
     vpxor   xp3, xp3, xp3
+    vpxor   xp4, xp4, xp4
+    vpxor   xp5, xp5, xp5
     xor     vec_i, vec_i
 
 %%next_vect:
     mov     ptr, [src + vec_i]
-    simd_load_avx2 x0, ptr + pos, %%LEN, tmp, tmp6 ;Get next source vector
+    simd_load_avx2 x0, ptr + pos, %%LEN, tmp, vskip3 ;Get next source vector
+    imul    vskip3, vec, 12             ;; restore vskip3 (clobbered by simd_load)
 
     lea     tmp, [mul_array + vec_i*4]
     add     vec_i, 8
@@ -270,8 +243,12 @@ section .text
     vmovdqu xgft1, [tmp]
     vmovdqu xgft2, [tmp + vec*4]
     vmovdqu xgft3, [tmp + vec*8]
+    vmovdqu xgft4, [tmp + vskip3]
+    vmovdqu xgft5, [tmp + vskip4]
 
-    GF_MUL_XOR VEX, x0, xgft1, xgft1, xp1, xgft2, xgft2, xp2, xgft3, xgft3, xp3
+    GF_MUL_XOR VEX, x0, xgft1, xgft1, xp1, xgft2, xgft2, xp2, \
+                       xgft3, xgft3, xp3, xgft4, xgft4, xp4, \
+                       xgft5, xgft5, xp5
 
     cmp     vec_i, vec
     jl      %%next_vect
@@ -285,44 +262,47 @@ section .text
 
     lea     ptr, [dest3 + pos]
     simd_store_avx2 ptr, xp3, %%LEN, tmp, vec_i
+
+    lea     ptr, [dest4 + pos]
+    simd_store_avx2 ptr, xp4, %%LEN, tmp, vec_i
+
+    lea     ptr, [dest5 + pos]
+    simd_store_avx2 ptr, xp5, %%LEN, tmp, vec_i
 %endmacro
 
 align 16
-mk_global gf_3vect_dot_prod_avx2_gfni, function
-func(gf_3vect_dot_prod_avx2_gfni)
+mk_global gf_5vect_dot_prod_avx2_gfni, function
+func(gf_5vect_dot_prod_avx2_gfni)
     FUNC_SAVE
 
     xor     pos, pos
-    shl     vec, 3      ;; vec *= 8. Make vec_i count by 8
-    mov     dest1, [dest]
-    mov     dest2, [dest + 8]
-    mov     dest3, [dest + 2*8]
+    mov     vskip3, vec
+    imul    vskip3, 32*3                ;; vskip3 = vec*96 (parity-row-3 stride)
+    mov     vskip4, vec
+    imul    vskip4, 32*4                ;; vskip4 = vec*128 (parity-row-4 stride)
+    shl     vec, 3                      ;; vec *= 8. Make vec_i count by 8
+    mov     dest2, [dest1 + 8]
+    mov     dest3, [dest1 + 2*8]
+    mov     dest4, [dest1 + 3*8]
+    mov     dest5, [dest1 + 4*8]
+    mov     dest1, [dest1]
 
-    cmp     len, 64
-    jl      .len_lt_64
-
-.loop64:
-    ENCODE_64B_3
-
-    add     pos, 64     ;; Loop on 64 bytes at a time first
-    sub     len, 64
-    cmp     len, 64
-    jge     .loop64
-
-.len_lt_64:
     cmp     len, 32
     jl      .len_lt_32
 
-    ENCODE_32B_3
+.loop32:
+    ENCODE_32B_5
 
     add     pos, 32     ;; encode next 32 bytes
     sub     len, 32
+    cmp     len, 32
+    jge     .loop32
 
 .len_lt_32:
-    or     len, len
-    jz     .exit
+    or      len, len
+    jz      .exit
 
-    ENCODE_LT_32B_3 len
+    ENCODE_LT_32B_5 len
 
 .exit:
     vzeroupper

--- a/erasure_code/gf_6vect_dot_prod_avx2_gfni.asm
+++ b/erasure_code/gf_6vect_dot_prod_avx2_gfni.asm
@@ -1,5 +1,5 @@
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;1;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;  Copyright(c) 2023 Intel Corporation All rights reserved.
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;  Copyright(c) 2026 Alibaba Group All rights reserved.
 ;
 ;  Redistribution and use in source and binary forms, with or without
 ;  modification, are permitted provided that the following conditions
@@ -10,7 +10,7 @@
 ;      notice, this list of conditions and the following disclaimer in
 ;      the documentation and/or other materials provided with the
 ;      distribution.
-;    * Neither the name of Intel Corporation nor the names of its
+;    * Neither the name of Alibaba Group nor the names of its
 ;      contributors may be used to endorse or promote products derived
 ;      from this software without specific prior written permission.
 ;
@@ -28,7 +28,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;;;
-;;; gf_3vect_dot_prod_avx2_gfni(len, vec, *g_tbls, **buffs, **dests);
+;;; gf_6vect_dot_prod_avx2_gfni(len, vec, *g_tbls, **buffs, **dests);
 ;;;
 
 %include "reg_sizes.asm"
@@ -36,11 +36,11 @@
 %include "memcpy.asm"
 
 %ifidn __OUTPUT_FORMAT__, elf64
- %define arg0  rdi
- %define arg1  rsi
- %define arg2  rdx
- %define arg3  rcx
- %define arg4  r8
+ %define arg0  rdi      ; len
+ %define arg1  rsi      ; vec
+ %define arg2  rdx      ; g_tbls
+ %define arg3  rcx      ; buffs
+ %define arg4  r8       ; dests
  %define arg5  r9
 
  %define tmp   r11
@@ -49,21 +49,27 @@
  %define tmp4  r12      ; must be saved and restored
  %define tmp5  r14      ; must be saved and restored
  %define tmp6  r15      ; must be saved and restored
+ %define tmp7  rbp      ; must be saved and restored
+ %define tmp8  rbx      ; must be saved and restored
 
- %define stack_size  4*8
+ %define stack_size  6*8
  %define func(x) x: endbranch
  %macro FUNC_SAVE 0
-    sub	    rsp, stack_size
+    sub     rsp, stack_size
     mov     [rsp + 0*8], r12
     mov     [rsp + 1*8], r13
     mov     [rsp + 2*8], r14
     mov     [rsp + 3*8], r15
+    mov     [rsp + 4*8], rbp
+    mov     [rsp + 5*8], rbx
  %endmacro
  %macro FUNC_RESTORE 0
     mov     r12, [rsp + 0*8]
     mov     r13, [rsp + 1*8]
     mov     r14, [rsp + 2*8]
     mov     r15, [rsp + 3*8]
+    mov     rbp, [rsp + 4*8]
+    mov     rbx, [rsp + 5*8]
     add     rsp, stack_size
  %endmacro
 %endif
@@ -82,7 +88,9 @@
  %define tmp4   r14     ; must be saved and restored
  %define tmp5   rdi     ; must be saved and restored
  %define tmp6   rsi     ; must be saved and restored
- %define stack_size  8*16 + 7*8     ; must be an odd multiple of 8
+ %define tmp7   rbp     ; must be saved and restored
+ %define tmp8   rbx     ; must be saved and restored
+ %define stack_size  7*16 + 9*8      ; must be an odd multiple of 8
  %define arg(x)      [rsp + stack_size + 8 + 8*x]
 
  %define func(x) proc_frame x
@@ -95,32 +103,34 @@
     vmovdqa [rsp + 4*16], xmm10
     vmovdqa [rsp + 5*16], xmm11
     vmovdqa [rsp + 6*16], xmm12
-    vmovdqa [rsp + 7*16], xmm13
-    mov     [rsp + 8*16 + 0*8], r12
-    mov     [rsp + 8*16 + 1*8], r13
-    mov     [rsp + 8*16 + 2*8], r14
-    mov     [rsp + 8*16 + 3*8], r15
-    mov     [rsp + 8*16 + 4*8], rdi
-    mov     [rsp + 8*16 + 5*8], rsi
+    mov     [rsp + 7*16 + 0*8], r12
+    mov     [rsp + 7*16 + 1*8], r13
+    mov     [rsp + 7*16 + 2*8], r14
+    mov     [rsp + 7*16 + 3*8], r15
+    mov     [rsp + 7*16 + 4*8], rdi
+    mov     [rsp + 7*16 + 5*8], rsi
+    mov     [rsp + 7*16 + 6*8], rbp
+    mov     [rsp + 7*16 + 7*8], rbx
     end_prolog
     mov     arg4, arg(4)
  %endmacro
 
  %macro FUNC_RESTORE 0
-    vmovdqa xmm6, [rsp + 0*16]
-    vmovdqa xmm7, [rsp + 1*16]
-    vmovdqa xmm8, [rsp + 2*16]
-    vmovdqa xmm9, [rsp + 3*16]
+    vmovdqa xmm6,  [rsp + 0*16]
+    vmovdqa xmm7,  [rsp + 1*16]
+    vmovdqa xmm8,  [rsp + 2*16]
+    vmovdqa xmm9,  [rsp + 3*16]
     vmovdqa xmm10, [rsp + 4*16]
     vmovdqa xmm11, [rsp + 5*16]
     vmovdqa xmm12, [rsp + 6*16]
-    vmovdqa xmm13, [rsp + 7*16]
-    mov     r12,  [rsp + 8*16 + 0*8]
-    mov     r13,  [rsp + 8*16 + 1*8]
-    mov     r14,  [rsp + 8*16 + 2*8]
-    mov     r15,  [rsp + 8*16 + 3*8]
-    mov     rdi,  [rsp + 8*16 + 4*8]
-    mov     rsi,  [rsp + 8*16 + 5*8]
+    mov     r12,  [rsp + 7*16 + 0*8]
+    mov     r13,  [rsp + 7*16 + 1*8]
+    mov     r14,  [rsp + 7*16 + 2*8]
+    mov     r15,  [rsp + 7*16 + 3*8]
+    mov     rdi,  [rsp + 7*16 + 4*8]
+    mov     rsi,  [rsp + 7*16 + 5*8]
+    mov     rbp,  [rsp + 7*16 + 6*8]
+    mov     rbx,  [rsp + 7*16 + 7*8]
     add     rsp, stack_size
  %endmacro
 %endif
@@ -130,12 +140,15 @@
 %define vec    arg1
 %define mul_array arg2
 %define src    arg3
-%define dest   arg4
+%define dest1  arg4
 %define ptr    arg5
 %define vec_i  tmp2
 %define dest2  tmp3
 %define dest3  tmp4
-%define dest1  tmp5
+%define dest4  tmp5
+%define vskip3 tmp6
+%define dest5  tmp7
+%define dest6  tmp8
 %define pos    rax
 
 %ifndef EC_ALIGNED_ADDR
@@ -153,28 +166,21 @@
  %endif
 %endif
 
-%define x0l ymm0
-%define x0h ymm1
+%define x0      ymm0
 
-%define xgft1   ymm8
-%define xgft2   ymm9
-%define xgft3   ymm10
+%define xp1     ymm1
+%define xp2     ymm2
+%define xp3     ymm3
+%define xp4     ymm4
+%define xp5     ymm5
+%define xp6     ymm6
 
-%define xtmp1   ymm11
-%define xtmp2   ymm12
-%define xtmp3   ymm13
-
-%define xp1l    ymm2
-%define xp2l    ymm3
-%define xp3l    ymm4
-%define xp1h    ymm5
-%define xp2h    ymm6
-%define xp3h    ymm7
-
-%define x0      x0l
-%define xp1     xp1l
-%define xp2     xp2l
-%define xp3     xp3l
+%define xgft1   ymm7
+%define xgft2   ymm8
+%define xgft3   ymm9
+%define xgft4   ymm10
+%define xgft5   ymm11
+%define xgft6   ymm12
 
 default rel
 [bits 64]
@@ -182,64 +188,35 @@ default rel
 section .text
 
 ;;
-;; Encodes 64 bytes of all "k" sources into 3x 64 bytes (parity disks)
+;; Encodes 32 bytes of all "k" sources into 6x 32 bytes (parity disks).
 ;;
-%macro ENCODE_64B_3 0
-    vpxor   xp1l, xp1l, xp1l
-    vpxor   xp1h, xp1h, xp1h
-    vpxor   xp2l, xp2l, xp2l
-    vpxor   xp2h, xp2h, xp2h
-    vpxor   xp3l, xp3l, xp3l
-    vpxor   xp3h, xp3h, xp3h
-    mov     tmp, mul_array
-    xor     vec_i, vec_i
-
-%%next_vect:
-    mov     ptr, [src + vec_i]
-    XLDR    x0l, [ptr + pos]        ;; Get next source vector low 32 bytes
-    XLDR    x0h, [ptr + pos + 32]   ;; Get next source vector high 32 bytes
-    add     vec_i, 8
-
-    vmovdqu xgft1, [tmp]
-    vmovdqu xgft2, [tmp + vec*4]
-    vmovdqu xgft3, [tmp + vec*8]
-    add     tmp, 32
-
-    GF_MUL_XOR VEX, x0l, xgft1, xtmp1, xp1l, xgft2, xtmp2, xp2l, xgft3, xtmp3, xp3l
-    GF_MUL_XOR VEX, x0h, xgft1, xgft1, xp1h, xgft2, xgft2, xp2h, xgft3, xgft3, xp3h
-
-    cmp     vec_i, vec
-    jl      %%next_vect
-
-    XSTR    [dest1 + pos], xp1l
-    XSTR    [dest1 + pos + 32], xp1h
-    XSTR    [dest2 + pos], xp2l
-    XSTR    [dest2 + pos + 32], xp2h
-    XSTR    [dest3 + pos], xp3l
-    XSTR    [dest3 + pos + 32], xp3h
-%endmacro
-
-;;
-;; Encodes 32 bytes of all "k" sources into 3x 32 bytes (parity disks)
-;;
-%macro ENCODE_32B_3 0
+%macro ENCODE_32B_6 0
     vpxor   xp1, xp1, xp1
     vpxor   xp2, xp2, xp2
     vpxor   xp3, xp3, xp3
+    vpxor   xp4, xp4, xp4
+    vpxor   xp5, xp5, xp5
+    vpxor   xp6, xp6, xp6
     mov     tmp, mul_array
     xor     vec_i, vec_i
 
 %%next_vect:
     mov     ptr, [src + vec_i]
-    XLDR    x0, [ptr + pos]     ;Get next source vector (32 bytes)
-    add	    vec_i, 8
+    XLDR    x0, [ptr + pos]             ;Get next source vector (32 bytes)
+    add     vec_i, 8
 
-    vmovdqu xgft1, [tmp]
-    vmovdqu xgft2, [tmp + vec*4]
-    vmovdqu xgft3, [tmp + vec*8]
+    vmovdqu xgft1, [tmp]                ;; row 0
+    vmovdqu xgft2, [tmp + vec*4]        ;; row 1 (vec is pre-shifted ×8, so vec*4 = 32*k)
+    vmovdqu xgft3, [tmp + vec*8]        ;; row 2
+    vmovdqu xgft4, [tmp + vskip3]       ;; row 3
+    lea     ptr,   [tmp + vskip3]       ;; ptr is dead here; reuse as "row 3 base"
+    vmovdqu xgft5, [ptr + vec*4]        ;; row 4 = row3 + 1 row
+    vmovdqu xgft6, [ptr + vec*8]        ;; row 5 = row3 + 2 rows
     add     tmp, 32
 
-    GF_MUL_XOR VEX, x0, xgft1, xgft1, xp1, xgft2, xgft2, xp2, xgft3, xgft3, xp3
+    GF_MUL_XOR VEX, x0, xgft1, xgft1, xp1, xgft2, xgft2, xp2, \
+                       xgft3, xgft3, xp3, xgft4, xgft4, xp4, \
+                       xgft5, xgft5, xp5, xgft6, xgft6, xp6
 
     cmp     vec_i, vec
     jl      %%next_vect
@@ -247,22 +224,29 @@ section .text
     XSTR    [dest1 + pos], xp1
     XSTR    [dest2 + pos], xp2
     XSTR    [dest3 + pos], xp3
+    XSTR    [dest4 + pos], xp4
+    XSTR    [dest5 + pos], xp5
+    XSTR    [dest6 + pos], xp6
 %endmacro
 
 ;;
-;; Encodes less than 32 bytes of all "k" sources into 3 parity disks
+;; Encodes less than 32 bytes of all "k" sources into 6 parity disks.
 ;;
-%macro ENCODE_LT_32B_3 1
+%macro ENCODE_LT_32B_6 1
 %define %%LEN   %1
 
     vpxor   xp1, xp1, xp1
     vpxor   xp2, xp2, xp2
     vpxor   xp3, xp3, xp3
+    vpxor   xp4, xp4, xp4
+    vpxor   xp5, xp5, xp5
+    vpxor   xp6, xp6, xp6
     xor     vec_i, vec_i
 
 %%next_vect:
     mov     ptr, [src + vec_i]
-    simd_load_avx2 x0, ptr + pos, %%LEN, tmp, tmp6 ;Get next source vector
+    simd_load_avx2 x0, ptr + pos, %%LEN, tmp, vskip3 ;Get next source vector
+    imul    vskip3, vec, 12             ;; restore vskip3 (clobbered by simd_load)
 
     lea     tmp, [mul_array + vec_i*4]
     add     vec_i, 8
@@ -270,8 +254,14 @@ section .text
     vmovdqu xgft1, [tmp]
     vmovdqu xgft2, [tmp + vec*4]
     vmovdqu xgft3, [tmp + vec*8]
+    vmovdqu xgft4, [tmp + vskip3]
+    lea     ptr, [tmp + vskip3]
+    vmovdqu xgft5, [ptr + vec*4]
+    vmovdqu xgft6, [ptr + vec*8]
 
-    GF_MUL_XOR VEX, x0, xgft1, xgft1, xp1, xgft2, xgft2, xp2, xgft3, xgft3, xp3
+    GF_MUL_XOR VEX, x0, xgft1, xgft1, xp1, xgft2, xgft2, xp2, \
+                       xgft3, xgft3, xp3, xgft4, xgft4, xp4, \
+                       xgft5, xgft5, xp5, xgft6, xgft6, xp6
 
     cmp     vec_i, vec
     jl      %%next_vect
@@ -285,44 +275,49 @@ section .text
 
     lea     ptr, [dest3 + pos]
     simd_store_avx2 ptr, xp3, %%LEN, tmp, vec_i
+
+    lea     ptr, [dest4 + pos]
+    simd_store_avx2 ptr, xp4, %%LEN, tmp, vec_i
+
+    lea     ptr, [dest5 + pos]
+    simd_store_avx2 ptr, xp5, %%LEN, tmp, vec_i
+
+    lea     ptr, [dest6 + pos]
+    simd_store_avx2 ptr, xp6, %%LEN, tmp, vec_i
 %endmacro
 
 align 16
-mk_global gf_3vect_dot_prod_avx2_gfni, function
-func(gf_3vect_dot_prod_avx2_gfni)
+mk_global gf_6vect_dot_prod_avx2_gfni, function
+func(gf_6vect_dot_prod_avx2_gfni)
     FUNC_SAVE
 
     xor     pos, pos
-    shl     vec, 3      ;; vec *= 8. Make vec_i count by 8
-    mov     dest1, [dest]
-    mov     dest2, [dest + 8]
-    mov     dest3, [dest + 2*8]
+    mov     vskip3, vec
+    imul    vskip3, 32*3                ;; vskip3 = vec*96 (parity-row-3 stride)
+    shl     vec, 3                      ;; vec *= 8. Make vec_i count by 8
+    mov     dest2, [dest1 + 8]
+    mov     dest3, [dest1 + 2*8]
+    mov     dest4, [dest1 + 3*8]
+    mov     dest5, [dest1 + 4*8]
+    mov     dest6, [dest1 + 5*8]
+    mov     dest1, [dest1]
 
-    cmp     len, 64
-    jl      .len_lt_64
-
-.loop64:
-    ENCODE_64B_3
-
-    add     pos, 64     ;; Loop on 64 bytes at a time first
-    sub     len, 64
-    cmp     len, 64
-    jge     .loop64
-
-.len_lt_64:
     cmp     len, 32
     jl      .len_lt_32
 
-    ENCODE_32B_3
+.loop32:
+    ENCODE_32B_6
 
     add     pos, 32     ;; encode next 32 bytes
     sub     len, 32
+    cmp     len, 32
+    jge     .loop32
 
 .len_lt_32:
-    or     len, len
-    jz     .exit
+    or      len, len
+    jz      .exit
 
-    ENCODE_LT_32B_3 len
+    ENCODE_LT_32B_6 len
 
 .exit:
     vzeroupper

--- a/erasure_code/gf_6vect_mad_avx2_gfni.asm
+++ b/erasure_code/gf_6vect_mad_avx2_gfni.asm
@@ -1,0 +1,274 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;  Copyright(c) 2026 Alibaba Group All rights reserved.
+;
+;  Redistribution and use in source and binary forms, with or without
+;  modification, are permitted provided that the following conditions
+;  are met:
+;    * Redistributions of source code must retain the above copyright
+;      notice, this list of conditions and the following disclaimer.
+;    * Redistributions in binary form must reproduce the above copyright
+;      notice, this list of conditions and the following disclaimer in
+;      the documentation and/or other materials provided with the
+;      distribution.
+;    * Neither the name of Alibaba Group nor the names of its
+;      contributors may be used to endorse or promote products derived
+;      from this software without specific prior written permission.
+;
+;  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+;  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+;  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+;  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+;  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+;  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+;  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+;  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+;  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+;  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+;  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;
+;;; gf_6vect_mad_avx2_gfni(len, vec, vec_i, mul_array, src, dest);
+;;;
+
+%include "reg_sizes.asm"
+%include "gf_vect_gfni.inc"
+%include "memcpy.asm"
+
+%ifidn __OUTPUT_FORMAT__, elf64
+ %define arg0   rdi
+ %define arg1   rsi
+ %define arg2   rdx
+ %define arg3   rcx
+ %define arg4   r8
+ %define arg5   r9
+ %define tmp    r11
+ %define tmp2   r10
+ %define tmp3   r12
+ %define tmp4   r13
+ %define func(x) x: endbranch
+ %define stack_size  2*8
+ %macro FUNC_SAVE 0
+        sub     rsp, stack_size
+        mov     [rsp + 0*8], r12
+        mov     [rsp + 1*8], r13
+ %endmacro
+ %macro FUNC_RESTORE 0
+        mov     r12, [rsp + 0*8]
+        mov     r13, [rsp + 1*8]
+        add     rsp, stack_size
+ %endmacro
+%endif
+
+%ifidn __OUTPUT_FORMAT__, win64
+ %define arg0   rcx
+ %define arg1   rdx
+ %define arg2   r8
+ %define arg3   r9
+ %define arg4   r12     ; must be saved, loaded and restored
+ %define arg5   r13     ; must be saved and restored
+ %define tmp    r11
+ %define tmp2   r10
+ %define tmp3   r14
+ %define tmp4   r15
+ %define stack_size 16*10 + 5*8
+ %define arg(x) [rsp + stack_size + 8 + 8*x]
+ %define func(x) proc_frame x
+
+ %macro FUNC_SAVE 0
+        sub     rsp, stack_size
+        vmovdqa [rsp + 0*16], xmm6
+        vmovdqa [rsp + 1*16], xmm7
+        vmovdqa [rsp + 2*16], xmm8
+        vmovdqa [rsp + 3*16], xmm9
+        vmovdqa [rsp + 4*16], xmm10
+        vmovdqa [rsp + 5*16], xmm11
+        vmovdqa [rsp + 6*16], xmm12
+        vmovdqa [rsp + 7*16], xmm13
+        vmovdqa [rsp + 8*16], xmm14
+        vmovdqa [rsp + 9*16], xmm15
+        mov     [rsp + 10*16 + 0*8], r12
+        mov     [rsp + 10*16 + 1*8], r13
+        mov     [rsp + 10*16 + 2*8], r14
+        mov     [rsp + 10*16 + 3*8], r15
+        end_prolog
+        mov     arg4, arg(4)
+        mov     arg5, arg(5)
+ %endmacro
+
+ %macro FUNC_RESTORE 0
+        vmovdqa xmm6, [rsp + 0*16]
+        vmovdqa xmm7, [rsp + 1*16]
+        vmovdqa xmm8, [rsp + 2*16]
+        vmovdqa xmm9, [rsp + 3*16]
+        vmovdqa xmm10, [rsp + 4*16]
+        vmovdqa xmm11, [rsp + 5*16]
+        vmovdqa xmm12, [rsp + 6*16]
+        vmovdqa xmm13, [rsp + 7*16]
+        vmovdqa xmm14, [rsp + 8*16]
+        vmovdqa xmm15, [rsp + 9*16]
+        mov     r12,  [rsp + 10*16 + 0*8]
+        mov     r13,  [rsp + 10*16 + 1*8]
+        mov     r14,  [rsp + 10*16 + 2*8]
+        mov     r15,  [rsp + 10*16 + 3*8]
+        add     rsp, stack_size
+ %endmacro
+%endif
+
+%define len   arg0
+%define vec   arg1
+%define vec_i arg2
+%define mul_array arg3
+%define src   arg4
+%define dest1 arg5
+%define pos   rax
+%define dest2 mul_array
+%define dest3 vec_i
+%define dest4 tmp3
+%define dest5 tmp4
+%define dest6 vec
+
+%ifndef EC_ALIGNED_ADDR
+;;; Use Un-aligned load/store
+ %define XLDR vmovdqu
+ %define XSTR vmovdqu
+%else
+;;; Use Non-temporal load/stor
+ %ifdef NO_NT_LDST
+  %define XLDR vmovdqa
+  %define XSTR vmovdqa
+ %else
+  %define XLDR vmovntdqa
+  %define XSTR vmovntdq
+ %endif
+%endif
+
+default rel
+[bits 64]
+section .text
+
+%define x0      ymm0
+%define xd1     ymm1
+%define xd2     ymm2
+%define xd3     ymm3
+%define xd4     ymm4
+%define xd5     ymm5
+%define xd6     ymm6
+%define xgft1   ymm7
+%define xgft2   ymm8
+%define xgft3   ymm9
+%define xgft4   ymm10
+%define xgft5   ymm11
+%define xgft6   ymm12
+%define xret1   ymm13
+%define xret2   ymm14
+%define xret3   ymm15
+
+;;
+;; Encodes 32 bytes of a single source into 6x 32 bytes (parity disks)
+;;
+%macro ENCODE_32B_6 0
+        ;; get next source vector
+        XLDR    x0, [src + pos]
+        ;; get next dest vectors
+        XLDR    xd1, [dest1 + pos]
+        XLDR    xd2, [dest2 + pos]
+        XLDR    xd3, [dest3 + pos]
+        XLDR    xd4, [dest4 + pos]
+        XLDR    xd5, [dest5 + pos]
+        XLDR    xd6, [dest6 + pos]
+
+        GF_MUL_XOR VEX, x0, xgft1, xret1, xd1, xgft2, xret2, xd2, \
+                xgft3, xret3, xd3
+        GF_MUL_XOR VEX, x0, xgft4, xret1, xd4, xgft5, xret2, xd5, \
+                xgft6, xret3, xd6
+
+        XSTR    [dest1 + pos], xd1
+        XSTR    [dest2 + pos], xd2
+        XSTR    [dest3 + pos], xd3
+        XSTR    [dest4 + pos], xd4
+        XSTR    [dest5 + pos], xd5
+        XSTR    [dest6 + pos], xd6
+%endmacro
+
+;;
+;; Encodes less than 32 bytes of a single source into 6x parity disks
+;;
+%macro ENCODE_LT_32B_6 1
+%define %%LEN   %1
+        ;; get next source vector
+        simd_load_avx2 x0, src + pos, %%LEN, tmp, tmp2
+        ;; get next dest vectors
+        simd_load_avx2 xd1, dest1 + pos, %%LEN, tmp, tmp2
+        simd_load_avx2 xd2, dest2 + pos, %%LEN, tmp, tmp2
+        simd_load_avx2 xd3, dest3 + pos, %%LEN, tmp, tmp2
+        simd_load_avx2 xd4, dest4 + pos, %%LEN, tmp, tmp2
+        simd_load_avx2 xd5, dest5 + pos, %%LEN, tmp, tmp2
+        simd_load_avx2 xd6, dest6 + pos, %%LEN, tmp, tmp2
+
+        GF_MUL_XOR VEX, x0, xgft1, xret1, xd1, xgft2, xret2, xd2, \
+                xgft3, xret3, xd3
+        GF_MUL_XOR VEX, x0, xgft4, xret1, xd4, xgft5, xret2, xd5, \
+                xgft6, xret3, xd6
+
+        lea     dest1, [dest1 + pos]
+        simd_store_avx2 dest1, xd1, %%LEN, tmp, tmp2
+        lea     dest2, [dest2 + pos]
+        simd_store_avx2 dest2, xd2, %%LEN, tmp, tmp2
+        lea     dest3, [dest3 + pos]
+        simd_store_avx2 dest3, xd3, %%LEN, tmp, tmp2
+        lea     dest4, [dest4 + pos]
+        simd_store_avx2 dest4, xd4, %%LEN, tmp, tmp2
+        lea     dest5, [dest5 + pos]
+        simd_store_avx2 dest5, xd5, %%LEN, tmp, tmp2
+        lea     dest6, [dest6 + pos]
+        simd_store_avx2 dest6, xd6, %%LEN, tmp, tmp2
+%endmacro
+
+align 16
+mk_global gf_6vect_mad_avx2_gfni, function
+func(gf_6vect_mad_avx2_gfni)
+        FUNC_SAVE
+
+        xor     pos, pos
+        shl     vec_i, 5                ;Multiply by 32
+        shl     vec, 5                  ;Multiply by 32
+        lea     tmp, [mul_array + vec_i]
+        vbroadcastsd xgft1, [tmp]
+        vbroadcastsd xgft2, [tmp + vec]
+        vbroadcastsd xgft3, [tmp + vec*2]
+        vbroadcastsd xgft5, [tmp + vec*4]
+        add     tmp, vec
+        vbroadcastsd xgft4, [tmp + vec*2]
+        vbroadcastsd xgft6, [tmp + vec*4]
+        mov     dest2, [dest1 + 1*8]    ; reuse mul_array
+        mov     dest3, [dest1 + 2*8]    ; reuse vec_i
+        mov     dest4, [dest1 + 3*8]
+        mov     dest5, [dest1 + 4*8]
+        mov     dest6, [dest1 + 5*8]    ; reuse vec
+        mov     dest1, [dest1]
+
+        cmp     len, 32
+        jl      .len_lt_32
+
+.loop32:
+        ENCODE_32B_6            ;; loop on 32 bytes at a time
+
+        add     pos, 32
+        sub     len, 32
+        cmp     len, 32
+        jge     .loop32
+
+.len_lt_32:
+        cmp     len, 0
+        jle     .exit
+
+        ENCODE_LT_32B_6 len     ;; encode final bytes
+
+.exit:
+        vzeroupper
+
+        FUNC_RESTORE
+        ret
+
+endproc_frame

--- a/erasure_code/gf_vect_dot_prod_avx2_gfni.asm
+++ b/erasure_code/gf_vect_dot_prod_avx2_gfni.asm
@@ -50,7 +50,7 @@
  %define stack_size  1*8
  %define func(x) x: endbranch
  %macro FUNC_SAVE 0
-        sub	    rsp, stack_size
+        sub	rsp, stack_size
         mov     [rsp + 0*8], r12
  %endmacro
  %macro FUNC_RESTORE 0
@@ -133,15 +133,11 @@
 %define xp1x    ymm5
 
 %define xgft1   ymm6
-%define xgft2   ymm7
-%define xgft3   ymm8
 
-%define xtmp1   ymm9
+%define xtmp1   ymm7
 
 %define x0      x0l
 %define xp1     xp1l
-%define xp2     xp2l
-%define xp3     xp3l
 
 default rel
 [bits 64]
@@ -248,10 +244,9 @@ section .text
         ; get next source vector
         mov     ptr, [src + vec_i]
         simd_load_avx2 x0, ptr + pos, %%LEN, tmp, tmp3
-        add     vec_i, 8
 
-        vmovdqu xgft1, [mul_array]
-        add     mul_array, 32
+        vmovdqu xgft1, [mul_array + vec_i*4]
+        add     vec_i, 8
 
         GF_MUL_XOR VEX, x0, xgft1, xgft1, xp1
 


### PR DESCRIPTION
Erasure Code:    
    1) add 4~6 vector AVX2 dot product with GFNI implementation
    2) add AVX2 6vect mad with GFNI implementation
    3) ensuring encoding process not modify the input mul_array pointer

Complete the implementations of ec_encode_data_avx2_gfni and ec_encode_data_update_avx2_gfni to support parity blocks k+1 through k+6, consistent with the implementations for other instruction sets (AVX512, AVX2, etc.). This avoids reading source data twice when computing parities k+4 to k+6, preventing memory bandwidth amplification.