### PR TITLE
erasure_code: add C intrinsic GFNI kernels (selectable at configure time)

### DIFF
--- a/cmake/erasure_code.cmake
+++ b/cmake/erasure_code.cmake
@@ -39,7 +39,6 @@ set(ERASURE_CODE_X86_64_SOURCES
     erasure_code/ec_highlevel_func.c
     erasure_code/gf_vect_mul_sse.asm
     erasure_code/gf_vect_mul_avx.asm
-    erasure_code/gf_vect_mul_avx2_gfni.asm
     erasure_code/gf_vect_dot_prod_sse.asm
     erasure_code/gf_vect_dot_prod_avx.asm
     erasure_code/gf_vect_dot_prod_avx2.asm
@@ -77,39 +76,75 @@ set(ERASURE_CODE_X86_64_SOURCES
     erasure_code/gf_5vect_mad_avx2.asm
     erasure_code/gf_6vect_mad_avx2.asm
     erasure_code/ec_multibinary.asm
-    erasure_code/gf_vect_mad_avx2_gfni.asm
-    erasure_code/gf_2vect_mad_avx2_gfni.asm
-    erasure_code/gf_3vect_mad_avx2_gfni.asm
-    erasure_code/gf_4vect_mad_avx2_gfni.asm
-    erasure_code/gf_5vect_mad_avx2_gfni.asm
     erasure_code/gf_vect_dot_prod_avx512.asm
     erasure_code/gf_2vect_dot_prod_avx512.asm
     erasure_code/gf_3vect_dot_prod_avx512.asm
     erasure_code/gf_4vect_dot_prod_avx512.asm
     erasure_code/gf_5vect_dot_prod_avx512.asm
     erasure_code/gf_6vect_dot_prod_avx512.asm
-    erasure_code/gf_vect_dot_prod_avx512_gfni.asm
-    erasure_code/gf_vect_dot_prod_avx2_gfni.asm
-    erasure_code/gf_2vect_dot_prod_avx2_gfni.asm
-    erasure_code/gf_3vect_dot_prod_avx2_gfni.asm
-    erasure_code/gf_2vect_dot_prod_avx512_gfni.asm
-    erasure_code/gf_3vect_dot_prod_avx512_gfni.asm
-    erasure_code/gf_4vect_dot_prod_avx512_gfni.asm
-    erasure_code/gf_5vect_dot_prod_avx512_gfni.asm
-    erasure_code/gf_6vect_dot_prod_avx512_gfni.asm
     erasure_code/gf_vect_mad_avx512.asm
     erasure_code/gf_2vect_mad_avx512.asm
     erasure_code/gf_3vect_mad_avx512.asm
     erasure_code/gf_4vect_mad_avx512.asm
     erasure_code/gf_5vect_mad_avx512.asm
     erasure_code/gf_6vect_mad_avx512.asm
-    erasure_code/gf_vect_mad_avx512_gfni.asm
-    erasure_code/gf_2vect_mad_avx512_gfni.asm
-    erasure_code/gf_3vect_mad_avx512_gfni.asm
-    erasure_code/gf_4vect_mad_avx512_gfni.asm
-    erasure_code/gf_5vect_mad_avx512_gfni.asm
-    erasure_code/gf_6vect_mad_avx512_gfni.asm
 )
+
+# GFNI erasure-code kernels: assembly by default, or C intrinsics when
+# GFNI_C_KERNELS is enabled. Both export the same symbols and share the
+# ec_multibinary runtime dispatch. The C path needs a compiler that supports
+# function target attributes (GCC/Clang); assembly stays the default and is
+# required for toolchains that do not (e.g. MSVC).
+option(GFNI_C_KERNELS "Build GFNI erasure-code kernels from C intrinsics instead of assembly" OFF)
+if(GFNI_C_KERNELS)
+    list(APPEND ERASURE_CODE_X86_64_SOURCES
+        erasure_code/gf_vect_mul_avx2_gfni.c
+        erasure_code/gf_vect_dot_prod_avx2_gfni.c
+        erasure_code/gf_2vect_dot_prod_avx2_gfni.c
+        erasure_code/gf_3vect_dot_prod_avx2_gfni.c
+        erasure_code/gf_vect_dot_prod_avx512_gfni.c
+        erasure_code/gf_2vect_dot_prod_avx512_gfni.c
+        erasure_code/gf_3vect_dot_prod_avx512_gfni.c
+        erasure_code/gf_4vect_dot_prod_avx512_gfni.c
+        erasure_code/gf_5vect_dot_prod_avx512_gfni.c
+        erasure_code/gf_6vect_dot_prod_avx512_gfni.c
+        erasure_code/gf_vect_mad_avx2_gfni.c
+        erasure_code/gf_2vect_mad_avx2_gfni.c
+        erasure_code/gf_3vect_mad_avx2_gfni.c
+        erasure_code/gf_4vect_mad_avx2_gfni.c
+        erasure_code/gf_5vect_mad_avx2_gfni.c
+        erasure_code/gf_vect_mad_avx512_gfni.c
+        erasure_code/gf_2vect_mad_avx512_gfni.c
+        erasure_code/gf_3vect_mad_avx512_gfni.c
+        erasure_code/gf_4vect_mad_avx512_gfni.c
+        erasure_code/gf_5vect_mad_avx512_gfni.c
+        erasure_code/gf_6vect_mad_avx512_gfni.c
+    )
+else()
+    list(APPEND ERASURE_CODE_X86_64_SOURCES
+        erasure_code/gf_vect_mul_avx2_gfni.asm
+        erasure_code/gf_vect_dot_prod_avx2_gfni.asm
+        erasure_code/gf_2vect_dot_prod_avx2_gfni.asm
+        erasure_code/gf_3vect_dot_prod_avx2_gfni.asm
+        erasure_code/gf_vect_dot_prod_avx512_gfni.asm
+        erasure_code/gf_2vect_dot_prod_avx512_gfni.asm
+        erasure_code/gf_3vect_dot_prod_avx512_gfni.asm
+        erasure_code/gf_4vect_dot_prod_avx512_gfni.asm
+        erasure_code/gf_5vect_dot_prod_avx512_gfni.asm
+        erasure_code/gf_6vect_dot_prod_avx512_gfni.asm
+        erasure_code/gf_vect_mad_avx2_gfni.asm
+        erasure_code/gf_2vect_mad_avx2_gfni.asm
+        erasure_code/gf_3vect_mad_avx2_gfni.asm
+        erasure_code/gf_4vect_mad_avx2_gfni.asm
+        erasure_code/gf_5vect_mad_avx2_gfni.asm
+        erasure_code/gf_vect_mad_avx512_gfni.asm
+        erasure_code/gf_2vect_mad_avx512_gfni.asm
+        erasure_code/gf_3vect_mad_avx512_gfni.asm
+        erasure_code/gf_4vect_mad_avx512_gfni.asm
+        erasure_code/gf_5vect_mad_avx512_gfni.asm
+        erasure_code/gf_6vect_mad_avx512_gfni.asm
+    )
+endif()
 
 set(ERASURE_CODE_AARCH64_SOURCES
     erasure_code/aarch64/ec_aarch64_highlevel_func.c

--- a/configure.ac
+++ b/configure.ac
@@ -157,6 +157,12 @@ AC_ARG_ENABLE([programs],
 	[], [enable_programs=no])
 AM_CONDITIONAL([HAVE_PROGRAMS], [test "x$enable_programs" != "xno"])
 
+AC_ARG_ENABLE([gfni-c-kernels],
+	AS_HELP_STRING([--enable-gfni-c-kernels],
+		[build the GFNI erasure-code kernels from C intrinsics instead of assembly @<:@default=disabled@:>@]),
+	[], [enable_gfni_c_kernels=no])
+AM_CONDITIONAL([GFNI_C_KERNELS], [test "x$enable_gfni_c_kernels" = "xyes"])
+
 # If this build is for x86, look for nasm
 if test x"$is_x86" = x"yes"; then
   AC_MSG_CHECKING([whether Intel CET is enabled])

--- a/erasure_code/Makefile.am
+++ b/erasure_code/Makefile.am
@@ -40,7 +40,6 @@ lsrc_x86_64  += \
 		erasure_code/ec_highlevel_func.c \
 		erasure_code/gf_vect_mul_sse.asm \
 		erasure_code/gf_vect_mul_avx.asm \
-		erasure_code/gf_vect_mul_avx2_gfni.asm \
 		erasure_code/gf_vect_dot_prod_sse.asm  \
 		erasure_code/gf_vect_dot_prod_avx.asm \
 		erasure_code/gf_vect_dot_prod_avx2.asm \
@@ -80,38 +79,73 @@ lsrc_x86_64  += \
 		erasure_code/ec_multibinary.asm
 
 lsrc_x86_64  += \
-		erasure_code/gf_vect_mad_avx2_gfni.asm \
-		erasure_code/gf_2vect_mad_avx2_gfni.asm \
-		erasure_code/gf_3vect_mad_avx2_gfni.asm \
-		erasure_code/gf_4vect_mad_avx2_gfni.asm \
-		erasure_code/gf_5vect_mad_avx2_gfni.asm \
 		erasure_code/gf_vect_dot_prod_avx512.asm \
 		erasure_code/gf_2vect_dot_prod_avx512.asm \
 		erasure_code/gf_3vect_dot_prod_avx512.asm \
 		erasure_code/gf_4vect_dot_prod_avx512.asm \
 		erasure_code/gf_5vect_dot_prod_avx512.asm \
 		erasure_code/gf_6vect_dot_prod_avx512.asm \
-		erasure_code/gf_vect_dot_prod_avx512_gfni.asm \
-		erasure_code/gf_vect_dot_prod_avx2_gfni.asm \
-		erasure_code/gf_2vect_dot_prod_avx2_gfni.asm \
-		erasure_code/gf_3vect_dot_prod_avx2_gfni.asm \
-		erasure_code/gf_2vect_dot_prod_avx512_gfni.asm \
-		erasure_code/gf_3vect_dot_prod_avx512_gfni.asm \
-		erasure_code/gf_4vect_dot_prod_avx512_gfni.asm \
-		erasure_code/gf_5vect_dot_prod_avx512_gfni.asm \
-		erasure_code/gf_6vect_dot_prod_avx512_gfni.asm \
 		erasure_code/gf_vect_mad_avx512.asm \
 		erasure_code/gf_2vect_mad_avx512.asm \
 		erasure_code/gf_3vect_mad_avx512.asm \
 		erasure_code/gf_4vect_mad_avx512.asm \
 		erasure_code/gf_5vect_mad_avx512.asm \
-		erasure_code/gf_6vect_mad_avx512.asm \
+		erasure_code/gf_6vect_mad_avx512.asm
+
+# GFNI erasure-code kernels. The assembly implementations are built by
+# default. Configuring with --enable-gfni-c-kernels builds the equivalent
+# C intrinsic implementations instead. Both export the same symbols and
+# plug into the same ec_multibinary runtime dispatch, so the choice is
+# transparent to callers. The C path requires a compiler that supports
+# function target attributes (GCC/Clang); assembly remains the default and
+# is required for toolchains that do not (e.g. MSVC).
+if GFNI_C_KERNELS
+lsrc_x86_64  += \
+		erasure_code/gf_vect_mul_avx2_gfni.c \
+		erasure_code/gf_vect_dot_prod_avx2_gfni.c \
+		erasure_code/gf_2vect_dot_prod_avx2_gfni.c \
+		erasure_code/gf_3vect_dot_prod_avx2_gfni.c \
+		erasure_code/gf_vect_dot_prod_avx512_gfni.c \
+		erasure_code/gf_2vect_dot_prod_avx512_gfni.c \
+		erasure_code/gf_3vect_dot_prod_avx512_gfni.c \
+		erasure_code/gf_4vect_dot_prod_avx512_gfni.c \
+		erasure_code/gf_5vect_dot_prod_avx512_gfni.c \
+		erasure_code/gf_6vect_dot_prod_avx512_gfni.c \
+		erasure_code/gf_vect_mad_avx2_gfni.c \
+		erasure_code/gf_2vect_mad_avx2_gfni.c \
+		erasure_code/gf_3vect_mad_avx2_gfni.c \
+		erasure_code/gf_4vect_mad_avx2_gfni.c \
+		erasure_code/gf_5vect_mad_avx2_gfni.c \
+		erasure_code/gf_vect_mad_avx512_gfni.c \
+		erasure_code/gf_2vect_mad_avx512_gfni.c \
+		erasure_code/gf_3vect_mad_avx512_gfni.c \
+		erasure_code/gf_4vect_mad_avx512_gfni.c \
+		erasure_code/gf_5vect_mad_avx512_gfni.c \
+		erasure_code/gf_6vect_mad_avx512_gfni.c
+else
+lsrc_x86_64  += \
+		erasure_code/gf_vect_mul_avx2_gfni.asm \
+		erasure_code/gf_vect_dot_prod_avx2_gfni.asm \
+		erasure_code/gf_2vect_dot_prod_avx2_gfni.asm \
+		erasure_code/gf_3vect_dot_prod_avx2_gfni.asm \
+		erasure_code/gf_vect_dot_prod_avx512_gfni.asm \
+		erasure_code/gf_2vect_dot_prod_avx512_gfni.asm \
+		erasure_code/gf_3vect_dot_prod_avx512_gfni.asm \
+		erasure_code/gf_4vect_dot_prod_avx512_gfni.asm \
+		erasure_code/gf_5vect_dot_prod_avx512_gfni.asm \
+		erasure_code/gf_6vect_dot_prod_avx512_gfni.asm \
+		erasure_code/gf_vect_mad_avx2_gfni.asm \
+		erasure_code/gf_2vect_mad_avx2_gfni.asm \
+		erasure_code/gf_3vect_mad_avx2_gfni.asm \
+		erasure_code/gf_4vect_mad_avx2_gfni.asm \
+		erasure_code/gf_5vect_mad_avx2_gfni.asm \
 		erasure_code/gf_vect_mad_avx512_gfni.asm \
 		erasure_code/gf_2vect_mad_avx512_gfni.asm \
 		erasure_code/gf_3vect_mad_avx512_gfni.asm \
 		erasure_code/gf_4vect_mad_avx512_gfni.asm \
 		erasure_code/gf_5vect_mad_avx512_gfni.asm \
 		erasure_code/gf_6vect_mad_avx512_gfni.asm
+endif
 
 src_include += -I $(srcdir)/erasure_code
 extern_hdrs  += include/erasure_code.h \

--- a/erasure_code/gf_2vect_dot_prod_avx2_gfni.c
+++ b/erasure_code/gf_2vect_dot_prod_avx2_gfni.c
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright(c) 2026 Intel Corporation All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <string.h>
+#include <immintrin.h>
+
+#define BCAST_GF8(p) _mm256_set1_epi64x((long long) *(const uint64_t *) (p))
+#define AFFINE(s, g) _mm256_gf2p8affine_epi64_epi8((s), (g), 0x00)
+#define LOAD256(p)   _mm256_loadu_si256((const __m256i *) (p))
+
+__attribute__((target("avx2,gfni"))) void
+gf_2vect_dot_prod_avx2_gfni(int len, int k, unsigned char *g_tbls, unsigned char **src,
+                            unsigned char **coding)
+{
+        unsigned char *d1 = coding[0], *d2 = coding[1];
+        const long row_stride = (long) k * 32;
+        int pos = 0;
+
+        for (; pos + 96 <= len; pos += 96) {
+                __m256i p1l = _mm256_setzero_si256();
+                __m256i p2l = _mm256_setzero_si256();
+                __m256i p1h = _mm256_setzero_si256();
+                __m256i p2h = _mm256_setzero_si256();
+                __m256i p1x = _mm256_setzero_si256();
+                __m256i p2x = _mm256_setzero_si256();
+                unsigned char *tbl = g_tbls;
+
+                for (int i = 0; i < k; i++) {
+                        const unsigned char *s = src[i] + pos;
+                        __m256i xl = LOAD256(s + 0);
+                        __m256i xh = LOAD256(s + 32);
+                        __m256i xx = LOAD256(s + 64);
+                        __m256i g1 = LOAD256(tbl + 0);
+                        __m256i g2 = LOAD256(tbl + row_stride);
+
+                        tbl += 32;
+                        p1l = _mm256_xor_si256(p1l, AFFINE(xl, g1));
+                        p2l = _mm256_xor_si256(p2l, AFFINE(xl, g2));
+                        p1h = _mm256_xor_si256(p1h, AFFINE(xh, g1));
+                        p2h = _mm256_xor_si256(p2h, AFFINE(xh, g2));
+                        p1x = _mm256_xor_si256(p1x, AFFINE(xx, g1));
+                        p2x = _mm256_xor_si256(p2x, AFFINE(xx, g2));
+                }
+                _mm256_storeu_si256((__m256i *) (d1 + pos + 0), p1l);
+                _mm256_storeu_si256((__m256i *) (d2 + pos + 0), p2l);
+                _mm256_storeu_si256((__m256i *) (d1 + pos + 32), p1h);
+                _mm256_storeu_si256((__m256i *) (d2 + pos + 32), p2h);
+                _mm256_storeu_si256((__m256i *) (d1 + pos + 64), p1x);
+                _mm256_storeu_si256((__m256i *) (d2 + pos + 64), p2x);
+        }
+
+        if (pos + 64 <= len) {
+                __m256i p1l = _mm256_setzero_si256();
+                __m256i p2l = _mm256_setzero_si256();
+                __m256i p1h = _mm256_setzero_si256();
+                __m256i p2h = _mm256_setzero_si256();
+                unsigned char *tbl = g_tbls;
+
+                for (int i = 0; i < k; i++) {
+                        const unsigned char *s = src[i] + pos;
+                        __m256i xl = LOAD256(s + 0);
+                        __m256i xh = LOAD256(s + 32);
+                        __m256i g1 = LOAD256(tbl + 0);
+                        __m256i g2 = LOAD256(tbl + row_stride);
+
+                        tbl += 32;
+                        p1l = _mm256_xor_si256(p1l, AFFINE(xl, g1));
+                        p2l = _mm256_xor_si256(p2l, AFFINE(xl, g2));
+                        p1h = _mm256_xor_si256(p1h, AFFINE(xh, g1));
+                        p2h = _mm256_xor_si256(p2h, AFFINE(xh, g2));
+                }
+                _mm256_storeu_si256((__m256i *) (d1 + pos + 0), p1l);
+                _mm256_storeu_si256((__m256i *) (d2 + pos + 0), p2l);
+                _mm256_storeu_si256((__m256i *) (d1 + pos + 32), p1h);
+                _mm256_storeu_si256((__m256i *) (d2 + pos + 32), p2h);
+                pos += 64;
+        }
+
+        if (pos + 32 <= len) {
+                __m256i p1 = _mm256_setzero_si256();
+                __m256i p2 = _mm256_setzero_si256();
+                unsigned char *tbl = g_tbls;
+
+                for (int i = 0; i < k; i++) {
+                        __m256i x = LOAD256(src[i] + pos);
+                        __m256i g1 = LOAD256(tbl + 0);
+                        __m256i g2 = LOAD256(tbl + row_stride);
+
+                        tbl += 32;
+                        p1 = _mm256_xor_si256(p1, AFFINE(x, g1));
+                        p2 = _mm256_xor_si256(p2, AFFINE(x, g2));
+                }
+                _mm256_storeu_si256((__m256i *) (d1 + pos), p1);
+                _mm256_storeu_si256((__m256i *) (d2 + pos), p2);
+                pos += 32;
+        }
+
+        if (pos < len) {
+                int rem = len - pos;
+                unsigned char buf[32] __attribute__ /**/ ((aligned(32))) = { 0 };
+                __m256i p1 = _mm256_setzero_si256();
+                __m256i p2 = _mm256_setzero_si256();
+                unsigned char *tbl = g_tbls;
+
+                for (int i = 0; i < k; i++) {
+                        memcpy(buf, src[i] + pos, rem);
+                        __m256i x = _mm256_load_si256((const __m256i *) buf);
+                        __m256i g1 = LOAD256(tbl + 0);
+                        __m256i g2 = LOAD256(tbl + row_stride);
+
+                        tbl += 32;
+                        p1 = _mm256_xor_si256(p1, AFFINE(x, g1));
+                        p2 = _mm256_xor_si256(p2, AFFINE(x, g2));
+                }
+                _mm256_store_si256((__m256i *) buf, p1);
+                memcpy(d1 + pos, buf, rem);
+                _mm256_store_si256((__m256i *) buf, p2);
+                memcpy(d2 + pos, buf, rem);
+        }
+
+        _mm256_zeroupper();
+}

--- a/erasure_code/gf_2vect_dot_prod_avx512_gfni.c
+++ b/erasure_code/gf_2vect_dot_prod_avx512_gfni.c
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright(c) 2026 Intel Corporation All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <immintrin.h>
+
+#define AFFINE(s, g)        _mm512_gf2p8affine_epi64_epi8((s), (g), 0x00)
+#define LOAD512(p)          _mm512_loadu_si512((const void *) (p))
+#define TAIL_MASK(len, pos) ((__mmask64) (((uint64_t) 1 << ((len) - (pos))) - 1))
+
+/*
+ * Embedded-broadcast GF multiply-accumulate for the dot_prod hot loop.
+ *
+ * acc ^= gf2p8affine(src, broadcast8(*coeff)).  The coefficient is read
+ * straight from the gftbls memory as an EVEX {1to8} embedded-broadcast operand
+ * of vgf2p8affineqb, folding the 8-byte broadcast into the affine's own load
+ * micro-op.  This deliberately avoids letting the compiler lower the broadcast
+ * to a GPR-source `vpbroadcastq %gpr,zmm` (+ a scalar `movq` load), which on
+ * Sapphire Rapids issues on the vector-ALU Port5 and made the multi-vect C
+ * encode ~25% slower than the NASM baseline (which keeps the broadcast on the
+ * load ports).  gcc/clang will NOT emit {1to8} from _mm512_set1_epi64()+affine
+ * (verified), so this must be inline asm.  A distinct scratch temp per call
+ * also keeps the N independent affines off a single shared dependency chain.
+ */
+#define AFFINE_XOR_BCAST(acc, s, coeff)                                                        \
+        do {                                                                                  \
+                __m512i _t;                                                                    \
+                __asm__("vgf2p8affineqb $0x00, (%[c])%{1to8%}, %[src], %[t]\n\t"               \
+                        "vpxorq %[t], %[p], %[p]"                                              \
+                        : [p] "+v"(acc), [t] "=&v"(_t)                                         \
+                        : [src] "v"(s), [c] "r"(coeff)                                         \
+                        :);                                                                    \
+        } while (0)
+
+__attribute__((target("avx512f,avx512bw,gfni"))) void
+gf_2vect_dot_prod_avx512_gfni(int len, int k, unsigned char *g_tbls, unsigned char **src,
+                              unsigned char **coding)
+{
+        unsigned char *d1 = coding[0], *d2 = coding[1];
+        const long row_stride = (long) k * 32;
+        int pos = 0;
+
+        for (; pos + 64 <= len; pos += 64) {
+                __m512i p1 = _mm512_setzero_si512();
+                __m512i p2 = _mm512_setzero_si512();
+                unsigned char *tbl = g_tbls;
+
+                for (int i = 0; i < k; i++) {
+                        __m512i s = LOAD512(src[i] + pos);
+
+                        AFFINE_XOR_BCAST(p1, s, tbl + 0);
+                        AFFINE_XOR_BCAST(p2, s, tbl + 1 * row_stride);
+                        tbl += 32;
+                }
+                _mm512_storeu_si512((void *) (d1 + pos), p1);
+                _mm512_storeu_si512((void *) (d2 + pos), p2);
+        }
+
+        if (pos < len) {
+                const __mmask64 m = TAIL_MASK(len, pos);
+                __m512i p1 = _mm512_setzero_si512();
+                __m512i p2 = _mm512_setzero_si512();
+                unsigned char *tbl = g_tbls;
+
+                for (int i = 0; i < k; i++) {
+                        __m512i s = _mm512_maskz_loadu_epi8(m, src[i] + pos);
+
+                        AFFINE_XOR_BCAST(p1, s, tbl + 0);
+                        AFFINE_XOR_BCAST(p2, s, tbl + 1 * row_stride);
+                        tbl += 32;
+                }
+                _mm512_mask_storeu_epi8(d1 + pos, m, p1);
+                _mm512_mask_storeu_epi8(d2 + pos, m, p2);
+        }
+}

--- a/erasure_code/gf_2vect_mad_avx2_gfni.c
+++ b/erasure_code/gf_2vect_mad_avx2_gfni.c
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright(c) 2026 Intel Corporation All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <string.h>
+#include <immintrin.h>
+
+#define BCAST_GF8(p) _mm256_set1_epi64x((long long) *(const uint64_t *) (p))
+#define AFFINE(s, g) _mm256_gf2p8affine_epi64_epi8((s), (g), 0x00)
+#define LOAD256(p)   _mm256_loadu_si256((const __m256i *) (p))
+
+__attribute__((target("avx2,gfni"))) void
+gf_2vect_mad_avx2_gfni(int len, int vec, int vec_i, unsigned char *gftbls, unsigned char *src,
+                       unsigned char **dest)
+{
+        const long row_stride = (long) vec * 32;
+        unsigned char *base = gftbls + (long) vec_i * 32;
+        unsigned char *dp1 = dest[0], *dp2 = dest[1];
+        __m256i gft1 = BCAST_GF8(base + 0 * row_stride);
+        __m256i gft2 = BCAST_GF8(base + 1 * row_stride);
+
+        int pos = 0;
+
+        for (; pos + 96 <= len; pos += 96) {
+                __m256i xl = LOAD256(src + pos + 0);
+                __m256i xh = LOAD256(src + pos + 32);
+                __m256i xx = LOAD256(src + pos + 64);
+                __m256i d1l = LOAD256(dp1 + pos + 0);
+                __m256i d2l = LOAD256(dp2 + pos + 0);
+
+                d1l = _mm256_xor_si256(d1l, AFFINE(xl, gft1));
+                d2l = _mm256_xor_si256(d2l, AFFINE(xl, gft2));
+                _mm256_storeu_si256((__m256i *) (dp1 + pos + 0), d1l);
+                _mm256_storeu_si256((__m256i *) (dp2 + pos + 0), d2l);
+                __m256i d1h = LOAD256(dp1 + pos + 32);
+                __m256i d2h = LOAD256(dp2 + pos + 32);
+
+                d1h = _mm256_xor_si256(d1h, AFFINE(xh, gft1));
+                d2h = _mm256_xor_si256(d2h, AFFINE(xh, gft2));
+                _mm256_storeu_si256((__m256i *) (dp1 + pos + 32), d1h);
+                _mm256_storeu_si256((__m256i *) (dp2 + pos + 32), d2h);
+                __m256i d1x = LOAD256(dp1 + pos + 64);
+                __m256i d2x = LOAD256(dp2 + pos + 64);
+
+                d1x = _mm256_xor_si256(d1x, AFFINE(xx, gft1));
+                d2x = _mm256_xor_si256(d2x, AFFINE(xx, gft2));
+                _mm256_storeu_si256((__m256i *) (dp1 + pos + 64), d1x);
+                _mm256_storeu_si256((__m256i *) (dp2 + pos + 64), d2x);
+        }
+
+        if (pos + 64 <= len) {
+                __m256i xl = LOAD256(src + pos + 0);
+                __m256i xh = LOAD256(src + pos + 32);
+                __m256i d1l = LOAD256(dp1 + pos + 0);
+                __m256i d2l = LOAD256(dp2 + pos + 0);
+
+                d1l = _mm256_xor_si256(d1l, AFFINE(xl, gft1));
+                d2l = _mm256_xor_si256(d2l, AFFINE(xl, gft2));
+                _mm256_storeu_si256((__m256i *) (dp1 + pos + 0), d1l);
+                _mm256_storeu_si256((__m256i *) (dp2 + pos + 0), d2l);
+                __m256i d1h = LOAD256(dp1 + pos + 32);
+                __m256i d2h = LOAD256(dp2 + pos + 32);
+
+                d1h = _mm256_xor_si256(d1h, AFFINE(xh, gft1));
+                d2h = _mm256_xor_si256(d2h, AFFINE(xh, gft2));
+                _mm256_storeu_si256((__m256i *) (dp1 + pos + 32), d1h);
+                _mm256_storeu_si256((__m256i *) (dp2 + pos + 32), d2h);
+                pos += 64;
+        }
+
+        if (pos + 32 <= len) {
+                __m256i x = LOAD256(src + pos);
+                __m256i d1 = LOAD256(dp1 + pos + 0);
+                __m256i d2 = LOAD256(dp2 + pos + 0);
+
+                d1 = _mm256_xor_si256(d1, AFFINE(x, gft1));
+                d2 = _mm256_xor_si256(d2, AFFINE(x, gft2));
+                _mm256_storeu_si256((__m256i *) (dp1 + pos + 0), d1);
+                _mm256_storeu_si256((__m256i *) (dp2 + pos + 0), d2);
+                pos += 32;
+        }
+
+        if (pos < len) {
+                int rem = len - pos;
+                unsigned char sbuf[32] __attribute__ /**/ ((aligned(32))) = { 0 };
+                unsigned char dbuf[32] __attribute__ /**/ ((aligned(32)));
+
+                memcpy(sbuf, src + pos, rem);
+                __m256i x = _mm256_load_si256((const __m256i *) sbuf);
+
+                memset(dbuf, 0, 32);
+                memcpy(dbuf, dp1 + pos, rem);
+                {
+                        __m256i d = _mm256_load_si256((const __m256i *) dbuf);
+                        d = _mm256_xor_si256(d, AFFINE(x, gft1));
+                        _mm256_store_si256((__m256i *) dbuf, d);
+                }
+                memcpy(dp1 + pos, dbuf, rem);
+                memset(dbuf, 0, 32);
+                memcpy(dbuf, dp2 + pos, rem);
+                {
+                        __m256i d = _mm256_load_si256((const __m256i *) dbuf);
+                        d = _mm256_xor_si256(d, AFFINE(x, gft2));
+                        _mm256_store_si256((__m256i *) dbuf, d);
+                }
+                memcpy(dp2 + pos, dbuf, rem);
+        }
+
+        _mm256_zeroupper();
+}

--- a/erasure_code/gf_2vect_mad_avx512_gfni.c
+++ b/erasure_code/gf_2vect_mad_avx512_gfni.c
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright(c) 2026 Intel Corporation All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <immintrin.h>
+
+#define BCAST_GF8(p)        _mm512_set1_epi64((long long) *(const uint64_t *) (p))
+#define AFFINE(s, g)        _mm512_gf2p8affine_epi64_epi8((s), (g), 0x00)
+#define LOAD512(p)          _mm512_loadu_si512((const void *) (p))
+#define TAIL_MASK(len, pos) ((__mmask64) (((uint64_t) 1 << ((len) - (pos))) - 1))
+
+__attribute__((target("avx512f,avx512bw,gfni"))) void
+gf_2vect_mad_avx512_gfni(int len, int vec, int vec_i, unsigned char *gftbls, unsigned char *src,
+                         unsigned char **dest)
+{
+        const long row_stride = (long) vec * 32;
+        unsigned char *base = gftbls + (long) vec_i * 32;
+        unsigned char *d1_p = dest[0], *d2_p = dest[1];
+        __m512i gft1 = BCAST_GF8(base + 0 * row_stride);
+        __m512i gft2 = BCAST_GF8(base + 1 * row_stride);
+
+        int pos = 0;
+
+        for (; pos + 64 <= len; pos += 64) {
+                __m512i s = LOAD512(src + pos);
+                __m512i d1 = LOAD512(d1_p + pos);
+                __m512i d2 = LOAD512(d2_p + pos);
+
+                d1 = _mm512_xor_si512(d1, AFFINE(s, gft1));
+                d2 = _mm512_xor_si512(d2, AFFINE(s, gft2));
+                _mm512_storeu_si512((void *) (d1_p + pos), d1);
+                _mm512_storeu_si512((void *) (d2_p + pos), d2);
+        }
+
+        if (pos < len) {
+                const __mmask64 m = TAIL_MASK(len, pos);
+                __m512i s = _mm512_maskz_loadu_epi8(m, src + pos);
+                __m512i d1 = _mm512_maskz_loadu_epi8(m, d1_p + pos);
+                __m512i d2 = _mm512_maskz_loadu_epi8(m, d2_p + pos);
+
+                d1 = _mm512_xor_si512(d1, AFFINE(s, gft1));
+                d2 = _mm512_xor_si512(d2, AFFINE(s, gft2));
+                _mm512_mask_storeu_epi8(d1_p + pos, m, d1);
+                _mm512_mask_storeu_epi8(d2_p + pos, m, d2);
+        }
+}

--- a/erasure_code/gf_3vect_dot_prod_avx2_gfni.c
+++ b/erasure_code/gf_3vect_dot_prod_avx2_gfni.c
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright(c) 2026 Intel Corporation All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <string.h>
+#include <immintrin.h>
+
+#define BCAST_GF8(p) _mm256_set1_epi64x((long long) *(const uint64_t *) (p))
+#define AFFINE(s, g) _mm256_gf2p8affine_epi64_epi8((s), (g), 0x00)
+#define LOAD256(p)   _mm256_loadu_si256((const __m256i *) (p))
+
+__attribute__((target("avx2,gfni"))) void
+gf_3vect_dot_prod_avx2_gfni(int len, int k, unsigned char *g_tbls, unsigned char **src,
+                            unsigned char **coding)
+{
+        unsigned char *d1 = coding[0], *d2 = coding[1];
+        unsigned char *d3 = coding[2];
+        const long row_stride = (long) k * 32;
+        int pos = 0;
+
+        for (; pos + 96 <= len; pos += 96) {
+                __m256i p1l = _mm256_setzero_si256();
+                __m256i p2l = _mm256_setzero_si256();
+                __m256i p3l = _mm256_setzero_si256();
+                __m256i p1h = _mm256_setzero_si256();
+                __m256i p2h = _mm256_setzero_si256();
+                __m256i p3h = _mm256_setzero_si256();
+                __m256i p1x = _mm256_setzero_si256();
+                __m256i p2x = _mm256_setzero_si256();
+                __m256i p3x = _mm256_setzero_si256();
+                unsigned char *tbl = g_tbls;
+
+                for (int i = 0; i < k; i++) {
+                        const unsigned char *s = src[i] + pos;
+                        __m256i xl = LOAD256(s + 0);
+                        __m256i xh = LOAD256(s + 32);
+                        __m256i xx = LOAD256(s + 64);
+                        __m256i g1 = LOAD256(tbl + 0);
+                        __m256i g2 = LOAD256(tbl + row_stride);
+                        __m256i g3 = LOAD256(tbl + 2 * row_stride);
+
+                        tbl += 32;
+                        p1l = _mm256_xor_si256(p1l, AFFINE(xl, g1));
+                        p2l = _mm256_xor_si256(p2l, AFFINE(xl, g2));
+                        p3l = _mm256_xor_si256(p3l, AFFINE(xl, g3));
+                        p1h = _mm256_xor_si256(p1h, AFFINE(xh, g1));
+                        p2h = _mm256_xor_si256(p2h, AFFINE(xh, g2));
+                        p3h = _mm256_xor_si256(p3h, AFFINE(xh, g3));
+                        p1x = _mm256_xor_si256(p1x, AFFINE(xx, g1));
+                        p2x = _mm256_xor_si256(p2x, AFFINE(xx, g2));
+                        p3x = _mm256_xor_si256(p3x, AFFINE(xx, g3));
+                }
+                _mm256_storeu_si256((__m256i *) (d1 + pos + 0), p1l);
+                _mm256_storeu_si256((__m256i *) (d2 + pos + 0), p2l);
+                _mm256_storeu_si256((__m256i *) (d3 + pos + 0), p3l);
+                _mm256_storeu_si256((__m256i *) (d1 + pos + 32), p1h);
+                _mm256_storeu_si256((__m256i *) (d2 + pos + 32), p2h);
+                _mm256_storeu_si256((__m256i *) (d3 + pos + 32), p3h);
+                _mm256_storeu_si256((__m256i *) (d1 + pos + 64), p1x);
+                _mm256_storeu_si256((__m256i *) (d2 + pos + 64), p2x);
+                _mm256_storeu_si256((__m256i *) (d3 + pos + 64), p3x);
+        }
+
+        if (pos + 64 <= len) {
+                __m256i p1l = _mm256_setzero_si256();
+                __m256i p2l = _mm256_setzero_si256();
+                __m256i p3l = _mm256_setzero_si256();
+                __m256i p1h = _mm256_setzero_si256();
+                __m256i p2h = _mm256_setzero_si256();
+                __m256i p3h = _mm256_setzero_si256();
+                unsigned char *tbl = g_tbls;
+
+                for (int i = 0; i < k; i++) {
+                        const unsigned char *s = src[i] + pos;
+                        __m256i xl = LOAD256(s + 0);
+                        __m256i xh = LOAD256(s + 32);
+                        __m256i g1 = LOAD256(tbl + 0);
+                        __m256i g2 = LOAD256(tbl + row_stride);
+                        __m256i g3 = LOAD256(tbl + 2 * row_stride);
+
+                        tbl += 32;
+                        p1l = _mm256_xor_si256(p1l, AFFINE(xl, g1));
+                        p2l = _mm256_xor_si256(p2l, AFFINE(xl, g2));
+                        p3l = _mm256_xor_si256(p3l, AFFINE(xl, g3));
+                        p1h = _mm256_xor_si256(p1h, AFFINE(xh, g1));
+                        p2h = _mm256_xor_si256(p2h, AFFINE(xh, g2));
+                        p3h = _mm256_xor_si256(p3h, AFFINE(xh, g3));
+                }
+                _mm256_storeu_si256((__m256i *) (d1 + pos + 0), p1l);
+                _mm256_storeu_si256((__m256i *) (d2 + pos + 0), p2l);
+                _mm256_storeu_si256((__m256i *) (d3 + pos + 0), p3l);
+                _mm256_storeu_si256((__m256i *) (d1 + pos + 32), p1h);
+                _mm256_storeu_si256((__m256i *) (d2 + pos + 32), p2h);
+                _mm256_storeu_si256((__m256i *) (d3 + pos + 32), p3h);
+                pos += 64;
+        }
+
+        if (pos + 32 <= len) {
+                __m256i p1 = _mm256_setzero_si256();
+                __m256i p2 = _mm256_setzero_si256();
+                __m256i p3 = _mm256_setzero_si256();
+                unsigned char *tbl = g_tbls;
+
+                for (int i = 0; i < k; i++) {
+                        __m256i x = LOAD256(src[i] + pos);
+                        __m256i g1 = LOAD256(tbl + 0);
+                        __m256i g2 = LOAD256(tbl + row_stride);
+                        __m256i g3 = LOAD256(tbl + 2 * row_stride);
+
+                        tbl += 32;
+                        p1 = _mm256_xor_si256(p1, AFFINE(x, g1));
+                        p2 = _mm256_xor_si256(p2, AFFINE(x, g2));
+                        p3 = _mm256_xor_si256(p3, AFFINE(x, g3));
+                }
+                _mm256_storeu_si256((__m256i *) (d1 + pos), p1);
+                _mm256_storeu_si256((__m256i *) (d2 + pos), p2);
+                _mm256_storeu_si256((__m256i *) (d3 + pos), p3);
+                pos += 32;
+        }
+
+        if (pos < len) {
+                int rem = len - pos;
+                unsigned char buf[32] __attribute__ /**/ ((aligned(32))) = { 0 };
+                __m256i p1 = _mm256_setzero_si256();
+                __m256i p2 = _mm256_setzero_si256();
+                __m256i p3 = _mm256_setzero_si256();
+                unsigned char *tbl = g_tbls;
+
+                for (int i = 0; i < k; i++) {
+                        memcpy(buf, src[i] + pos, rem);
+                        __m256i x = _mm256_load_si256((const __m256i *) buf);
+                        __m256i g1 = LOAD256(tbl + 0);
+                        __m256i g2 = LOAD256(tbl + row_stride);
+                        __m256i g3 = LOAD256(tbl + 2 * row_stride);
+
+                        tbl += 32;
+                        p1 = _mm256_xor_si256(p1, AFFINE(x, g1));
+                        p2 = _mm256_xor_si256(p2, AFFINE(x, g2));
+                        p3 = _mm256_xor_si256(p3, AFFINE(x, g3));
+                }
+                _mm256_store_si256((__m256i *) buf, p1);
+                memcpy(d1 + pos, buf, rem);
+                _mm256_store_si256((__m256i *) buf, p2);
+                memcpy(d2 + pos, buf, rem);
+                _mm256_store_si256((__m256i *) buf, p3);
+                memcpy(d3 + pos, buf, rem);
+        }
+
+        _mm256_zeroupper();
+}

--- a/erasure_code/gf_3vect_dot_prod_avx512_gfni.c
+++ b/erasure_code/gf_3vect_dot_prod_avx512_gfni.c
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright(c) 2026 Intel Corporation All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <immintrin.h>
+
+#define AFFINE(s, g)        _mm512_gf2p8affine_epi64_epi8((s), (g), 0x00)
+#define LOAD512(p)          _mm512_loadu_si512((const void *) (p))
+#define TAIL_MASK(len, pos) ((__mmask64) (((uint64_t) 1 << ((len) - (pos))) - 1))
+
+/*
+ * Embedded-broadcast GF multiply-accumulate for the dot_prod hot loop.
+ *
+ * acc ^= gf2p8affine(src, broadcast8(*coeff)).  The coefficient is read
+ * straight from the gftbls memory as an EVEX {1to8} embedded-broadcast operand
+ * of vgf2p8affineqb, folding the 8-byte broadcast into the affine's own load
+ * micro-op.  This deliberately avoids letting the compiler lower the broadcast
+ * to a GPR-source `vpbroadcastq %gpr,zmm` (+ a scalar `movq` load), which on
+ * Sapphire Rapids issues on the vector-ALU Port5 and made the multi-vect C
+ * encode ~25% slower than the NASM baseline (which keeps the broadcast on the
+ * load ports).  gcc/clang will NOT emit {1to8} from _mm512_set1_epi64()+affine
+ * (verified), so this must be inline asm.  A distinct scratch temp per call
+ * also keeps the N independent affines off a single shared dependency chain.
+ */
+#define AFFINE_XOR_BCAST(acc, s, coeff)                                                        \
+        do {                                                                                  \
+                __m512i _t;                                                                    \
+                __asm__("vgf2p8affineqb $0x00, (%[c])%{1to8%}, %[src], %[t]\n\t"               \
+                        "vpxorq %[t], %[p], %[p]"                                              \
+                        : [p] "+v"(acc), [t] "=&v"(_t)                                         \
+                        : [src] "v"(s), [c] "r"(coeff)                                         \
+                        :);                                                                    \
+        } while (0)
+
+__attribute__((target("avx512f,avx512bw,gfni"))) void
+gf_3vect_dot_prod_avx512_gfni(int len, int k, unsigned char *g_tbls, unsigned char **src,
+                              unsigned char **coding)
+{
+        unsigned char *d1 = coding[0], *d2 = coding[1];
+        unsigned char *d3 = coding[2];
+        const long row_stride = (long) k * 32;
+        int pos = 0;
+
+        for (; pos + 64 <= len; pos += 64) {
+                __m512i p1 = _mm512_setzero_si512();
+                __m512i p2 = _mm512_setzero_si512();
+                __m512i p3 = _mm512_setzero_si512();
+                unsigned char *tbl = g_tbls;
+
+                for (int i = 0; i < k; i++) {
+                        __m512i s = LOAD512(src[i] + pos);
+                        AFFINE_XOR_BCAST(p1, s, tbl + 0);
+                        AFFINE_XOR_BCAST(p2, s, tbl + 1 * row_stride);
+                        AFFINE_XOR_BCAST(p3, s, tbl + 2 * row_stride);
+                        tbl += 32;
+                }
+                _mm512_storeu_si512((void *) (d1 + pos), p1);
+                _mm512_storeu_si512((void *) (d2 + pos), p2);
+                _mm512_storeu_si512((void *) (d3 + pos), p3);
+        }
+
+        if (pos < len) {
+                const __mmask64 m = TAIL_MASK(len, pos);
+                __m512i p1 = _mm512_setzero_si512();
+                __m512i p2 = _mm512_setzero_si512();
+                __m512i p3 = _mm512_setzero_si512();
+                unsigned char *tbl = g_tbls;
+
+                for (int i = 0; i < k; i++) {
+                        __m512i s = _mm512_maskz_loadu_epi8(m, src[i] + pos);
+                        AFFINE_XOR_BCAST(p1, s, tbl + 0);
+                        AFFINE_XOR_BCAST(p2, s, tbl + 1 * row_stride);
+                        AFFINE_XOR_BCAST(p3, s, tbl + 2 * row_stride);
+                        tbl += 32;
+                }
+                _mm512_mask_storeu_epi8(d1 + pos, m, p1);
+                _mm512_mask_storeu_epi8(d2 + pos, m, p2);
+                _mm512_mask_storeu_epi8(d3 + pos, m, p3);
+        }
+}

--- a/erasure_code/gf_3vect_mad_avx2_gfni.c
+++ b/erasure_code/gf_3vect_mad_avx2_gfni.c
@@ -1,0 +1,154 @@
+/**********************************************************************
+  Copyright(c) 2026 Intel Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+#include <stdint.h>
+#include <string.h>
+#include <immintrin.h>
+
+#define BCAST_GF8(p) _mm256_set1_epi64x((long long) *(const uint64_t *) (p))
+#define AFFINE(s, g) _mm256_gf2p8affine_epi64_epi8((s), (g), 0x00)
+#define LOAD256(p)   _mm256_loadu_si256((const __m256i *) (p))
+
+__attribute__((target("avx2,gfni"))) void
+gf_3vect_mad_avx2_gfni(int len, int vec, int vec_i, unsigned char *gftbls, unsigned char *src,
+                       unsigned char **dest)
+{
+        const long row_stride = (long) vec * 32;
+        unsigned char *base = gftbls + (long) vec_i * 32;
+        unsigned char *dp1 = dest[0], *dp2 = dest[1], *dp3 = dest[2];
+        __m256i gft1 = BCAST_GF8(base + 0 * row_stride);
+        __m256i gft2 = BCAST_GF8(base + 1 * row_stride);
+        __m256i gft3 = BCAST_GF8(base + 2 * row_stride);
+
+        int pos = 0;
+        for (; pos + 96 <= len; pos += 96) {
+                __m256i xl = LOAD256(src + pos + 0);
+                __m256i xh = LOAD256(src + pos + 32);
+                __m256i xx = LOAD256(src + pos + 64);
+                __m256i d1l = LOAD256(dp1 + pos + 0);
+                __m256i d2l = LOAD256(dp2 + pos + 0);
+                __m256i d3l = LOAD256(dp3 + pos + 0);
+                d1l = _mm256_xor_si256(d1l, AFFINE(xl, gft1));
+                d2l = _mm256_xor_si256(d2l, AFFINE(xl, gft2));
+                d3l = _mm256_xor_si256(d3l, AFFINE(xl, gft3));
+                _mm256_storeu_si256((__m256i *) (dp1 + pos + 0), d1l);
+                _mm256_storeu_si256((__m256i *) (dp2 + pos + 0), d2l);
+                _mm256_storeu_si256((__m256i *) (dp3 + pos + 0), d3l);
+                __m256i d1h = LOAD256(dp1 + pos + 32);
+                __m256i d2h = LOAD256(dp2 + pos + 32);
+                __m256i d3h = LOAD256(dp3 + pos + 32);
+                d1h = _mm256_xor_si256(d1h, AFFINE(xh, gft1));
+                d2h = _mm256_xor_si256(d2h, AFFINE(xh, gft2));
+                d3h = _mm256_xor_si256(d3h, AFFINE(xh, gft3));
+                _mm256_storeu_si256((__m256i *) (dp1 + pos + 32), d1h);
+                _mm256_storeu_si256((__m256i *) (dp2 + pos + 32), d2h);
+                _mm256_storeu_si256((__m256i *) (dp3 + pos + 32), d3h);
+                __m256i d1x = LOAD256(dp1 + pos + 64);
+                __m256i d2x = LOAD256(dp2 + pos + 64);
+                __m256i d3x = LOAD256(dp3 + pos + 64);
+                d1x = _mm256_xor_si256(d1x, AFFINE(xx, gft1));
+                d2x = _mm256_xor_si256(d2x, AFFINE(xx, gft2));
+                d3x = _mm256_xor_si256(d3x, AFFINE(xx, gft3));
+                _mm256_storeu_si256((__m256i *) (dp1 + pos + 64), d1x);
+                _mm256_storeu_si256((__m256i *) (dp2 + pos + 64), d2x);
+                _mm256_storeu_si256((__m256i *) (dp3 + pos + 64), d3x);
+        }
+
+        if (pos + 64 <= len) {
+                __m256i xl = LOAD256(src + pos + 0);
+                __m256i xh = LOAD256(src + pos + 32);
+                __m256i d1l = LOAD256(dp1 + pos + 0);
+                __m256i d2l = LOAD256(dp2 + pos + 0);
+                __m256i d3l = LOAD256(dp3 + pos + 0);
+                d1l = _mm256_xor_si256(d1l, AFFINE(xl, gft1));
+                d2l = _mm256_xor_si256(d2l, AFFINE(xl, gft2));
+                d3l = _mm256_xor_si256(d3l, AFFINE(xl, gft3));
+                _mm256_storeu_si256((__m256i *) (dp1 + pos + 0), d1l);
+                _mm256_storeu_si256((__m256i *) (dp2 + pos + 0), d2l);
+                _mm256_storeu_si256((__m256i *) (dp3 + pos + 0), d3l);
+                __m256i d1h = LOAD256(dp1 + pos + 32);
+                __m256i d2h = LOAD256(dp2 + pos + 32);
+                __m256i d3h = LOAD256(dp3 + pos + 32);
+                d1h = _mm256_xor_si256(d1h, AFFINE(xh, gft1));
+                d2h = _mm256_xor_si256(d2h, AFFINE(xh, gft2));
+                d3h = _mm256_xor_si256(d3h, AFFINE(xh, gft3));
+                _mm256_storeu_si256((__m256i *) (dp1 + pos + 32), d1h);
+                _mm256_storeu_si256((__m256i *) (dp2 + pos + 32), d2h);
+                _mm256_storeu_si256((__m256i *) (dp3 + pos + 32), d3h);
+                pos += 64;
+        }
+
+        if (pos + 32 <= len) {
+                __m256i x = LOAD256(src + pos);
+                __m256i d1 = LOAD256(dp1 + pos + 0);
+                __m256i d2 = LOAD256(dp2 + pos + 0);
+                __m256i d3 = LOAD256(dp3 + pos + 0);
+                d1 = _mm256_xor_si256(d1, AFFINE(x, gft1));
+                d2 = _mm256_xor_si256(d2, AFFINE(x, gft2));
+                d3 = _mm256_xor_si256(d3, AFFINE(x, gft3));
+                _mm256_storeu_si256((__m256i *) (dp1 + pos + 0), d1);
+                _mm256_storeu_si256((__m256i *) (dp2 + pos + 0), d2);
+                _mm256_storeu_si256((__m256i *) (dp3 + pos + 0), d3);
+                pos += 32;
+        }
+
+        if (pos < len) {
+                int rem = len - pos;
+                unsigned char sbuf[32] __attribute__((aligned(32))) = { 0 };
+                unsigned char dbuf[32] __attribute__((aligned(32)));
+                memcpy(sbuf, src + pos, rem);
+                __m256i x = _mm256_load_si256((const __m256i *) sbuf);
+                memset(dbuf, 0, 32);
+                memcpy(dbuf, dp1 + pos, rem);
+                {
+                        __m256i d = _mm256_load_si256((const __m256i *) dbuf);
+                        d = _mm256_xor_si256(d, AFFINE(x, gft1));
+                        _mm256_store_si256((__m256i *) dbuf, d);
+                }
+                memcpy(dp1 + pos, dbuf, rem);
+                memset(dbuf, 0, 32);
+                memcpy(dbuf, dp2 + pos, rem);
+                {
+                        __m256i d = _mm256_load_si256((const __m256i *) dbuf);
+                        d = _mm256_xor_si256(d, AFFINE(x, gft2));
+                        _mm256_store_si256((__m256i *) dbuf, d);
+                }
+                memcpy(dp2 + pos, dbuf, rem);
+                memset(dbuf, 0, 32);
+                memcpy(dbuf, dp3 + pos, rem);
+                {
+                        __m256i d = _mm256_load_si256((const __m256i *) dbuf);
+                        d = _mm256_xor_si256(d, AFFINE(x, gft3));
+                        _mm256_store_si256((__m256i *) dbuf, d);
+                }
+                memcpy(dp3 + pos, dbuf, rem);
+        }
+
+        _mm256_zeroupper();
+}

--- a/erasure_code/gf_3vect_mad_avx512_gfni.c
+++ b/erasure_code/gf_3vect_mad_avx512_gfni.c
@@ -1,0 +1,71 @@
+/**********************************************************************
+  Copyright(c) 2026 Intel Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+#include <stdint.h>
+#include <immintrin.h>
+
+__attribute__((target("avx512f,avx512bw,gfni"))) void
+gf_3vect_mad_avx512_gfni(int len, int vec, int vec_i, unsigned char *gftbls, unsigned char *src,
+                         unsigned char **dest)
+{
+        const long row_stride = (long) vec * 32;
+        unsigned char *base = gftbls + (long) vec_i * 32;
+        unsigned char *d1_p = dest[0], *d2_p = dest[1], *d3_p = dest[2];
+        __m512i gft1 = _mm512_set1_epi64((long long) *(const uint64_t *) (base + 0 * row_stride));
+        __m512i gft2 = _mm512_set1_epi64((long long) *(const uint64_t *) (base + 1 * row_stride));
+        __m512i gft3 = _mm512_set1_epi64((long long) *(const uint64_t *) (base + 2 * row_stride));
+
+        int pos = 0;
+        for (; pos + 64 <= len; pos += 64) {
+                __m512i s = _mm512_loadu_si512((const void *) (src + pos));
+                __m512i d1 = _mm512_loadu_si512((const void *) (d1_p + pos));
+                __m512i d2 = _mm512_loadu_si512((const void *) (d2_p + pos));
+                __m512i d3 = _mm512_loadu_si512((const void *) (d3_p + pos));
+                d1 = _mm512_xor_si512(d1, _mm512_gf2p8affine_epi64_epi8(s, gft1, 0x00));
+                d2 = _mm512_xor_si512(d2, _mm512_gf2p8affine_epi64_epi8(s, gft2, 0x00));
+                d3 = _mm512_xor_si512(d3, _mm512_gf2p8affine_epi64_epi8(s, gft3, 0x00));
+                _mm512_storeu_si512((void *) (d1_p + pos), d1);
+                _mm512_storeu_si512((void *) (d2_p + pos), d2);
+                _mm512_storeu_si512((void *) (d3_p + pos), d3);
+        }
+
+        if (pos < len) {
+                const __mmask64 m = (__mmask64) (((uint64_t) 1 << (len - pos)) - 1);
+                __m512i s = _mm512_maskz_loadu_epi8(m, src + pos);
+                __m512i d1 = _mm512_maskz_loadu_epi8(m, d1_p + pos);
+                __m512i d2 = _mm512_maskz_loadu_epi8(m, d2_p + pos);
+                __m512i d3 = _mm512_maskz_loadu_epi8(m, d3_p + pos);
+                d1 = _mm512_xor_si512(d1, _mm512_gf2p8affine_epi64_epi8(s, gft1, 0x00));
+                d2 = _mm512_xor_si512(d2, _mm512_gf2p8affine_epi64_epi8(s, gft2, 0x00));
+                d3 = _mm512_xor_si512(d3, _mm512_gf2p8affine_epi64_epi8(s, gft3, 0x00));
+                _mm512_mask_storeu_epi8(d1_p + pos, m, d1);
+                _mm512_mask_storeu_epi8(d2_p + pos, m, d2);
+                _mm512_mask_storeu_epi8(d3_p + pos, m, d3);
+        }
+}

--- a/erasure_code/gf_4vect_dot_prod_avx512_gfni.c
+++ b/erasure_code/gf_4vect_dot_prod_avx512_gfni.c
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright(c) 2026 Intel Corporation All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <immintrin.h>
+
+#define AFFINE(s, g)        _mm512_gf2p8affine_epi64_epi8((s), (g), 0x00)
+#define LOAD512(p)          _mm512_loadu_si512((const void *) (p))
+#define TAIL_MASK(len, pos) ((__mmask64) (((uint64_t) 1 << ((len) - (pos))) - 1))
+
+/*
+ * Embedded-broadcast GF multiply-accumulate for the dot_prod hot loop.
+ *
+ * acc ^= gf2p8affine(src, broadcast8(*coeff)).  The coefficient is read
+ * straight from the gftbls memory as an EVEX {1to8} embedded-broadcast operand
+ * of vgf2p8affineqb, folding the 8-byte broadcast into the affine's own load
+ * micro-op.  This deliberately avoids letting the compiler lower the broadcast
+ * to a GPR-source `vpbroadcastq %gpr,zmm` (+ a scalar `movq` load), which on
+ * Sapphire Rapids issues on the vector-ALU Port5 and made the multi-vect C
+ * encode ~25% slower than the NASM baseline (which keeps the broadcast on the
+ * load ports).  gcc/clang will NOT emit {1to8} from _mm512_set1_epi64()+affine
+ * (verified), so this must be inline asm.  A distinct scratch temp per call
+ * also keeps the N independent affines off a single shared dependency chain.
+ */
+#define AFFINE_XOR_BCAST(acc, s, coeff)                                                        \
+        do {                                                                                  \
+                __m512i _t;                                                                    \
+                __asm__("vgf2p8affineqb $0x00, (%[c])%{1to8%}, %[src], %[t]\n\t"               \
+                        "vpxorq %[t], %[p], %[p]"                                              \
+                        : [p] "+v"(acc), [t] "=&v"(_t)                                         \
+                        : [src] "v"(s), [c] "r"(coeff)                                         \
+                        :);                                                                    \
+        } while (0)
+
+__attribute__((target("avx512f,avx512bw,gfni"))) void
+gf_4vect_dot_prod_avx512_gfni(int len, int k, unsigned char *g_tbls, unsigned char **src,
+                              unsigned char **coding)
+{
+        unsigned char *d1 = coding[0], *d2 = coding[1];
+        unsigned char *d3 = coding[2], *d4 = coding[3];
+        const long row_stride = (long) k * 32;
+        int pos = 0;
+
+        for (; pos + 64 <= len; pos += 64) {
+                __m512i p1 = _mm512_setzero_si512();
+                __m512i p2 = _mm512_setzero_si512();
+                __m512i p3 = _mm512_setzero_si512();
+                __m512i p4 = _mm512_setzero_si512();
+                unsigned char *tbl = g_tbls;
+
+                for (int i = 0; i < k; i++) {
+                        __m512i s = LOAD512(src[i] + pos);
+                        AFFINE_XOR_BCAST(p1, s, tbl + 0);
+                        AFFINE_XOR_BCAST(p2, s, tbl + 1 * row_stride);
+                        AFFINE_XOR_BCAST(p3, s, tbl + 2 * row_stride);
+                        AFFINE_XOR_BCAST(p4, s, tbl + 3 * row_stride);
+                        tbl += 32;
+                }
+                _mm512_storeu_si512((void *) (d1 + pos), p1);
+                _mm512_storeu_si512((void *) (d2 + pos), p2);
+                _mm512_storeu_si512((void *) (d3 + pos), p3);
+                _mm512_storeu_si512((void *) (d4 + pos), p4);
+        }
+
+        if (pos < len) {
+                const __mmask64 m = TAIL_MASK(len, pos);
+                __m512i p1 = _mm512_setzero_si512();
+                __m512i p2 = _mm512_setzero_si512();
+                __m512i p3 = _mm512_setzero_si512();
+                __m512i p4 = _mm512_setzero_si512();
+                unsigned char *tbl = g_tbls;
+
+                for (int i = 0; i < k; i++) {
+                        __m512i s = _mm512_maskz_loadu_epi8(m, src[i] + pos);
+                        AFFINE_XOR_BCAST(p1, s, tbl + 0);
+                        AFFINE_XOR_BCAST(p2, s, tbl + 1 * row_stride);
+                        AFFINE_XOR_BCAST(p3, s, tbl + 2 * row_stride);
+                        AFFINE_XOR_BCAST(p4, s, tbl + 3 * row_stride);
+                        tbl += 32;
+                }
+                _mm512_mask_storeu_epi8(d1 + pos, m, p1);
+                _mm512_mask_storeu_epi8(d2 + pos, m, p2);
+                _mm512_mask_storeu_epi8(d3 + pos, m, p3);
+                _mm512_mask_storeu_epi8(d4 + pos, m, p4);
+        }
+}

--- a/erasure_code/gf_4vect_mad_avx2_gfni.c
+++ b/erasure_code/gf_4vect_mad_avx2_gfni.c
@@ -1,0 +1,179 @@
+/**********************************************************************
+  Copyright(c) 2026 Intel Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+#include <stdint.h>
+#include <string.h>
+#include <immintrin.h>
+
+#define AFFINE(s, g) _mm256_gf2p8affine_epi64_epi8((s), (g), 0x00)
+
+__attribute__((target("avx2,gfni"))) void
+gf_4vect_mad_avx2_gfni(int len, int vec, int vec_i, unsigned char *gftbls, unsigned char *src,
+                       unsigned char **dest)
+{
+        const long row_stride = (long) vec * 32;
+        unsigned char *base = gftbls + (long) vec_i * 32;
+        unsigned char *dp1 = dest[0], *dp2 = dest[1], *dp3 = dest[2], *dp4 = dest[3];
+        __m256i gft1 = _mm256_set1_epi64x((long long) *(const uint64_t *) (base + 0 * row_stride));
+        __m256i gft2 = _mm256_set1_epi64x((long long) *(const uint64_t *) (base + 1 * row_stride));
+        __m256i gft3 = _mm256_set1_epi64x((long long) *(const uint64_t *) (base + 2 * row_stride));
+        __m256i gft4 = _mm256_set1_epi64x((long long) *(const uint64_t *) (base + 3 * row_stride));
+
+        int pos = 0;
+        for (; pos + 96 <= len; pos += 96) {
+                __m256i xl = _mm256_loadu_si256((const __m256i *) (src + pos + 0));
+                __m256i xh = _mm256_loadu_si256((const __m256i *) (src + pos + 32));
+                __m256i xx = _mm256_loadu_si256((const __m256i *) (src + pos + 64));
+                __m256i d1l = _mm256_loadu_si256((const __m256i *) (dp1 + pos + 0));
+                __m256i d2l = _mm256_loadu_si256((const __m256i *) (dp2 + pos + 0));
+                __m256i d3l = _mm256_loadu_si256((const __m256i *) (dp3 + pos + 0));
+                __m256i d4l = _mm256_loadu_si256((const __m256i *) (dp4 + pos + 0));
+                d1l = _mm256_xor_si256(d1l, AFFINE(xl, gft1));
+                d2l = _mm256_xor_si256(d2l, AFFINE(xl, gft2));
+                d3l = _mm256_xor_si256(d3l, AFFINE(xl, gft3));
+                d4l = _mm256_xor_si256(d4l, AFFINE(xl, gft4));
+                _mm256_storeu_si256((__m256i *) (dp1 + pos + 0), d1l);
+                _mm256_storeu_si256((__m256i *) (dp2 + pos + 0), d2l);
+                _mm256_storeu_si256((__m256i *) (dp3 + pos + 0), d3l);
+                _mm256_storeu_si256((__m256i *) (dp4 + pos + 0), d4l);
+                __m256i d1h = _mm256_loadu_si256((const __m256i *) (dp1 + pos + 32));
+                __m256i d2h = _mm256_loadu_si256((const __m256i *) (dp2 + pos + 32));
+                __m256i d3h = _mm256_loadu_si256((const __m256i *) (dp3 + pos + 32));
+                __m256i d4h = _mm256_loadu_si256((const __m256i *) (dp4 + pos + 32));
+                d1h = _mm256_xor_si256(d1h, AFFINE(xh, gft1));
+                d2h = _mm256_xor_si256(d2h, AFFINE(xh, gft2));
+                d3h = _mm256_xor_si256(d3h, AFFINE(xh, gft3));
+                d4h = _mm256_xor_si256(d4h, AFFINE(xh, gft4));
+                _mm256_storeu_si256((__m256i *) (dp1 + pos + 32), d1h);
+                _mm256_storeu_si256((__m256i *) (dp2 + pos + 32), d2h);
+                _mm256_storeu_si256((__m256i *) (dp3 + pos + 32), d3h);
+                _mm256_storeu_si256((__m256i *) (dp4 + pos + 32), d4h);
+                __m256i d1x = _mm256_loadu_si256((const __m256i *) (dp1 + pos + 64));
+                __m256i d2x = _mm256_loadu_si256((const __m256i *) (dp2 + pos + 64));
+                __m256i d3x = _mm256_loadu_si256((const __m256i *) (dp3 + pos + 64));
+                __m256i d4x = _mm256_loadu_si256((const __m256i *) (dp4 + pos + 64));
+                d1x = _mm256_xor_si256(d1x, AFFINE(xx, gft1));
+                d2x = _mm256_xor_si256(d2x, AFFINE(xx, gft2));
+                d3x = _mm256_xor_si256(d3x, AFFINE(xx, gft3));
+                d4x = _mm256_xor_si256(d4x, AFFINE(xx, gft4));
+                _mm256_storeu_si256((__m256i *) (dp1 + pos + 64), d1x);
+                _mm256_storeu_si256((__m256i *) (dp2 + pos + 64), d2x);
+                _mm256_storeu_si256((__m256i *) (dp3 + pos + 64), d3x);
+                _mm256_storeu_si256((__m256i *) (dp4 + pos + 64), d4x);
+        }
+
+        if (pos + 64 <= len) {
+                __m256i xl = _mm256_loadu_si256((const __m256i *) (src + pos + 0));
+                __m256i xh = _mm256_loadu_si256((const __m256i *) (src + pos + 32));
+                __m256i d1l = _mm256_loadu_si256((const __m256i *) (dp1 + pos + 0));
+                __m256i d2l = _mm256_loadu_si256((const __m256i *) (dp2 + pos + 0));
+                __m256i d3l = _mm256_loadu_si256((const __m256i *) (dp3 + pos + 0));
+                __m256i d4l = _mm256_loadu_si256((const __m256i *) (dp4 + pos + 0));
+                d1l = _mm256_xor_si256(d1l, AFFINE(xl, gft1));
+                d2l = _mm256_xor_si256(d2l, AFFINE(xl, gft2));
+                d3l = _mm256_xor_si256(d3l, AFFINE(xl, gft3));
+                d4l = _mm256_xor_si256(d4l, AFFINE(xl, gft4));
+                _mm256_storeu_si256((__m256i *) (dp1 + pos + 0), d1l);
+                _mm256_storeu_si256((__m256i *) (dp2 + pos + 0), d2l);
+                _mm256_storeu_si256((__m256i *) (dp3 + pos + 0), d3l);
+                _mm256_storeu_si256((__m256i *) (dp4 + pos + 0), d4l);
+                __m256i d1h = _mm256_loadu_si256((const __m256i *) (dp1 + pos + 32));
+                __m256i d2h = _mm256_loadu_si256((const __m256i *) (dp2 + pos + 32));
+                __m256i d3h = _mm256_loadu_si256((const __m256i *) (dp3 + pos + 32));
+                __m256i d4h = _mm256_loadu_si256((const __m256i *) (dp4 + pos + 32));
+                d1h = _mm256_xor_si256(d1h, AFFINE(xh, gft1));
+                d2h = _mm256_xor_si256(d2h, AFFINE(xh, gft2));
+                d3h = _mm256_xor_si256(d3h, AFFINE(xh, gft3));
+                d4h = _mm256_xor_si256(d4h, AFFINE(xh, gft4));
+                _mm256_storeu_si256((__m256i *) (dp1 + pos + 32), d1h);
+                _mm256_storeu_si256((__m256i *) (dp2 + pos + 32), d2h);
+                _mm256_storeu_si256((__m256i *) (dp3 + pos + 32), d3h);
+                _mm256_storeu_si256((__m256i *) (dp4 + pos + 32), d4h);
+                pos += 64;
+        }
+
+        if (pos + 32 <= len) {
+                __m256i x = _mm256_loadu_si256((const __m256i *) (src + pos));
+                __m256i d1 = _mm256_loadu_si256((const __m256i *) (dp1 + pos + 0));
+                __m256i d2 = _mm256_loadu_si256((const __m256i *) (dp2 + pos + 0));
+                __m256i d3 = _mm256_loadu_si256((const __m256i *) (dp3 + pos + 0));
+                __m256i d4 = _mm256_loadu_si256((const __m256i *) (dp4 + pos + 0));
+                d1 = _mm256_xor_si256(d1, AFFINE(x, gft1));
+                d2 = _mm256_xor_si256(d2, AFFINE(x, gft2));
+                d3 = _mm256_xor_si256(d3, AFFINE(x, gft3));
+                d4 = _mm256_xor_si256(d4, AFFINE(x, gft4));
+                _mm256_storeu_si256((__m256i *) (dp1 + pos + 0), d1);
+                _mm256_storeu_si256((__m256i *) (dp2 + pos + 0), d2);
+                _mm256_storeu_si256((__m256i *) (dp3 + pos + 0), d3);
+                _mm256_storeu_si256((__m256i *) (dp4 + pos + 0), d4);
+                pos += 32;
+        }
+
+        if (pos < len) {
+                int rem = len - pos;
+                unsigned char sbuf[32] __attribute__((aligned(32))) = { 0 };
+                unsigned char dbuf[32] __attribute__((aligned(32)));
+                memcpy(sbuf, src + pos, rem);
+                __m256i x = _mm256_load_si256((const __m256i *) sbuf);
+                memset(dbuf, 0, 32);
+                memcpy(dbuf, dp1 + pos, rem);
+                {
+                        __m256i d = _mm256_load_si256((const __m256i *) dbuf);
+                        d = _mm256_xor_si256(d, AFFINE(x, gft1));
+                        _mm256_store_si256((__m256i *) dbuf, d);
+                }
+                memcpy(dp1 + pos, dbuf, rem);
+                memset(dbuf, 0, 32);
+                memcpy(dbuf, dp2 + pos, rem);
+                {
+                        __m256i d = _mm256_load_si256((const __m256i *) dbuf);
+                        d = _mm256_xor_si256(d, AFFINE(x, gft2));
+                        _mm256_store_si256((__m256i *) dbuf, d);
+                }
+                memcpy(dp2 + pos, dbuf, rem);
+                memset(dbuf, 0, 32);
+                memcpy(dbuf, dp3 + pos, rem);
+                {
+                        __m256i d = _mm256_load_si256((const __m256i *) dbuf);
+                        d = _mm256_xor_si256(d, AFFINE(x, gft3));
+                        _mm256_store_si256((__m256i *) dbuf, d);
+                }
+                memcpy(dp3 + pos, dbuf, rem);
+                memset(dbuf, 0, 32);
+                memcpy(dbuf, dp4 + pos, rem);
+                {
+                        __m256i d = _mm256_load_si256((const __m256i *) dbuf);
+                        d = _mm256_xor_si256(d, AFFINE(x, gft4));
+                        _mm256_store_si256((__m256i *) dbuf, d);
+                }
+                memcpy(dp4 + pos, dbuf, rem);
+        }
+
+        _mm256_zeroupper();
+}

--- a/erasure_code/gf_4vect_mad_avx512_gfni.c
+++ b/erasure_code/gf_4vect_mad_avx512_gfni.c
@@ -1,0 +1,78 @@
+/**********************************************************************
+  Copyright(c) 2026 Intel Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+#include <stdint.h>
+#include <immintrin.h>
+
+__attribute__((target("avx512f,avx512bw,gfni"))) void
+gf_4vect_mad_avx512_gfni(int len, int vec, int vec_i, unsigned char *gftbls, unsigned char *src,
+                         unsigned char **dest)
+{
+        const long row_stride = (long) vec * 32;
+        unsigned char *base = gftbls + (long) vec_i * 32;
+        unsigned char *d1_p = dest[0], *d2_p = dest[1], *d3_p = dest[2], *d4_p = dest[3];
+        __m512i gft1 = _mm512_set1_epi64((long long) *(const uint64_t *) (base + 0 * row_stride));
+        __m512i gft2 = _mm512_set1_epi64((long long) *(const uint64_t *) (base + 1 * row_stride));
+        __m512i gft3 = _mm512_set1_epi64((long long) *(const uint64_t *) (base + 2 * row_stride));
+        __m512i gft4 = _mm512_set1_epi64((long long) *(const uint64_t *) (base + 3 * row_stride));
+
+        int pos = 0;
+        for (; pos + 64 <= len; pos += 64) {
+                __m512i s = _mm512_loadu_si512((const void *) (src + pos));
+                __m512i d1 = _mm512_loadu_si512((const void *) (d1_p + pos));
+                __m512i d2 = _mm512_loadu_si512((const void *) (d2_p + pos));
+                __m512i d3 = _mm512_loadu_si512((const void *) (d3_p + pos));
+                __m512i d4 = _mm512_loadu_si512((const void *) (d4_p + pos));
+                d1 = _mm512_xor_si512(d1, _mm512_gf2p8affine_epi64_epi8(s, gft1, 0x00));
+                d2 = _mm512_xor_si512(d2, _mm512_gf2p8affine_epi64_epi8(s, gft2, 0x00));
+                d3 = _mm512_xor_si512(d3, _mm512_gf2p8affine_epi64_epi8(s, gft3, 0x00));
+                d4 = _mm512_xor_si512(d4, _mm512_gf2p8affine_epi64_epi8(s, gft4, 0x00));
+                _mm512_storeu_si512((void *) (d1_p + pos), d1);
+                _mm512_storeu_si512((void *) (d2_p + pos), d2);
+                _mm512_storeu_si512((void *) (d3_p + pos), d3);
+                _mm512_storeu_si512((void *) (d4_p + pos), d4);
+        }
+
+        if (pos < len) {
+                const __mmask64 m = (__mmask64) (((uint64_t) 1 << (len - pos)) - 1);
+                __m512i s = _mm512_maskz_loadu_epi8(m, src + pos);
+                __m512i d1 = _mm512_maskz_loadu_epi8(m, d1_p + pos);
+                __m512i d2 = _mm512_maskz_loadu_epi8(m, d2_p + pos);
+                __m512i d3 = _mm512_maskz_loadu_epi8(m, d3_p + pos);
+                __m512i d4 = _mm512_maskz_loadu_epi8(m, d4_p + pos);
+                d1 = _mm512_xor_si512(d1, _mm512_gf2p8affine_epi64_epi8(s, gft1, 0x00));
+                d2 = _mm512_xor_si512(d2, _mm512_gf2p8affine_epi64_epi8(s, gft2, 0x00));
+                d3 = _mm512_xor_si512(d3, _mm512_gf2p8affine_epi64_epi8(s, gft3, 0x00));
+                d4 = _mm512_xor_si512(d4, _mm512_gf2p8affine_epi64_epi8(s, gft4, 0x00));
+                _mm512_mask_storeu_epi8(d1_p + pos, m, d1);
+                _mm512_mask_storeu_epi8(d2_p + pos, m, d2);
+                _mm512_mask_storeu_epi8(d3_p + pos, m, d3);
+                _mm512_mask_storeu_epi8(d4_p + pos, m, d4);
+        }
+}

--- a/erasure_code/gf_5vect_dot_prod_avx512_gfni.c
+++ b/erasure_code/gf_5vect_dot_prod_avx512_gfni.c
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright(c) 2026 Intel Corporation All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <immintrin.h>
+
+#define AFFINE(s, g)        _mm512_gf2p8affine_epi64_epi8((s), (g), 0x00)
+#define LOAD512(p)          _mm512_loadu_si512((const void *) (p))
+#define TAIL_MASK(len, pos) ((__mmask64) (((uint64_t) 1 << ((len) - (pos))) - 1))
+
+/*
+ * Embedded-broadcast GF multiply-accumulate for the dot_prod hot loop.
+ *
+ * acc ^= gf2p8affine(src, broadcast8(*coeff)).  The coefficient is read
+ * straight from the gftbls memory as an EVEX {1to8} embedded-broadcast operand
+ * of vgf2p8affineqb, folding the 8-byte broadcast into the affine's own load
+ * micro-op.  This deliberately avoids letting the compiler lower the broadcast
+ * to a GPR-source `vpbroadcastq %gpr,zmm` (+ a scalar `movq` load), which on
+ * Sapphire Rapids issues on the vector-ALU Port5 and made the multi-vect C
+ * encode ~25% slower than the NASM baseline (which keeps the broadcast on the
+ * load ports).  gcc/clang will NOT emit {1to8} from _mm512_set1_epi64()+affine
+ * (verified), so this must be inline asm.  A distinct scratch temp per call
+ * also keeps the N independent affines off a single shared dependency chain.
+ */
+#define AFFINE_XOR_BCAST(acc, s, coeff)                                                        \
+        do {                                                                                  \
+                __m512i _t;                                                                    \
+                __asm__("vgf2p8affineqb $0x00, (%[c])%{1to8%}, %[src], %[t]\n\t"               \
+                        "vpxorq %[t], %[p], %[p]"                                              \
+                        : [p] "+v"(acc), [t] "=&v"(_t)                                         \
+                        : [src] "v"(s), [c] "r"(coeff)                                         \
+                        :);                                                                    \
+        } while (0)
+
+__attribute__((target("avx512f,avx512bw,gfni"))) void
+gf_5vect_dot_prod_avx512_gfni(int len, int k, unsigned char *g_tbls, unsigned char **src,
+                              unsigned char **coding)
+{
+        unsigned char *d1 = coding[0], *d2 = coding[1];
+        unsigned char *d3 = coding[2], *d4 = coding[3];
+        unsigned char *d5 = coding[4];
+        const long row_stride = (long) k * 32;
+        int pos = 0;
+
+        for (; pos + 64 <= len; pos += 64) {
+                __m512i p1 = _mm512_setzero_si512();
+                __m512i p2 = _mm512_setzero_si512();
+                __m512i p3 = _mm512_setzero_si512();
+                __m512i p4 = _mm512_setzero_si512();
+                __m512i p5 = _mm512_setzero_si512();
+                unsigned char *tbl = g_tbls;
+
+                for (int i = 0; i < k; i++) {
+                        __m512i s = LOAD512(src[i] + pos);
+                        AFFINE_XOR_BCAST(p1, s, tbl + 0);
+                        AFFINE_XOR_BCAST(p2, s, tbl + 1 * row_stride);
+                        AFFINE_XOR_BCAST(p3, s, tbl + 2 * row_stride);
+                        AFFINE_XOR_BCAST(p4, s, tbl + 3 * row_stride);
+                        AFFINE_XOR_BCAST(p5, s, tbl + 4 * row_stride);
+                        tbl += 32;
+                }
+                _mm512_storeu_si512((void *) (d1 + pos), p1);
+                _mm512_storeu_si512((void *) (d2 + pos), p2);
+                _mm512_storeu_si512((void *) (d3 + pos), p3);
+                _mm512_storeu_si512((void *) (d4 + pos), p4);
+                _mm512_storeu_si512((void *) (d5 + pos), p5);
+        }
+
+        if (pos < len) {
+                const __mmask64 m = TAIL_MASK(len, pos);
+                __m512i p1 = _mm512_setzero_si512();
+                __m512i p2 = _mm512_setzero_si512();
+                __m512i p3 = _mm512_setzero_si512();
+                __m512i p4 = _mm512_setzero_si512();
+                __m512i p5 = _mm512_setzero_si512();
+                unsigned char *tbl = g_tbls;
+
+                for (int i = 0; i < k; i++) {
+                        __m512i s = _mm512_maskz_loadu_epi8(m, src[i] + pos);
+                        AFFINE_XOR_BCAST(p1, s, tbl + 0);
+                        AFFINE_XOR_BCAST(p2, s, tbl + 1 * row_stride);
+                        AFFINE_XOR_BCAST(p3, s, tbl + 2 * row_stride);
+                        AFFINE_XOR_BCAST(p4, s, tbl + 3 * row_stride);
+                        AFFINE_XOR_BCAST(p5, s, tbl + 4 * row_stride);
+                        tbl += 32;
+                }
+                _mm512_mask_storeu_epi8(d1 + pos, m, p1);
+                _mm512_mask_storeu_epi8(d2 + pos, m, p2);
+                _mm512_mask_storeu_epi8(d3 + pos, m, p3);
+                _mm512_mask_storeu_epi8(d4 + pos, m, p4);
+                _mm512_mask_storeu_epi8(d5 + pos, m, p5);
+        }
+}

--- a/erasure_code/gf_5vect_mad_avx2_gfni.c
+++ b/erasure_code/gf_5vect_mad_avx2_gfni.c
@@ -1,0 +1,207 @@
+/**********************************************************************
+  Copyright(c) 2026 Intel Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+#include <stdint.h>
+#include <string.h>
+#include <immintrin.h>
+
+#define AFFINE(s, g) _mm256_gf2p8affine_epi64_epi8((s), (g), 0x00)
+
+__attribute__((target("avx2,gfni"))) void
+gf_5vect_mad_avx2_gfni(int len, int vec, int vec_i, unsigned char *gftbls, unsigned char *src,
+                       unsigned char **dest)
+{
+        const long row_stride = (long) vec * 32;
+        unsigned char *base = gftbls + (long) vec_i * 32;
+        unsigned char *dp1 = dest[0], *dp2 = dest[1], *dp3 = dest[2], *dp4 = dest[3],
+                      *dp5 = dest[4];
+        __m256i gft1 = _mm256_set1_epi64x((long long) *(const uint64_t *) (base + 0 * row_stride));
+        __m256i gft2 = _mm256_set1_epi64x((long long) *(const uint64_t *) (base + 1 * row_stride));
+        __m256i gft3 = _mm256_set1_epi64x((long long) *(const uint64_t *) (base + 2 * row_stride));
+        __m256i gft4 = _mm256_set1_epi64x((long long) *(const uint64_t *) (base + 3 * row_stride));
+        __m256i gft5 = _mm256_set1_epi64x((long long) *(const uint64_t *) (base + 4 * row_stride));
+
+        int pos = 0;
+        for (; pos + 96 <= len; pos += 96) {
+                __m256i xl = _mm256_loadu_si256((const __m256i *) (src + pos + 0));
+                __m256i xh = _mm256_loadu_si256((const __m256i *) (src + pos + 32));
+                __m256i xx = _mm256_loadu_si256((const __m256i *) (src + pos + 64));
+                __m256i d1l = _mm256_loadu_si256((const __m256i *) (dp1 + pos + 0));
+                __m256i d2l = _mm256_loadu_si256((const __m256i *) (dp2 + pos + 0));
+                __m256i d3l = _mm256_loadu_si256((const __m256i *) (dp3 + pos + 0));
+                __m256i d4l = _mm256_loadu_si256((const __m256i *) (dp4 + pos + 0));
+                __m256i d5l = _mm256_loadu_si256((const __m256i *) (dp5 + pos + 0));
+                d1l = _mm256_xor_si256(d1l, AFFINE(xl, gft1));
+                d2l = _mm256_xor_si256(d2l, AFFINE(xl, gft2));
+                d3l = _mm256_xor_si256(d3l, AFFINE(xl, gft3));
+                d4l = _mm256_xor_si256(d4l, AFFINE(xl, gft4));
+                d5l = _mm256_xor_si256(d5l, AFFINE(xl, gft5));
+                _mm256_storeu_si256((__m256i *) (dp1 + pos + 0), d1l);
+                _mm256_storeu_si256((__m256i *) (dp2 + pos + 0), d2l);
+                _mm256_storeu_si256((__m256i *) (dp3 + pos + 0), d3l);
+                _mm256_storeu_si256((__m256i *) (dp4 + pos + 0), d4l);
+                _mm256_storeu_si256((__m256i *) (dp5 + pos + 0), d5l);
+                __m256i d1h = _mm256_loadu_si256((const __m256i *) (dp1 + pos + 32));
+                __m256i d2h = _mm256_loadu_si256((const __m256i *) (dp2 + pos + 32));
+                __m256i d3h = _mm256_loadu_si256((const __m256i *) (dp3 + pos + 32));
+                __m256i d4h = _mm256_loadu_si256((const __m256i *) (dp4 + pos + 32));
+                __m256i d5h = _mm256_loadu_si256((const __m256i *) (dp5 + pos + 32));
+                d1h = _mm256_xor_si256(d1h, AFFINE(xh, gft1));
+                d2h = _mm256_xor_si256(d2h, AFFINE(xh, gft2));
+                d3h = _mm256_xor_si256(d3h, AFFINE(xh, gft3));
+                d4h = _mm256_xor_si256(d4h, AFFINE(xh, gft4));
+                d5h = _mm256_xor_si256(d5h, AFFINE(xh, gft5));
+                _mm256_storeu_si256((__m256i *) (dp1 + pos + 32), d1h);
+                _mm256_storeu_si256((__m256i *) (dp2 + pos + 32), d2h);
+                _mm256_storeu_si256((__m256i *) (dp3 + pos + 32), d3h);
+                _mm256_storeu_si256((__m256i *) (dp4 + pos + 32), d4h);
+                _mm256_storeu_si256((__m256i *) (dp5 + pos + 32), d5h);
+                __m256i d1x = _mm256_loadu_si256((const __m256i *) (dp1 + pos + 64));
+                __m256i d2x = _mm256_loadu_si256((const __m256i *) (dp2 + pos + 64));
+                __m256i d3x = _mm256_loadu_si256((const __m256i *) (dp3 + pos + 64));
+                __m256i d4x = _mm256_loadu_si256((const __m256i *) (dp4 + pos + 64));
+                __m256i d5x = _mm256_loadu_si256((const __m256i *) (dp5 + pos + 64));
+                d1x = _mm256_xor_si256(d1x, AFFINE(xx, gft1));
+                d2x = _mm256_xor_si256(d2x, AFFINE(xx, gft2));
+                d3x = _mm256_xor_si256(d3x, AFFINE(xx, gft3));
+                d4x = _mm256_xor_si256(d4x, AFFINE(xx, gft4));
+                d5x = _mm256_xor_si256(d5x, AFFINE(xx, gft5));
+                _mm256_storeu_si256((__m256i *) (dp1 + pos + 64), d1x);
+                _mm256_storeu_si256((__m256i *) (dp2 + pos + 64), d2x);
+                _mm256_storeu_si256((__m256i *) (dp3 + pos + 64), d3x);
+                _mm256_storeu_si256((__m256i *) (dp4 + pos + 64), d4x);
+                _mm256_storeu_si256((__m256i *) (dp5 + pos + 64), d5x);
+        }
+
+        if (pos + 64 <= len) {
+                __m256i xl = _mm256_loadu_si256((const __m256i *) (src + pos + 0));
+                __m256i xh = _mm256_loadu_si256((const __m256i *) (src + pos + 32));
+                __m256i d1l = _mm256_loadu_si256((const __m256i *) (dp1 + pos + 0));
+                __m256i d2l = _mm256_loadu_si256((const __m256i *) (dp2 + pos + 0));
+                __m256i d3l = _mm256_loadu_si256((const __m256i *) (dp3 + pos + 0));
+                __m256i d4l = _mm256_loadu_si256((const __m256i *) (dp4 + pos + 0));
+                __m256i d5l = _mm256_loadu_si256((const __m256i *) (dp5 + pos + 0));
+                d1l = _mm256_xor_si256(d1l, AFFINE(xl, gft1));
+                d2l = _mm256_xor_si256(d2l, AFFINE(xl, gft2));
+                d3l = _mm256_xor_si256(d3l, AFFINE(xl, gft3));
+                d4l = _mm256_xor_si256(d4l, AFFINE(xl, gft4));
+                d5l = _mm256_xor_si256(d5l, AFFINE(xl, gft5));
+                _mm256_storeu_si256((__m256i *) (dp1 + pos + 0), d1l);
+                _mm256_storeu_si256((__m256i *) (dp2 + pos + 0), d2l);
+                _mm256_storeu_si256((__m256i *) (dp3 + pos + 0), d3l);
+                _mm256_storeu_si256((__m256i *) (dp4 + pos + 0), d4l);
+                _mm256_storeu_si256((__m256i *) (dp5 + pos + 0), d5l);
+                __m256i d1h = _mm256_loadu_si256((const __m256i *) (dp1 + pos + 32));
+                __m256i d2h = _mm256_loadu_si256((const __m256i *) (dp2 + pos + 32));
+                __m256i d3h = _mm256_loadu_si256((const __m256i *) (dp3 + pos + 32));
+                __m256i d4h = _mm256_loadu_si256((const __m256i *) (dp4 + pos + 32));
+                __m256i d5h = _mm256_loadu_si256((const __m256i *) (dp5 + pos + 32));
+                d1h = _mm256_xor_si256(d1h, AFFINE(xh, gft1));
+                d2h = _mm256_xor_si256(d2h, AFFINE(xh, gft2));
+                d3h = _mm256_xor_si256(d3h, AFFINE(xh, gft3));
+                d4h = _mm256_xor_si256(d4h, AFFINE(xh, gft4));
+                d5h = _mm256_xor_si256(d5h, AFFINE(xh, gft5));
+                _mm256_storeu_si256((__m256i *) (dp1 + pos + 32), d1h);
+                _mm256_storeu_si256((__m256i *) (dp2 + pos + 32), d2h);
+                _mm256_storeu_si256((__m256i *) (dp3 + pos + 32), d3h);
+                _mm256_storeu_si256((__m256i *) (dp4 + pos + 32), d4h);
+                _mm256_storeu_si256((__m256i *) (dp5 + pos + 32), d5h);
+                pos += 64;
+        }
+
+        if (pos + 32 <= len) {
+                __m256i x = _mm256_loadu_si256((const __m256i *) (src + pos));
+                __m256i d1 = _mm256_loadu_si256((const __m256i *) (dp1 + pos + 0));
+                __m256i d2 = _mm256_loadu_si256((const __m256i *) (dp2 + pos + 0));
+                __m256i d3 = _mm256_loadu_si256((const __m256i *) (dp3 + pos + 0));
+                __m256i d4 = _mm256_loadu_si256((const __m256i *) (dp4 + pos + 0));
+                __m256i d5 = _mm256_loadu_si256((const __m256i *) (dp5 + pos + 0));
+                d1 = _mm256_xor_si256(d1, AFFINE(x, gft1));
+                d2 = _mm256_xor_si256(d2, AFFINE(x, gft2));
+                d3 = _mm256_xor_si256(d3, AFFINE(x, gft3));
+                d4 = _mm256_xor_si256(d4, AFFINE(x, gft4));
+                d5 = _mm256_xor_si256(d5, AFFINE(x, gft5));
+                _mm256_storeu_si256((__m256i *) (dp1 + pos + 0), d1);
+                _mm256_storeu_si256((__m256i *) (dp2 + pos + 0), d2);
+                _mm256_storeu_si256((__m256i *) (dp3 + pos + 0), d3);
+                _mm256_storeu_si256((__m256i *) (dp4 + pos + 0), d4);
+                _mm256_storeu_si256((__m256i *) (dp5 + pos + 0), d5);
+                pos += 32;
+        }
+
+        if (pos < len) {
+                int rem = len - pos;
+                unsigned char sbuf[32] __attribute__((aligned(32))) = { 0 };
+                unsigned char dbuf[32] __attribute__((aligned(32)));
+                memcpy(sbuf, src + pos, rem);
+                __m256i x = _mm256_load_si256((const __m256i *) sbuf);
+                memset(dbuf, 0, 32);
+                memcpy(dbuf, dp1 + pos, rem);
+                {
+                        __m256i d = _mm256_load_si256((const __m256i *) dbuf);
+                        d = _mm256_xor_si256(d, AFFINE(x, gft1));
+                        _mm256_store_si256((__m256i *) dbuf, d);
+                }
+                memcpy(dp1 + pos, dbuf, rem);
+                memset(dbuf, 0, 32);
+                memcpy(dbuf, dp2 + pos, rem);
+                {
+                        __m256i d = _mm256_load_si256((const __m256i *) dbuf);
+                        d = _mm256_xor_si256(d, AFFINE(x, gft2));
+                        _mm256_store_si256((__m256i *) dbuf, d);
+                }
+                memcpy(dp2 + pos, dbuf, rem);
+                memset(dbuf, 0, 32);
+                memcpy(dbuf, dp3 + pos, rem);
+                {
+                        __m256i d = _mm256_load_si256((const __m256i *) dbuf);
+                        d = _mm256_xor_si256(d, AFFINE(x, gft3));
+                        _mm256_store_si256((__m256i *) dbuf, d);
+                }
+                memcpy(dp3 + pos, dbuf, rem);
+                memset(dbuf, 0, 32);
+                memcpy(dbuf, dp4 + pos, rem);
+                {
+                        __m256i d = _mm256_load_si256((const __m256i *) dbuf);
+                        d = _mm256_xor_si256(d, AFFINE(x, gft4));
+                        _mm256_store_si256((__m256i *) dbuf, d);
+                }
+                memcpy(dp4 + pos, dbuf, rem);
+                memset(dbuf, 0, 32);
+                memcpy(dbuf, dp5 + pos, rem);
+                {
+                        __m256i d = _mm256_load_si256((const __m256i *) dbuf);
+                        d = _mm256_xor_si256(d, AFFINE(x, gft5));
+                        _mm256_store_si256((__m256i *) dbuf, d);
+                }
+                memcpy(dp5 + pos, dbuf, rem);
+        }
+
+        _mm256_zeroupper();
+}

--- a/erasure_code/gf_5vect_mad_avx512_gfni.c
+++ b/erasure_code/gf_5vect_mad_avx512_gfni.c
@@ -1,0 +1,86 @@
+/**********************************************************************
+  Copyright(c) 2026 Intel Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+#include <stdint.h>
+#include <immintrin.h>
+
+__attribute__((target("avx512f,avx512bw,gfni"))) void
+gf_5vect_mad_avx512_gfni(int len, int vec, int vec_i, unsigned char *gftbls, unsigned char *src,
+                         unsigned char **dest)
+{
+        const long row_stride = (long) vec * 32;
+        unsigned char *base = gftbls + (long) vec_i * 32;
+        unsigned char *d1_p = dest[0], *d2_p = dest[1], *d3_p = dest[2], *d4_p = dest[3],
+                      *d5_p = dest[4];
+        __m512i gft1 = _mm512_set1_epi64((long long) *(const uint64_t *) (base + 0 * row_stride));
+        __m512i gft2 = _mm512_set1_epi64((long long) *(const uint64_t *) (base + 1 * row_stride));
+        __m512i gft3 = _mm512_set1_epi64((long long) *(const uint64_t *) (base + 2 * row_stride));
+        __m512i gft4 = _mm512_set1_epi64((long long) *(const uint64_t *) (base + 3 * row_stride));
+        __m512i gft5 = _mm512_set1_epi64((long long) *(const uint64_t *) (base + 4 * row_stride));
+
+        int pos = 0;
+        for (; pos + 64 <= len; pos += 64) {
+                __m512i s = _mm512_loadu_si512((const void *) (src + pos));
+                __m512i d1 = _mm512_loadu_si512((const void *) (d1_p + pos));
+                __m512i d2 = _mm512_loadu_si512((const void *) (d2_p + pos));
+                __m512i d3 = _mm512_loadu_si512((const void *) (d3_p + pos));
+                __m512i d4 = _mm512_loadu_si512((const void *) (d4_p + pos));
+                __m512i d5 = _mm512_loadu_si512((const void *) (d5_p + pos));
+                d1 = _mm512_xor_si512(d1, _mm512_gf2p8affine_epi64_epi8(s, gft1, 0x00));
+                d2 = _mm512_xor_si512(d2, _mm512_gf2p8affine_epi64_epi8(s, gft2, 0x00));
+                d3 = _mm512_xor_si512(d3, _mm512_gf2p8affine_epi64_epi8(s, gft3, 0x00));
+                d4 = _mm512_xor_si512(d4, _mm512_gf2p8affine_epi64_epi8(s, gft4, 0x00));
+                d5 = _mm512_xor_si512(d5, _mm512_gf2p8affine_epi64_epi8(s, gft5, 0x00));
+                _mm512_storeu_si512((void *) (d1_p + pos), d1);
+                _mm512_storeu_si512((void *) (d2_p + pos), d2);
+                _mm512_storeu_si512((void *) (d3_p + pos), d3);
+                _mm512_storeu_si512((void *) (d4_p + pos), d4);
+                _mm512_storeu_si512((void *) (d5_p + pos), d5);
+        }
+
+        if (pos < len) {
+                const __mmask64 m = (__mmask64) (((uint64_t) 1 << (len - pos)) - 1);
+                __m512i s = _mm512_maskz_loadu_epi8(m, src + pos);
+                __m512i d1 = _mm512_maskz_loadu_epi8(m, d1_p + pos);
+                __m512i d2 = _mm512_maskz_loadu_epi8(m, d2_p + pos);
+                __m512i d3 = _mm512_maskz_loadu_epi8(m, d3_p + pos);
+                __m512i d4 = _mm512_maskz_loadu_epi8(m, d4_p + pos);
+                __m512i d5 = _mm512_maskz_loadu_epi8(m, d5_p + pos);
+                d1 = _mm512_xor_si512(d1, _mm512_gf2p8affine_epi64_epi8(s, gft1, 0x00));
+                d2 = _mm512_xor_si512(d2, _mm512_gf2p8affine_epi64_epi8(s, gft2, 0x00));
+                d3 = _mm512_xor_si512(d3, _mm512_gf2p8affine_epi64_epi8(s, gft3, 0x00));
+                d4 = _mm512_xor_si512(d4, _mm512_gf2p8affine_epi64_epi8(s, gft4, 0x00));
+                d5 = _mm512_xor_si512(d5, _mm512_gf2p8affine_epi64_epi8(s, gft5, 0x00));
+                _mm512_mask_storeu_epi8(d1_p + pos, m, d1);
+                _mm512_mask_storeu_epi8(d2_p + pos, m, d2);
+                _mm512_mask_storeu_epi8(d3_p + pos, m, d3);
+                _mm512_mask_storeu_epi8(d4_p + pos, m, d4);
+                _mm512_mask_storeu_epi8(d5_p + pos, m, d5);
+        }
+}

--- a/erasure_code/gf_6vect_dot_prod_avx512_gfni.c
+++ b/erasure_code/gf_6vect_dot_prod_avx512_gfni.c
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright(c) 2026 Intel Corporation All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdint.h>
+#include <immintrin.h>
+
+#define AFFINE(s, g)        _mm512_gf2p8affine_epi64_epi8((s), (g), 0x00)
+#define LOAD512(p)          _mm512_loadu_si512((const void *) (p))
+#define TAIL_MASK(len, pos) ((__mmask64) (((uint64_t) 1 << ((len) - (pos))) - 1))
+
+/*
+ * Embedded-broadcast GF multiply-accumulate for the dot_prod hot loop.
+ *
+ * acc ^= gf2p8affine(src, broadcast8(*coeff)).  The coefficient is read
+ * straight from the gftbls memory as an EVEX {1to8} embedded-broadcast operand
+ * of vgf2p8affineqb, folding the 8-byte broadcast into the affine's own load
+ * micro-op.  This deliberately avoids letting the compiler lower the broadcast
+ * to a GPR-source `vpbroadcastq %gpr,zmm` (+ a scalar `movq` load), which on
+ * Sapphire Rapids issues on the vector-ALU Port5 and made the multi-vect C
+ * encode ~25% slower than the NASM baseline (which keeps the broadcast on the
+ * load ports).  gcc/clang will NOT emit {1to8} from _mm512_set1_epi64()+affine
+ * (verified), so this must be inline asm.  A distinct scratch temp per call
+ * also keeps the N independent affines off a single shared dependency chain.
+ */
+#define AFFINE_XOR_BCAST(acc, s, coeff)                                                        \
+        do {                                                                                  \
+                __m512i _t;                                                                    \
+                __asm__("vgf2p8affineqb $0x00, (%[c])%{1to8%}, %[src], %[t]\n\t"               \
+                        "vpxorq %[t], %[p], %[p]"                                              \
+                        : [p] "+v"(acc), [t] "=&v"(_t)                                         \
+                        : [src] "v"(s), [c] "r"(coeff)                                         \
+                        :);                                                                    \
+        } while (0)
+
+__attribute__((target("avx512f,avx512bw,gfni"))) void
+gf_6vect_dot_prod_avx512_gfni(int len, int k, unsigned char *g_tbls, unsigned char **src,
+                              unsigned char **coding)
+{
+        unsigned char *d1 = coding[0], *d2 = coding[1];
+        unsigned char *d3 = coding[2], *d4 = coding[3];
+        unsigned char *d5 = coding[4], *d6 = coding[5];
+        const long row_stride = (long) k * 32;
+        int pos = 0;
+
+        for (; pos + 64 <= len; pos += 64) {
+                __m512i p1 = _mm512_setzero_si512();
+                __m512i p2 = _mm512_setzero_si512();
+                __m512i p3 = _mm512_setzero_si512();
+                __m512i p4 = _mm512_setzero_si512();
+                __m512i p5 = _mm512_setzero_si512();
+                __m512i p6 = _mm512_setzero_si512();
+                unsigned char *tbl = g_tbls;
+
+                for (int i = 0; i < k; i++) {
+                        __m512i s = LOAD512(src[i] + pos);
+                        AFFINE_XOR_BCAST(p1, s, tbl + 0);
+                        AFFINE_XOR_BCAST(p2, s, tbl + 1 * row_stride);
+                        AFFINE_XOR_BCAST(p3, s, tbl + 2 * row_stride);
+                        AFFINE_XOR_BCAST(p4, s, tbl + 3 * row_stride);
+                        AFFINE_XOR_BCAST(p5, s, tbl + 4 * row_stride);
+                        AFFINE_XOR_BCAST(p6, s, tbl + 5 * row_stride);
+                        tbl += 32;
+                }
+                _mm512_storeu_si512((void *) (d1 + pos), p1);
+                _mm512_storeu_si512((void *) (d2 + pos), p2);
+                _mm512_storeu_si512((void *) (d3 + pos), p3);
+                _mm512_storeu_si512((void *) (d4 + pos), p4);
+                _mm512_storeu_si512((void *) (d5 + pos), p5);
+                _mm512_storeu_si512((void *) (d6 + pos), p6);
+        }
+
+        if (pos < len) {
+                const __mmask64 m = TAIL_MASK(len, pos);
+                __m512i p1 = _mm512_setzero_si512();
+                __m512i p2 = _mm512_setzero_si512();
+                __m512i p3 = _mm512_setzero_si512();
+                __m512i p4 = _mm512_setzero_si512();
+                __m512i p5 = _mm512_setzero_si512();
+                __m512i p6 = _mm512_setzero_si512();
+                unsigned char *tbl = g_tbls;
+
+                for (int i = 0; i < k; i++) {
+                        __m512i s = _mm512_maskz_loadu_epi8(m, src[i] + pos);
+                        AFFINE_XOR_BCAST(p1, s, tbl + 0);
+                        AFFINE_XOR_BCAST(p2, s, tbl + 1 * row_stride);
+                        AFFINE_XOR_BCAST(p3, s, tbl + 2 * row_stride);
+                        AFFINE_XOR_BCAST(p4, s, tbl + 3 * row_stride);
+                        AFFINE_XOR_BCAST(p5, s, tbl + 4 * row_stride);
+                        AFFINE_XOR_BCAST(p6, s, tbl + 5 * row_stride);
+                        tbl += 32;
+                }
+                _mm512_mask_storeu_epi8(d1 + pos, m, p1);
+                _mm512_mask_storeu_epi8(d2 + pos, m, p2);
+                _mm512_mask_storeu_epi8(d3 + pos, m, p3);
+                _mm512_mask_storeu_epi8(d4 + pos, m, p4);
+                _mm512_mask_storeu_epi8(d5 + pos, m, p5);
+                _mm512_mask_storeu_epi8(d6 + pos, m, p6);
+        }
+}

--- a/erasure_code/gf_6vect_mad_avx512_gfni.c
+++ b/erasure_code/gf_6vect_mad_avx512_gfni.c
@@ -1,0 +1,93 @@
+/**********************************************************************
+  Copyright(c) 2026 Intel Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+#include <stdint.h>
+#include <immintrin.h>
+
+__attribute__((target("avx512f,avx512bw,gfni"))) void
+gf_6vect_mad_avx512_gfni(int len, int vec, int vec_i, unsigned char *gftbls, unsigned char *src,
+                         unsigned char **dest)
+{
+        const long row_stride = (long) vec * 32;
+        unsigned char *base = gftbls + (long) vec_i * 32;
+        unsigned char *d1_p = dest[0], *d2_p = dest[1], *d3_p = dest[2], *d4_p = dest[3],
+                      *d5_p = dest[4], *d6_p = dest[5];
+        __m512i gft1 = _mm512_set1_epi64((long long) *(const uint64_t *) (base + 0 * row_stride));
+        __m512i gft2 = _mm512_set1_epi64((long long) *(const uint64_t *) (base + 1 * row_stride));
+        __m512i gft3 = _mm512_set1_epi64((long long) *(const uint64_t *) (base + 2 * row_stride));
+        __m512i gft4 = _mm512_set1_epi64((long long) *(const uint64_t *) (base + 3 * row_stride));
+        __m512i gft5 = _mm512_set1_epi64((long long) *(const uint64_t *) (base + 4 * row_stride));
+        __m512i gft6 = _mm512_set1_epi64((long long) *(const uint64_t *) (base + 5 * row_stride));
+
+        int pos = 0;
+        for (; pos + 64 <= len; pos += 64) {
+                __m512i s = _mm512_loadu_si512((const void *) (src + pos));
+                __m512i d1 = _mm512_loadu_si512((const void *) (d1_p + pos));
+                __m512i d2 = _mm512_loadu_si512((const void *) (d2_p + pos));
+                __m512i d3 = _mm512_loadu_si512((const void *) (d3_p + pos));
+                __m512i d4 = _mm512_loadu_si512((const void *) (d4_p + pos));
+                __m512i d5 = _mm512_loadu_si512((const void *) (d5_p + pos));
+                __m512i d6 = _mm512_loadu_si512((const void *) (d6_p + pos));
+                d1 = _mm512_xor_si512(d1, _mm512_gf2p8affine_epi64_epi8(s, gft1, 0x00));
+                d2 = _mm512_xor_si512(d2, _mm512_gf2p8affine_epi64_epi8(s, gft2, 0x00));
+                d3 = _mm512_xor_si512(d3, _mm512_gf2p8affine_epi64_epi8(s, gft3, 0x00));
+                d4 = _mm512_xor_si512(d4, _mm512_gf2p8affine_epi64_epi8(s, gft4, 0x00));
+                d5 = _mm512_xor_si512(d5, _mm512_gf2p8affine_epi64_epi8(s, gft5, 0x00));
+                d6 = _mm512_xor_si512(d6, _mm512_gf2p8affine_epi64_epi8(s, gft6, 0x00));
+                _mm512_storeu_si512((void *) (d1_p + pos), d1);
+                _mm512_storeu_si512((void *) (d2_p + pos), d2);
+                _mm512_storeu_si512((void *) (d3_p + pos), d3);
+                _mm512_storeu_si512((void *) (d4_p + pos), d4);
+                _mm512_storeu_si512((void *) (d5_p + pos), d5);
+                _mm512_storeu_si512((void *) (d6_p + pos), d6);
+        }
+
+        if (pos < len) {
+                const __mmask64 m = (__mmask64) (((uint64_t) 1 << (len - pos)) - 1);
+                __m512i s = _mm512_maskz_loadu_epi8(m, src + pos);
+                __m512i d1 = _mm512_maskz_loadu_epi8(m, d1_p + pos);
+                __m512i d2 = _mm512_maskz_loadu_epi8(m, d2_p + pos);
+                __m512i d3 = _mm512_maskz_loadu_epi8(m, d3_p + pos);
+                __m512i d4 = _mm512_maskz_loadu_epi8(m, d4_p + pos);
+                __m512i d5 = _mm512_maskz_loadu_epi8(m, d5_p + pos);
+                __m512i d6 = _mm512_maskz_loadu_epi8(m, d6_p + pos);
+                d1 = _mm512_xor_si512(d1, _mm512_gf2p8affine_epi64_epi8(s, gft1, 0x00));
+                d2 = _mm512_xor_si512(d2, _mm512_gf2p8affine_epi64_epi8(s, gft2, 0x00));
+                d3 = _mm512_xor_si512(d3, _mm512_gf2p8affine_epi64_epi8(s, gft3, 0x00));
+                d4 = _mm512_xor_si512(d4, _mm512_gf2p8affine_epi64_epi8(s, gft4, 0x00));
+                d5 = _mm512_xor_si512(d5, _mm512_gf2p8affine_epi64_epi8(s, gft5, 0x00));
+                d6 = _mm512_xor_si512(d6, _mm512_gf2p8affine_epi64_epi8(s, gft6, 0x00));
+                _mm512_mask_storeu_epi8(d1_p + pos, m, d1);
+                _mm512_mask_storeu_epi8(d2_p + pos, m, d2);
+                _mm512_mask_storeu_epi8(d3_p + pos, m, d3);
+                _mm512_mask_storeu_epi8(d4_p + pos, m, d4);
+                _mm512_mask_storeu_epi8(d5_p + pos, m, d5);
+                _mm512_mask_storeu_epi8(d6_p + pos, m, d6);
+        }
+}

--- a/erasure_code/gf_vect_dot_prod_avx2_gfni.c
+++ b/erasure_code/gf_vect_dot_prod_avx2_gfni.c
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright(c) 2026 Intel Corporation All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * gf_vect_dot_prod_avx2_gfni(len, k, g_tbls, src, dest)
+ *
+ * dest[0..len) = XOR over j in [0,k) of mul(g_tbls[j], src[j][0..len)).
+ *
+ * Uses 96B / 64B / 32B unrolled body matching the prior NASM kernel; the
+ * sub-32B tail is staged through a 32-byte stack buffer.
+ */
+
+#include <string.h>
+#include <immintrin.h>
+
+#define BCAST_GF8(p) _mm256_set1_epi64x((long long) *(const uint64_t *) (p))
+#define AFFINE(s, g) _mm256_gf2p8affine_epi64_epi8((s), (g), 0x00)
+#define LOAD256(p)   _mm256_loadu_si256((const __m256i *) (p))
+
+__attribute__((target("avx2,gfni"))) void
+gf_vect_dot_prod_avx2_gfni(int len, int k, unsigned char *g_tbls, unsigned char **src,
+                           unsigned char *dest)
+{
+        int pos = 0;
+
+        for (; pos + 96 <= len; pos += 96) {
+                __m256i p1l = _mm256_setzero_si256();
+                __m256i p1h = _mm256_setzero_si256();
+                __m256i p1x = _mm256_setzero_si256();
+                unsigned char *tbl = g_tbls;
+
+                for (int i = 0; i < k; i++) {
+                        const unsigned char *s = src[i] + pos;
+                        __m256i x0l = LOAD256(s + 0);
+                        __m256i x0h = LOAD256(s + 32);
+                        __m256i x0x = LOAD256(s + 64);
+                        __m256i gft = _mm256_loadu_si256((const __m256i *) tbl);
+
+                        tbl += 32;
+
+                        p1l = _mm256_xor_si256(p1l, AFFINE(x0l, gft));
+                        p1h = _mm256_xor_si256(p1h, AFFINE(x0h, gft));
+                        p1x = _mm256_xor_si256(p1x, AFFINE(x0x, gft));
+                }
+                _mm256_storeu_si256((__m256i *) (dest + pos + 0), p1l);
+                _mm256_storeu_si256((__m256i *) (dest + pos + 32), p1h);
+                _mm256_storeu_si256((__m256i *) (dest + pos + 64), p1x);
+        }
+
+        if (pos + 64 <= len) {
+                __m256i p1l = _mm256_setzero_si256();
+                __m256i p1h = _mm256_setzero_si256();
+                unsigned char *tbl = g_tbls;
+
+                for (int i = 0; i < k; i++) {
+                        const unsigned char *s = src[i] + pos;
+                        __m256i x0l = LOAD256(s + 0);
+                        __m256i x0h = LOAD256(s + 32);
+                        __m256i gft = _mm256_loadu_si256((const __m256i *) tbl);
+
+                        tbl += 32;
+
+                        p1l = _mm256_xor_si256(p1l, AFFINE(x0l, gft));
+                        p1h = _mm256_xor_si256(p1h, AFFINE(x0h, gft));
+                }
+                _mm256_storeu_si256((__m256i *) (dest + pos + 0), p1l);
+                _mm256_storeu_si256((__m256i *) (dest + pos + 32), p1h);
+                pos += 64;
+        }
+
+        if (pos + 32 <= len) {
+                __m256i p1 = _mm256_setzero_si256();
+                unsigned char *tbl = g_tbls;
+
+                for (int i = 0; i < k; i++) {
+                        __m256i x0 = LOAD256(src[i] + pos);
+                        __m256i gft = _mm256_loadu_si256((const __m256i *) tbl);
+
+                        tbl += 32;
+                        p1 = _mm256_xor_si256(p1, AFFINE(x0, gft));
+                }
+                _mm256_storeu_si256((__m256i *) (dest + pos), p1);
+                pos += 32;
+        }
+
+        if (pos < len) {
+                int rem = len - pos;
+                unsigned char buf[32] __attribute__ /**/ ((aligned(32))) = { 0 };
+                __m256i p1 = _mm256_setzero_si256();
+                unsigned char *tbl = g_tbls;
+
+                for (int i = 0; i < k; i++) {
+                        memcpy(buf, src[i] + pos, rem);
+                        __m256i x0 = _mm256_load_si256((const __m256i *) buf);
+                        __m256i gft = _mm256_loadu_si256((const __m256i *) tbl);
+
+                        tbl += 32;
+                        p1 = _mm256_xor_si256(p1, AFFINE(x0, gft));
+                }
+                _mm256_store_si256((__m256i *) buf, p1);
+                memcpy(dest + pos, buf, rem);
+        }
+
+        _mm256_zeroupper();
+}

--- a/erasure_code/gf_vect_dot_prod_avx512_gfni.c
+++ b/erasure_code/gf_vect_dot_prod_avx512_gfni.c
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright(c) 2026 Intel Corporation All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * gf_vect_dot_prod_avx512_gfni(len, k, g_tbls, src, dest)
+ *
+ * Compute dest[0..len) = XOR over j in [0,k) of mul(g_tbls[j], src[j][0..len)).
+ * g_tbls is laid out as k entries of 32 bytes each; only the first 8 bytes
+ * (the GF(2^8) affine matrix) are read, and broadcast to all 8 zmm lanes.
+ *
+ * Tail (len % 64) is handled with a byte-granular k-mask load/store.
+ */
+
+#include <stdint.h>
+#include <immintrin.h>
+
+#define BCAST_GF8(p)        _mm512_set1_epi64((long long) *(const uint64_t *) (p))
+#define AFFINE(s, g)        _mm512_gf2p8affine_epi64_epi8((s), (g), 0x00)
+#define LOAD512(p)          _mm512_loadu_si512((const void *) (p))
+#define TAIL_MASK(len, pos) ((__mmask64) (((uint64_t) 1 << ((len) - (pos))) - 1))
+
+__attribute__((target("avx512f,avx512bw,gfni"))) void
+gf_vect_dot_prod_avx512_gfni(int len, int k, unsigned char *g_tbls, unsigned char **src,
+                             unsigned char *dest)
+{
+        int pos = 0;
+
+        for (; pos + 64 <= len; pos += 64) {
+                __m512i p1 = _mm512_setzero_si512();
+                unsigned char *tbl = g_tbls;
+
+                for (int i = 0; i < k; i++) {
+                        __m512i s = LOAD512(src[i] + pos);
+                        __m512i gft = BCAST_GF8(tbl);
+                        p1 = _mm512_xor_si512(p1, AFFINE(s, gft));
+                        tbl += 32;
+                }
+                _mm512_storeu_si512((void *) (dest + pos), p1);
+        }
+
+        if (pos < len) {
+                const __mmask64 m = TAIL_MASK(len, pos);
+                __m512i p1 = _mm512_setzero_si512();
+                unsigned char *tbl = g_tbls;
+
+                for (int i = 0; i < k; i++) {
+                        __m512i s = _mm512_maskz_loadu_epi8(m, src[i] + pos);
+                        __m512i gft = BCAST_GF8(tbl);
+                        p1 = _mm512_xor_si512(p1, AFFINE(s, gft));
+                        tbl += 32;
+                }
+                _mm512_mask_storeu_epi8(dest + pos, m, p1);
+        }
+}

--- a/erasure_code/gf_vect_mad_avx2_gfni.c
+++ b/erasure_code/gf_vect_mad_avx2_gfni.c
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright(c) 2026 Intel Corporation All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Intel Corporation nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * gf_vect_mad_avx2_gfni(len, vec, vec_i, gftbls, src, dest)
+ *
+ * dest[i] ^= mul(gftbls[vec_i], src[i]) for i in [0,len).
+ * 96B / 64B / 32B / <32B body, matching the prior NASM kernel.
+ */
+
+#include <stdint.h>
+#include <string.h>
+#include <immintrin.h>
+
+#define BCAST_GF8(p) _mm256_set1_epi64x((long long) *(const uint64_t *) (p))
+#define AFFINE(s, g) _mm256_gf2p8affine_epi64_epi8((s), (g), 0x00)
+#define LOAD256(p)   _mm256_loadu_si256((const __m256i *) (p))
+
+__attribute__((target("avx2,gfni"))) void
+gf_vect_mad_avx2_gfni(int len, int vec, int vec_i, unsigned char *gftbls, unsigned char *src,
+                      unsigned char *dest)
+{
+        (void) vec;
+        const __m256i gft = BCAST_GF8(gftbls + vec_i * 32);
+
+        int pos = 0;
+
+        for (; pos + 96 <= len; pos += 96) {
+                __m256i x0l = LOAD256(src + pos + 0);
+                __m256i x0h = LOAD256(src + pos + 32);
+                __m256i x0x = LOAD256(src + pos + 64);
+                __m256i d0l = LOAD256(dest + pos + 0);
+                __m256i d0h = LOAD256(dest + pos + 32);
+                __m256i d0x = LOAD256(dest + pos + 64);
+
+                d0l = _mm256_xor_si256(d0l, AFFINE(x0l, gft));
+                d0h = _mm256_xor_si256(d0h, AFFINE(x0h, gft));
+                d0x = _mm256_xor_si256(d0x, AFFINE(x0x, gft));
+
+                _mm256_storeu_si256((__m256i *) (dest + pos + 0), d0l);
+                _mm256_storeu_si256((__m256i *) (dest + pos + 32), d0h);
+                _mm256_storeu_si256((__m256i *) (dest + pos + 64), d0x);
+        }
+
+        if (pos + 64 <= len) {
+                __m256i x0l = LOAD256(src + pos + 0);
+                __m256i x0h = LOAD256(src + pos + 32);
+                __m256i d0l = LOAD256(dest + pos + 0);
+                __m256i d0h = LOAD256(dest + pos + 32);
+
+                d0l = _mm256_xor_si256(d0l, AFFINE(x0l, gft));
+                d0h = _mm256_xor_si256(d0h, AFFINE(x0h, gft));
+
+                _mm256_storeu_si256((__m256i *) (dest + pos + 0), d0l);
+                _mm256_storeu_si256((__m256i *) (dest + pos + 32), d0h);
+                pos += 64;
+        }
+
+        if (pos + 32 <= len) {
+                __m256i x0 = LOAD256(src + pos);
+                __m256i d0 = LOAD256(dest + pos);
+
+                d0 = _mm256_xor_si256(d0, AFFINE(x0, gft));
+                _mm256_storeu_si256((__m256i *) (dest + pos), d0);
+                pos += 32;
+        }
+
+        if (pos < len) {
+                int rem = len - pos;
+                unsigned char sbuf[32] __attribute__ /**/ ((aligned(32))) = { 0 };
+                unsigned char dbuf[32] __attribute__ /**/ ((aligned(32))) = { 0 };
+
+                memcpy(sbuf, src + pos, rem);
+                memcpy(dbuf, dest + pos, rem);
+                __m256i x0 = _mm256_load_si256((const __m256i *) sbuf);
+                __m256i d0 = _mm256_load_si256((const __m256i *) dbuf);
+
+                d0 = _mm256_xor_si256(d0, AFFINE(x0, gft));
+                _mm256_store_si256((__m256i *) dbuf, d0);
+                memcpy(dest + pos, dbuf, rem);
+        }
+
+        _mm256_zeroupper();
+}

--- a/erasure_code/gf_vect_mad_avx512_gfni.c
+++ b/erasure_code/gf_vect_mad_avx512_gfni.c
@@ -1,0 +1,66 @@
+/**********************************************************************
+  Copyright(c) 2026 Intel Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+/*
+ * gf_vect_mad_avx512_gfni(len, vec, vec_i, gftbls, src, dest)
+ *
+ * Multiply-add update: dest[i] ^= mul(gftbls[vec_i], src[i]) for i in [0,len).
+ * Only the affine matrix at gftbls[vec_i*32] is consulted.
+ *
+ * vec is the source count k for the parent ec_encode_data_update_avx512_gfni
+ * dispatch; this single-vect kernel ignores it.
+ */
+
+#include <stdint.h>
+#include <immintrin.h>
+
+__attribute__((target("avx512f,avx512bw,gfni"))) void
+gf_vect_mad_avx512_gfni(int len, int vec, int vec_i, unsigned char *gftbls, unsigned char *src,
+                        unsigned char *dest)
+{
+        (void) vec;
+        const __m512i gft =
+                _mm512_set1_epi64((long long) *(const uint64_t *) (gftbls + vec_i * 32));
+
+        int pos = 0;
+        for (; pos + 64 <= len; pos += 64) {
+                __m512i s = _mm512_loadu_si512((const void *) (src + pos));
+                __m512i d = _mm512_loadu_si512((const void *) (dest + pos));
+                d = _mm512_xor_si512(d, _mm512_gf2p8affine_epi64_epi8(s, gft, 0x00));
+                _mm512_storeu_si512((void *) (dest + pos), d);
+        }
+
+        if (pos < len) {
+                const __mmask64 m = (__mmask64) (((uint64_t) 1 << (len - pos)) - 1);
+                __m512i s = _mm512_maskz_loadu_epi8(m, src + pos);
+                __m512i d = _mm512_maskz_loadu_epi8(m, dest + pos);
+                d = _mm512_xor_si512(d, _mm512_gf2p8affine_epi64_epi8(s, gft, 0x00));
+                _mm512_mask_storeu_epi8(dest + pos, m, d);
+        }
+}

--- a/erasure_code/gf_vect_mul_avx2_gfni.c
+++ b/erasure_code/gf_vect_mul_avx2_gfni.c
@@ -1,0 +1,71 @@
+/**********************************************************************
+  Copyright(c) 2026 Intel Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+
+/*
+ * gf_vect_mul_avx2_gfni(len, mul_array, src, dest)
+ *
+ * Multiplies len bytes of src by the GF(2^8) constant whose 8x8 affine
+ * matrix is broadcast in mul_array, writing the result to dest.
+ *
+ * Constraints (matching the prior NASM kernel):
+ *   - len must be a multiple of 32; otherwise returns 1.
+ *   - src and dest must be 32-byte aligned (non-temporal moves).
+ *
+ * Returns 0 on success, 1 if len is not a multiple of 32.
+ */
+
+#include <immintrin.h>
+
+#define AFFINE(s, g) _mm256_gf2p8affine_epi64_epi8((s), (g), 0x00)
+
+__attribute__((target("avx2,gfni"))) int
+gf_vect_mul_avx2_gfni(int len, unsigned char *mul_array, void *src, void *dest)
+{
+        if (len & 0x1f)
+                return 1;
+
+        const __m256i gft = _mm256_loadu_si256((const __m256i *) mul_array);
+        const unsigned char *s = (const unsigned char *) src;
+        unsigned char *d = (unsigned char *) dest;
+
+        for (int pos = 0; pos < len; pos += 32) {
+#ifdef NO_NT_LDST
+                __m256i x = _mm256_load_si256((const __m256i *) (s + pos));
+                __m256i y = AFFINE(x, gft);
+                _mm256_store_si256((__m256i *) (d + pos), y);
+#else
+                __m256i x = _mm256_stream_load_si256((const __m256i *) (s + pos));
+                __m256i y = AFFINE(x, gft);
+                _mm256_stream_si256((__m256i *) (d + pos), y);
+#endif
+        }
+
+        _mm256_zeroupper();
+        return 0;
+}


### PR DESCRIPTION
## Summary

Add C intrinsic implementations of the 21 GFNI erasure-code kernels
(`gf_{1..6}vect_{mul,dot_prod,mad}_avx{2,512}_gfni`) alongside the existing
NASM kernels, selectable at configure time. The assembly kernels remain the
**default**; configuring with `--enable-gfni-c-kernels` (CMake:
`-DGFNI_C_KERNELS=ON`) builds the C versions instead.

Both implementations export the same symbols and plug into the unchanged
`ec_multibinary` runtime dispatch, so the **public ABI and all callers are
unaffected** by the choice.

## Motivation

C intrinsics are easier to review, debug, and retarget across toolchains than
hand-written NASM, and drop the nasm dependency from the GFNI path when
selected. Assembly remains the default because the C path relies on function
target attributes (GCC/Clang) that MSVC does not provide.

## Implementation notes

- Scalar `__m256i`/`__m512i` accumulators rather than arrays (which spill to
  the stack at `-O2` and cost throughput).
- `dot_prod` broadcasts each coefficient through an embedded-broadcast affine
  operand, keeping the GF(2^8) multiply off the single affine port that
  otherwise bottlenecks the wide kernels on Sapphire Rapids.
- Multi-vector kernels use a distinct affine temporary per output so the
  independent products do not serialize on one register.

## Performance

Parity with the NASM kernels. Measured single-thread, NASM and C built into
separate trees and run **interleaved** per metric, pinned to a P-core,
median of 9.

AVX2-GFNI — Raptor Lake (i5-1340P), clang 19, GB/s:

| benchmark | NASM | C | delta |
|---|---:|---:|---:|
| `gf_vect_mul_perf` | 57.1 | 57.2 | +0.2% |
| `gf_vect_dot_prod_perf` | 48.2 | 48.6 | +0.8% |
| `erasure_code_perf` encode | 20.7 | 20.9 | +1.0% |
| `erasure_code_perf` decode | 22.4 | 21.9 | -2.2% |
| `erasure_code_update_perf` encode | 16.8 | 16.9 | +0.6% |
| `erasure_code_update_perf` single_src | 55.2 | 55.1 | -0.2% |

AVX512-GFNI — Sapphire Rapids (Xeon Platinum 8481C), gcc, GB/s:

| benchmark | NASM | C | delta |
|---|---:|---:|---:|
| `gf_vect_mul_perf` | 36.4 | 36.7 | +0.8% |
| `gf_vect_dot_prod_perf` | 79.1 | 79.0 | -0.1% |
| `erasure_code_perf` encode | 41.4 | 40.2 | -2.9% |
| `erasure_code_perf` decode | 50.6 | 50.5 | -0.2% |
| `erasure_code_update_perf` encode | 35.8 | 35.8 | +0.0% |
| `erasure_code_update_perf` single_src | 111.9 | 111.4 | -0.4% |

## Testing

- `make check` passes with both the default (asm) and `--enable-gfni-c-kernels`
  configurations.
- Runtime-validated on real GFNI hardware — AVX2-GFNI (Raptor Lake) and
  AVX512-GFNI (Sapphire Rapids): the dispatcher selects the C `*_gfni`
  kernels (confirmed the objects emit `vgf2p8affineqb`) and all erasure-code
  unit tests pass.
