### PR TITLE
cmake/erasure_code.cmake update

### DIFF
--- a/cmake/erasure_code.cmake
+++ b/cmake/erasure_code.cmake
@@ -132,15 +132,8 @@ set(ERASURE_CODE_AARCH64_SOURCES
     erasure_code/aarch64/gf_4vect_mad_sve.S
     erasure_code/aarch64/gf_5vect_mad_sve.S
     erasure_code/aarch64/gf_6vect_mad_sve.S
-    erasure_code/aarch64/gf_vect_dot_prod_sve.S
-    erasure_code/aarch64/gf_2vect_dot_prod_sve.S
-    erasure_code/aarch64/gf_3vect_dot_prod_sve.S
-    erasure_code/aarch64/gf_4vect_dot_prod_sve.S
-    erasure_code/aarch64/gf_5vect_dot_prod_sve.S
-    erasure_code/aarch64/gf_6vect_dot_prod_sve.S
-    erasure_code/aarch64/gf_7vect_dot_prod_sve.S
-    erasure_code/aarch64/gf_8vect_dot_prod_sve.S
     erasure_code/aarch64/gf_vect_mul_sve.S
+    erasure_code/aarch64/gf_nvect_dot_prod_sve.c
     erasure_code/aarch64/ec_multibinary_arm.S
 )
 


### PR DESCRIPTION
The variable `ERASURE_CODE_AARCH64_SOURCES` in `cmake/erasure_code.cmake update` was being assigned names of files that are not in the repo. This caused errors during builds on macOS (Darwin 25.0.0, gcc-15.2.0, cmake 4.2.3). Now the variable is set equal to the same files indicated in `erasure_code/aarch64/Makefile.am`, which fixes the issue.