### PR TITLE
igzip/riscv64: Optimize deflate performance with vectorized assembly implementation of compare258

### DIFF
--- a/cmake/igzip.cmake
+++ b/cmake/igzip.cmake
@@ -91,6 +91,13 @@ set(IGZIP_RISCV64_SOURCES
     igzip/riscv64/igzip_multibinary_riscv64.S
     igzip/riscv64/igzip_isal_adler32_rvv.S
     igzip/riscv64/igzip_isal_adler32_rvv128.S
+    igzip/riscv64/igzip_deflate_hash_rvv.S
+    igzip/riscv64/compare258_rvv.S
+    igzip/riscv64/igzip_icf_body_hash_hist_rvv.c
+    igzip/riscv64/igzip_icf_finish_hash_hist_rvv.c
+    igzip/riscv64/igzip_deflate_body_rvv.c
+    igzip/riscv64/igzip_update_histogram_rvv.c
+    igzip/riscv64/igzip_set_long_icf_fg_rvv.c
 )
 
 # Build source list based on architecture

--- a/igzip/riscv64/Makefile.am
+++ b/igzip/riscv64/Makefile.am
@@ -31,4 +31,11 @@ lsrc_riscv64 += \
 	igzip/riscv64/igzip_multibinary_riscv64_dispatcher.c \
 	igzip/riscv64/igzip_multibinary_riscv64.S \
 	igzip/riscv64/igzip_isal_adler32_rvv.S \
-	igzip/riscv64/igzip_isal_adler32_rvv128.S
+	igzip/riscv64/igzip_isal_adler32_rvv128.S \
+	igzip/riscv64/igzip_deflate_hash_rvv.S \
+	igzip/riscv64/compare258_rvv.S \
+	igzip/riscv64/igzip_icf_body_hash_hist_rvv.c \
+	igzip/riscv64/igzip_icf_finish_hash_hist_rvv.c \
+	igzip/riscv64/igzip_deflate_body_rvv.c \
+	igzip/riscv64/igzip_update_histogram_rvv.c \
+	igzip/riscv64/igzip_set_long_icf_fg_rvv.c

--- a/igzip/riscv64/compare258_rvv.S
+++ b/igzip/riscv64/compare258_rvv.S
@@ -1,0 +1,100 @@
+/**********************************************************************
+  Copyright (c) 2026 ZTE Corporation.
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of ZTE Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+/*
+ *   uint32_t compare258_rvv(const uint8_t *str1,   // a0
+ *                           const uint8_t *str2,   // a1
+ *                           uint32_t max_length);  // a2
+ */
+#if HAVE_RVV
+	.option arch, +v
+	.text
+	.align 2
+	.global compare258_rvv
+	.type compare258_rvv, @function
+compare258_rvv:
+	// if (max_length > 258) max_length = 258;
+	li	t0, 258
+	bltu	a2, t0, 1f
+	mv	a2, t0
+1:
+	li	t1, 0			// count = 0
+.Lc258_loop:
+	bgeu	t1, a2, .Lc258_allmatch	// count >= max_length -> all matched
+	sub	a3, a2, t1		// remaining = max_length - count
+	vsetvli	t3, a3, e8, m1, ta, ma	// vl = min(remaining, VLMAX_e8m1)
+	vle8.v	v1, (a0)		// str1 chunk
+	vle8.v	v2, (a1)		// str2 chunk
+	vmsne.vv v3, v1, v2		// mask: differing bytes
+	vfirst.m a4, v3		// first mismatch index, or -1
+	bltz	a4, .Lc258_advance	// -1 -> whole chunk matches
+	// mismatch at byte (count + a4)
+	add	a0, t1, a4
+	ret
+.Lc258_advance:
+	add	a0, a0, t3
+	add	a1, a1, t3
+	add	t1, t1, t3
+	j	.Lc258_loop
+.Lc258_allmatch:
+	mv	a0, a2			// return max_length
+	ret
+	.size compare258_rvv, .-compare258_rvv
+
+/*
+ *   uint32_t compare_rvv(const uint8_t *str1,   // a0
+ *                        const uint8_t *str2,   // a1
+ *                        uint32_t max_length);  // a2
+ *
+ * Same longest-common-prefix match as compare258_rvv, but WITHOUT the 258 cap
+ * (matches up to max_length). Bit-identical to compare() in huffman.h.
+ */
+	.global compare_rvv
+	.type compare_rvv, @function
+compare_rvv:
+	li	t1, 0			// count = 0
+.Lcmp_loop:
+	bgeu	t1, a2, .Lcmp_allmatch	// count >= max_length -> all matched
+	sub	a3, a2, t1		// remaining = max_length - count
+	vsetvli	t3, a3, e8, m1, ta, ma	// vl = min(remaining, VLMAX_e8m1)
+	vle8.v	v1, (a0)
+	vle8.v	v2, (a1)
+	vmsne.vv v3, v1, v2		// mask: differing bytes
+	vfirst.m a4, v3		// first mismatch index, or -1
+	bltz	a4, .Lcmp_advance	// -1 -> whole chunk matches
+	add	a0, t1, a4		// mismatch at byte (count + a4)
+	ret
+.Lcmp_advance:
+	add	a0, a0, t3
+	add	a1, a1, t3
+	add	t1, t1, t3
+	j	.Lcmp_loop
+.Lcmp_allmatch:
+	mv	a0, a2			// return max_length
+	ret
+	.size compare_rvv, .-compare_rvv
+#endif

--- a/igzip/riscv64/igzip_deflate_body_rvv.c
+++ b/igzip/riscv64/igzip_deflate_body_rvv.c
@@ -1,0 +1,221 @@
+#include <stdint.h>
+#include "igzip_lib.h"
+#include "../huffman.h"
+#include "../huff_codes.h"
+#include "../bitbuf2.h"
+#include "unaligned.h"
+
+extern uint32_t
+compare258_rvv(const uint8_t *str1, const uint8_t *str2, uint32_t max_length);
+
+/* Replicated from igzip_base.c (file-local there). */
+static inline void
+update_state(struct isal_zstream *stream, uint8_t *start_in, uint8_t *next_in, uint8_t *end_in)
+{
+        struct isal_zstate *state = &stream->internal_state;
+        uint32_t bytes_written;
+
+        if (next_in - start_in > 0)
+                state->has_hist = IGZIP_HIST;
+
+        stream->next_in = next_in;
+        stream->total_in += (uint32_t) (next_in - start_in);
+        stream->avail_in = (uint32_t) (end_in - next_in);
+
+        bytes_written = buffer_used(&state->bitbuf);
+        stream->total_out += bytes_written;
+        stream->next_out += bytes_written;
+        stream->avail_out -= bytes_written;
+}
+
+void
+isal_deflate_body_rvv(struct isal_zstream *stream)
+{
+        uint32_t literal, hash;
+        uint8_t *start_in, *next_in, *end_in, *end, *next_hash;
+        uint32_t match_length;
+        uint32_t dist;
+        uint64_t code, code2;
+        uint32_t code_len, code_len2;
+        struct isal_zstate *state = &stream->internal_state;
+        uint16_t *last_seen = state->head;
+        uint8_t *file_start = (uint8_t *) ((uintptr_t) stream->next_in - stream->total_in);
+        uint32_t hist_size = state->dist_mask;
+        uint32_t hash_mask = state->hash_mask;
+
+        if (stream->avail_in == 0) {
+                if (stream->end_of_stream || stream->flush != NO_FLUSH)
+                        state->state = ZSTATE_FLUSH_READ_BUFFER;
+                return;
+        }
+
+        set_buf(&state->bitbuf, stream->next_out, stream->avail_out);
+
+        start_in = stream->next_in;
+        end_in = start_in + stream->avail_in;
+        next_in = start_in;
+
+        while (next_in + ISAL_LOOK_AHEAD < end_in) {
+
+                if (is_full(&state->bitbuf)) {
+                        update_state(stream, start_in, next_in, end_in);
+                        return;
+                }
+
+                literal = load_le_u32(next_in);
+                hash = compute_hash(literal) & hash_mask;
+                dist = (next_in - file_start - last_seen[hash]) & 0xFFFF;
+                last_seen[hash] = (uint16_t) (next_in - file_start);
+
+                /* The -1 are to handle the case when dist = 0 */
+                if (dist - 1 < hist_size) {
+                        assert(dist != 0);
+
+                        /* RVV-accelerated longest-common-prefix match. */
+                        match_length = compare258_rvv(next_in - dist, next_in, 258);
+
+                        if (match_length >= SHORTEST_MATCH) {
+                                next_hash = next_in;
+#ifdef ISAL_LIMIT_HASH_UPDATE
+                                end = next_hash + 3;
+#else
+                                end = next_hash + match_length;
+#endif
+                                next_hash++;
+
+                                for (; next_hash < end; next_hash++) {
+                                        literal = load_le_u32(next_hash);
+                                        hash = compute_hash(literal) & hash_mask;
+                                        last_seen[hash] = (uint16_t) (next_hash - file_start);
+                                }
+
+                                get_len_code(stream->hufftables, match_length, &code, &code_len);
+                                get_dist_code(stream->hufftables, dist, &code2, &code_len2);
+
+                                code |= code2 << code_len;
+                                code_len += code_len2;
+
+                                write_bits(&state->bitbuf, code, code_len);
+
+                                next_in += match_length;
+
+                                continue;
+                        }
+                }
+
+                get_lit_code(stream->hufftables, literal & 0xFF, &code, &code_len);
+                write_bits(&state->bitbuf, code, code_len);
+                next_in++;
+        }
+
+        update_state(stream, start_in, next_in, end_in);
+
+        assert(stream->avail_in <= ISAL_LOOK_AHEAD);
+        if (stream->end_of_stream || stream->flush != NO_FLUSH)
+                state->state = ZSTATE_FLUSH_READ_BUFFER;
+
+        return;
+}
+
+void
+isal_deflate_finish_rvv(struct isal_zstream *stream)
+{
+        uint32_t literal = 0, hash;
+        uint8_t *start_in, *next_in, *end_in, *end, *next_hash;
+        uint32_t match_length;
+        uint32_t dist;
+        uint64_t code, code2;
+        uint32_t code_len, code_len2;
+        struct isal_zstate *state = &stream->internal_state;
+        uint16_t *last_seen = state->head;
+        uint8_t *file_start = (uint8_t *) ((uintptr_t) stream->next_in - stream->total_in);
+        uint32_t hist_size = state->dist_mask;
+        uint32_t hash_mask = state->hash_mask;
+
+        set_buf(&state->bitbuf, stream->next_out, stream->avail_out);
+
+        start_in = stream->next_in;
+        end_in = start_in + stream->avail_in;
+        next_in = start_in;
+
+        if (stream->avail_in != 0) {
+                while (next_in + 3 < end_in) {
+                        if (is_full(&state->bitbuf)) {
+                                update_state(stream, start_in, next_in, end_in);
+                                return;
+                        }
+
+                        literal = load_le_u32(next_in);
+                        hash = compute_hash(literal) & hash_mask;
+                        dist = (next_in - file_start - last_seen[hash]) & 0xFFFF;
+                        last_seen[hash] = (uint16_t) (next_in - file_start);
+
+                        if (dist - 1 < hist_size) {
+                                /* RVV-accelerated longest-common-prefix match. */
+                                match_length = compare258_rvv(next_in - dist, next_in,
+                                                              (uint32_t) (end_in - next_in));
+
+                                if (match_length >= SHORTEST_MATCH) {
+                                        next_hash = next_in;
+#ifdef ISAL_LIMIT_HASH_UPDATE
+                                        end = next_hash + 3;
+#else
+                                        end = next_hash + match_length;
+#endif
+                                        next_hash++;
+
+                                        for (; next_hash < end - 3; next_hash++) {
+                                                literal = load_le_u32(next_hash);
+                                                hash = compute_hash(literal) & hash_mask;
+                                                last_seen[hash] =
+                                                        (uint16_t) (next_hash - file_start);
+                                        }
+
+                                        get_len_code(stream->hufftables, match_length, &code,
+                                                     &code_len);
+                                        get_dist_code(stream->hufftables, dist, &code2, &code_len2);
+
+                                        code |= code2 << code_len;
+                                        code_len += code_len2;
+
+                                        write_bits(&state->bitbuf, code, code_len);
+
+                                        next_in += match_length;
+
+                                        continue;
+                                }
+                        }
+
+                        get_lit_code(stream->hufftables, literal & 0xFF, &code, &code_len);
+                        write_bits(&state->bitbuf, code, code_len);
+                        next_in++;
+                }
+
+                while (next_in < end_in) {
+                        if (is_full(&state->bitbuf)) {
+                                update_state(stream, start_in, next_in, end_in);
+                                return;
+                        }
+
+                        literal = *next_in;
+                        get_lit_code(stream->hufftables, literal & 0xFF, &code, &code_len);
+                        write_bits(&state->bitbuf, code, code_len);
+                        next_in++;
+                }
+        }
+
+        if (!is_full(&state->bitbuf)) {
+                get_lit_code(stream->hufftables, 256, &code, &code_len);
+                write_bits(&state->bitbuf, code, code_len);
+                state->has_eob = 1;
+
+                if (stream->end_of_stream == 1)
+                        state->state = ZSTATE_TRL;
+                else
+                        state->state = ZSTATE_SYNC_FLUSH;
+        }
+
+        update_state(stream, start_in, next_in, end_in);
+
+        return;
+}

--- a/igzip/riscv64/igzip_deflate_hash_rvv.S
+++ b/igzip/riscv64/igzip_deflate_hash_rvv.S
@@ -1,0 +1,98 @@
+/**********************************************************************
+  Copyright (c) 2026 ZTE Corporation.
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of ZTE Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+/*
+ * RISC-V accelerated deflate hash-table update.
+ *
+ *   void isal_deflate_hash_rvv(uint16_t *hash_table,   // a0
+ *                              uint32_t hash_mask,      // a1
+ *                              uint32_t current_index,  // a2
+ *                              uint8_t *dict,           // a3
+ *                              uint32_t dict_len);      // a4
+ */
+#if HAVE_RVV
+	.option arch, +v
+	.text
+	.align 2
+	.global isal_deflate_hash_rvv
+	.type isal_deflate_hash_rvv, @function
+isal_deflate_hash_rvv:
+	// if (dict_len < SHORTEST_MATCH=4) return
+	li	t4, 4
+	bltu	a4, t4, .Ldh_done
+
+	// n = dict_len - SHORTEST_MATCH + 1   (number of 4-byte windows)
+	addi	t0, a4, -3
+	// index = (current_index - dict_len) & 0xFFFF
+	sub	t1, a2, a4
+	slli	t1, t1, 48
+	srli	t1, t1, 48
+	// constants
+	li	t2, 0xB2D06057		// PROD (compute_hash multiplier)
+	li	t3, -1
+	srli	t3, t3, 32		// mask32 = 0xFFFFFFFF
+	li	t5, 1			// 1-byte stride for overlapping windows
+
+.Ldh_loop:
+	beqz	t0, .Ldh_done
+	// vl = vsetvli_e64m1(n); writes element count to t4
+	vsetvli	t4, t0, e64, m1, ta, ma
+
+	// load vl overlapping little-endian 4-byte windows, zero-ext to e64
+	vlse64.v	v1, (a3), t5
+	// keep only the low 32 bits (the actual window value)
+	vand.vx		v1, v1, t3
+	// hash = data * PROD
+	vmul.vx		v1, v1, t2
+	vsrl.vi		v1, v1, 16
+	// hash *= PROD  (low 64 bits == uint64_t modular truncation)
+	vmul.vx		v1, v1, t2
+	vsrl.vi		v1, v1, 16
+
+	// in-order scatter stores (lane 0 .. vl-1) -> last writer wins
+	mv	a5, t4			// remaining lanes
+.Ldh_store:
+	vmv.x.s		t6, v1			// extract lane 0 -> GPR
+	and		t6, t6, a1		// h & hash_mask
+	slli		t6, t6, 1		// byte offset (uint16_t table)
+	add		t6, t6, a0		// &hash_table[h]
+	sh		t1, (t6)		// hash_table[h] = index (low 16 bits)
+	addi		t1, t1, 1		// index++
+	vslidedown.vi	v1, v1, 1		// next lane -> position 0
+	addi		a5, a5, -1
+	bnez		a5, .Ldh_store
+
+	// advance over the vl windows just consumed
+	add		a3, a3, t4
+	sub		t0, t0, t4
+	j		.Ldh_loop
+
+.Ldh_done:
+	ret
+	.size isal_deflate_hash_rvv, .-isal_deflate_hash_rvv
+#endif
+

--- a/igzip/riscv64/igzip_icf_body_hash_hist_rvv.c
+++ b/igzip/riscv64/igzip_icf_body_hash_hist_rvv.c
@@ -1,0 +1,134 @@
+#include <stdint.h>
+#include "igzip_lib.h"
+#include "../huffman.h"
+#include "../huff_codes.h"
+#include "../encode_df.h"
+#include "../igzip_level_buf_structs.h"
+#include "unaligned.h"
+
+/* RVV longest-common-prefix match primitive (compare258_rvv.S). */
+extern uint32_t
+compare258_rvv(const uint8_t *str1, const uint8_t *str2, uint32_t max_length);
+
+static inline void
+write_deflate_icf(struct deflate_icf *icf, uint32_t lit_len, uint32_t lit_dist, uint32_t extra_bits)
+{
+        icf->lit_len = lit_len;
+        icf->lit_dist = lit_dist;
+        icf->dist_extra = extra_bits;
+}
+
+static inline void
+update_state(struct isal_zstream *stream, uint8_t *start_in, uint8_t *next_in, uint8_t *end_in,
+             struct deflate_icf *start_out, struct deflate_icf *next_out,
+             struct deflate_icf *end_out)
+{
+        struct level_buf *level_buf = (struct level_buf *) stream->level_buf;
+
+        if (next_in - start_in > 0)
+                stream->internal_state.has_hist = IGZIP_HIST;
+
+        stream->next_in = next_in;
+        stream->total_in += (uint32_t) (next_in - start_in);
+        stream->internal_state.block_end = stream->total_in;
+        stream->avail_in = (uint32_t) (end_in - next_in);
+
+        level_buf->icf_buf_next = next_out;
+        level_buf->icf_buf_avail_out = end_out - next_out;
+}
+
+void
+isal_deflate_icf_body_hash_hist_rvv(struct isal_zstream *stream)
+{
+        uint32_t literal, hash;
+        uint8_t *start_in, *next_in, *end_in, *end, *next_hash;
+        struct deflate_icf *start_out, *next_out, *end_out;
+        uint32_t match_length;
+        uint32_t dist;
+        uint32_t code, code2, extra_bits;
+        struct isal_zstate *state = &stream->internal_state;
+        struct level_buf *level_buf = (struct level_buf *) stream->level_buf;
+        uint16_t *last_seen = level_buf->hash_hist.hash_table;
+        uint8_t *file_start = (uint8_t *) ((uintptr_t) stream->next_in - stream->total_in);
+        uint32_t hist_size = state->dist_mask;
+        uint32_t hash_mask = state->hash_mask;
+
+        if (stream->avail_in == 0) {
+                if (stream->end_of_stream || stream->flush != NO_FLUSH)
+                        state->state = ZSTATE_FLUSH_READ_BUFFER;
+                return;
+        }
+
+        start_in = stream->next_in;
+        end_in = start_in + stream->avail_in;
+        next_in = start_in;
+
+        start_out = ((struct level_buf *) stream->level_buf)->icf_buf_next;
+        end_out = start_out + ((struct level_buf *) stream->level_buf)->icf_buf_avail_out /
+                                      sizeof(struct deflate_icf);
+        next_out = start_out;
+
+        while (next_in + ISAL_LOOK_AHEAD < end_in) {
+
+                if (next_out >= end_out) {
+                        state->state = ZSTATE_CREATE_HDR;
+                        update_state(stream, start_in, next_in, end_in, start_out, next_out,
+                                     end_out);
+                        return;
+                }
+
+                literal = load_le_u32(next_in);
+                hash = compute_hash(literal) & hash_mask;
+                dist = (next_in - file_start - last_seen[hash]) & 0xFFFF;
+                last_seen[hash] = (uint16_t) (next_in - file_start);
+
+                /* The -1 are to handle the case when dist = 0 */
+                if (dist - 1 < hist_size) {
+                        assert(dist != 0);
+                        /* RVV-accelerated longest-common-prefix match. */
+                        match_length = compare258_rvv(next_in - dist, next_in, 258);
+
+                        if (match_length >= SHORTEST_MATCH) {
+                                next_hash = next_in;
+#ifdef ISAL_LIMIT_HASH_UPDATE
+                                end = next_hash + 3;
+#else
+                                end = next_hash + match_length;
+#endif
+                                next_hash++;
+
+                                for (; next_hash < end; next_hash++) {
+                                        literal = load_le_u32(next_hash);
+                                        hash = compute_hash(literal) & hash_mask;
+                                        last_seen[hash] = (uint16_t) (next_hash - file_start);
+                                }
+
+                                get_len_icf_code(match_length, &code);
+                                get_dist_icf_code(dist, &code2, &extra_bits);
+
+                                level_buf->hist.ll_hist[code]++;
+                                level_buf->hist.d_hist[code2]++;
+
+                                write_deflate_icf(next_out, code, code2, extra_bits);
+                                next_out++;
+                                next_in += match_length;
+
+                                continue;
+                        }
+                }
+
+                get_lit_icf_code(literal & 0xFF, &code);
+                level_buf->hist.ll_hist[code]++;
+                write_deflate_icf(next_out, code, NULL_DIST_SYM, 0);
+                next_out++;
+                next_in++;
+        }
+
+        update_state(stream, start_in, next_in, end_in, start_out, next_out, end_out);
+
+        assert(stream->avail_in <= ISAL_LOOK_AHEAD);
+        if (stream->end_of_stream || stream->flush != NO_FLUSH)
+                state->state = ZSTATE_FLUSH_READ_BUFFER;
+
+        return;
+}

--- a/igzip/riscv64/igzip_icf_finish_hash_hist_rvv.c
+++ b/igzip/riscv64/igzip_icf_finish_hash_hist_rvv.c
@@ -1,0 +1,150 @@
+#include <stdint.h>
+#include "igzip_lib.h"
+#include "../huffman.h"
+#include "../huff_codes.h"
+#include "../encode_df.h"
+#include "../igzip_level_buf_structs.h"
+#include "unaligned.h"
+
+extern uint32_t
+compare258_rvv(const uint8_t *str1, const uint8_t *str2, uint32_t max_length);
+
+static inline void
+write_deflate_icf(struct deflate_icf *icf, uint32_t lit_len, uint32_t lit_dist, uint32_t extra_bits)
+{
+        icf->lit_len = lit_len;
+        icf->lit_dist = lit_dist;
+        icf->dist_extra = extra_bits;
+}
+
+static inline void
+update_state(struct isal_zstream *stream, uint8_t *start_in, uint8_t *next_in, uint8_t *end_in,
+             struct deflate_icf *start_out, struct deflate_icf *next_out,
+             struct deflate_icf *end_out)
+{
+        struct level_buf *level_buf = (struct level_buf *) stream->level_buf;
+
+        if (next_in - start_in > 0)
+                stream->internal_state.has_hist = IGZIP_HIST;
+
+        stream->next_in = next_in;
+        stream->total_in += (uint32_t) (next_in - start_in);
+        stream->internal_state.block_end = stream->total_in;
+        stream->avail_in = (uint32_t) (end_in - next_in);
+
+        level_buf->icf_buf_next = next_out;
+        level_buf->icf_buf_avail_out = end_out - next_out;
+}
+
+void
+isal_deflate_icf_finish_hash_hist_rvv(struct isal_zstream *stream)
+{
+        uint32_t literal = 0, hash;
+        uint8_t *start_in, *next_in, *end_in, *end, *next_hash;
+        struct deflate_icf *start_out, *next_out, *end_out;
+        uint32_t match_length;
+        uint32_t dist;
+        uint32_t code, code2, extra_bits;
+        struct isal_zstate *state = &stream->internal_state;
+        struct level_buf *level_buf = (struct level_buf *) stream->level_buf;
+        uint16_t *last_seen = level_buf->hash_hist.hash_table;
+        uint8_t *file_start = (uint8_t *) ((uintptr_t) stream->next_in - stream->total_in);
+        uint32_t hist_size = state->dist_mask;
+        uint32_t hash_mask = state->hash_mask;
+
+        start_in = stream->next_in;
+        end_in = start_in + stream->avail_in;
+        next_in = start_in;
+
+        start_out = ((struct level_buf *) stream->level_buf)->icf_buf_next;
+        end_out = start_out + ((struct level_buf *) stream->level_buf)->icf_buf_avail_out /
+                                      sizeof(struct deflate_icf);
+        next_out = start_out;
+
+        if (stream->avail_in == 0) {
+                if (stream->end_of_stream || stream->flush != NO_FLUSH)
+                        state->state = ZSTATE_CREATE_HDR;
+                return;
+        }
+
+        while (next_in + 3 < end_in) {
+                if (next_out >= end_out) {
+                        state->state = ZSTATE_CREATE_HDR;
+                        update_state(stream, start_in, next_in, end_in, start_out, next_out,
+                                     end_out);
+                        return;
+                }
+
+                literal = load_le_u32(next_in);
+                hash = compute_hash(literal) & hash_mask;
+                dist = (next_in - file_start - last_seen[hash]) & 0xFFFF;
+                last_seen[hash] = (uint16_t) (next_in - file_start);
+
+                if (dist - 1 < hist_size) { /* The -1 are to handle the case when dist = 0 */
+
+                        /* RVV-accelerated longest-common-prefix match (caps at 258). */
+                        match_length = compare258_rvv(next_in - dist, next_in,
+                                                      (uint32_t) (end_in - next_in));
+
+                        if (match_length >= SHORTEST_MATCH) {
+                                next_hash = next_in;
+#ifdef ISAL_LIMIT_HASH_UPDATE
+                                end = next_hash + 3;
+#else
+                                end = next_hash + match_length;
+#endif
+                                next_hash++;
+
+                                for (; next_hash < end - 3; next_hash++) {
+                                        literal = load_le_u32(next_hash);
+                                        hash = compute_hash(literal) & hash_mask;
+                                        last_seen[hash] = (uint16_t) (next_hash - file_start);
+                                }
+
+                                get_len_icf_code(match_length, &code);
+                                get_dist_icf_code(dist, &code2, &extra_bits);
+
+                                level_buf->hist.ll_hist[code]++;
+                                level_buf->hist.d_hist[code2]++;
+
+                                write_deflate_icf(next_out, code, code2, extra_bits);
+
+                                next_out++;
+                                next_in += match_length;
+
+                                continue;
+                        }
+                }
+
+                get_lit_icf_code(literal & 0xFF, &code);
+                level_buf->hist.ll_hist[code]++;
+                write_deflate_icf(next_out, code, NULL_DIST_SYM, 0);
+                next_out++;
+                next_in++;
+        }
+
+        while (next_in < end_in) {
+                if (next_out >= end_out) {
+                        state->state = ZSTATE_CREATE_HDR;
+                        update_state(stream, start_in, next_in, end_in, start_out, next_out,
+                                     end_out);
+                        return;
+                }
+
+                literal = *next_in;
+                get_lit_icf_code(literal & 0xFF, &code);
+                level_buf->hist.ll_hist[code]++;
+                write_deflate_icf(next_out, code, NULL_DIST_SYM, 0);
+                next_out++;
+                next_in++;
+        }
+
+        if (next_in == end_in) {
+                if (stream->end_of_stream || stream->flush != NO_FLUSH)
+                        state->state = ZSTATE_CREATE_HDR;
+        }
+
+        update_state(stream, start_in, next_in, end_in, start_out, next_out, end_out);
+
+        return;
+}

--- a/igzip/riscv64/igzip_multibinary_riscv64.S
+++ b/igzip/riscv64/igzip_multibinary_riscv64.S
@@ -38,17 +38,59 @@
 mbin_interface_base gen_icf_map_lh1, gen_icf_map_h1_base
 mbin_interface_base decode_huffman_code_block_stateless, decode_huffman_code_block_stateless_base
 mbin_interface_base isal_deflate_icf_finish_lvl3, isal_deflate_icf_finish_hash_map_base
+#if HAVE_RVV
+    mbin_interface	isal_deflate_hash_lvl3
+    mbin_interface	isal_deflate_hash_lvl1
+#else
 mbin_interface_base isal_deflate_hash_lvl3, isal_deflate_hash_base
 mbin_interface_base isal_deflate_hash_lvl1, isal_deflate_hash_base
+#endif
+#if HAVE_RVV
+    mbin_interface	isal_deflate_icf_body_lvl2
+#else
 mbin_interface_base isal_deflate_icf_body_lvl2, isal_deflate_icf_body_hash_hist_base
-mbin_interface_base isal_deflate_icf_finish_lvl1, isal_deflate_icf_finish_hash_hist_base
-mbin_interface_base isal_deflate_finish, isal_deflate_finish_base
-mbin_interface_base isal_deflate_body, isal_deflate_body_base
-mbin_interface_base isal_deflate_hash_lvl2, isal_deflate_hash_base
+#endif
+#if HAVE_RVV
+    mbin_interface	isal_deflate_icf_finish_lvl1
+#else
+    mbin_interface_base isal_deflate_icf_finish_lvl1, isal_deflate_icf_finish_hash_hist_base
+#endif
+#if HAVE_RVV
+    mbin_interface	isal_deflate_finish
+#else
+    mbin_interface_base isal_deflate_finish, isal_deflate_finish_base
+#endif
+#if HAVE_RVV
+    mbin_interface	isal_deflate_body
+#else
+    mbin_interface_base isal_deflate_body, isal_deflate_body_base
+#endif
+#if HAVE_RVV
+    mbin_interface	isal_deflate_hash_lvl2
+    mbin_interface	isal_deflate_hash_lvl0
+#else
+    mbin_interface_base isal_deflate_hash_lvl2, isal_deflate_hash_base
+    mbin_interface_base isal_deflate_hash_lvl0, isal_deflate_hash_base
+#endif
 mbin_interface_base encode_deflate_icf, encode_deflate_icf_base
-mbin_interface_base set_long_icf_fg, set_long_icf_fg_base
+#if HAVE_RVV
+    mbin_interface	set_long_icf_fg
+#else
+    mbin_interface_base set_long_icf_fg, set_long_icf_fg_base
+#endif
 mbin_interface_base isal_deflate_icf_body_lvl3, icf_body_hash1_fillgreedy_lazy
-mbin_interface_base isal_deflate_icf_body_lvl1, isal_deflate_icf_body_hash_hist_base
-mbin_interface_base isal_deflate_hash_lvl0, isal_deflate_hash_base
-mbin_interface_base isal_deflate_icf_finish_lvl2, isal_deflate_icf_finish_hash_hist_base
-mbin_interface_base isal_update_histogram, isal_update_histogram_base
+#if HAVE_RVV
+    mbin_interface	isal_deflate_icf_body_lvl1
+#else
+    mbin_interface_base isal_deflate_icf_body_lvl1, isal_deflate_icf_body_hash_hist_base
+#endif
+#if HAVE_RVV
+    mbin_interface	isal_deflate_icf_finish_lvl2
+#else
+    mbin_interface_base isal_deflate_icf_finish_lvl2, isal_deflate_icf_finish_hash_hist_base
+#endif
+#if HAVE_RVV
+    mbin_interface	isal_update_histogram
+#else
+    mbin_interface_base isal_update_histogram, isal_update_histogram_base
+#endif

--- a/igzip/riscv64/igzip_multibinary_riscv64_dispatcher.c
+++ b/igzip/riscv64/igzip_multibinary_riscv64_dispatcher.c
@@ -35,6 +35,90 @@ adler32_rvv128(uint32_t, uint8_t *, uint64_t);
 extern uint32_t
 adler32_base(uint32_t, uint8_t *, uint64_t);
 
+extern void
+isal_deflate_hash_rvv(uint16_t *, uint32_t, uint32_t, uint8_t *, uint32_t);
+extern void
+isal_deflate_hash_base(uint16_t *, uint32_t, uint32_t, uint8_t *, uint32_t);
+
+struct isal_zstream;
+extern void
+isal_deflate_icf_body_hash_hist_rvv(struct isal_zstream *);
+extern void
+isal_deflate_icf_body_hash_hist_base(struct isal_zstream *);
+
+extern void
+isal_deflate_icf_finish_hash_hist_rvv(struct isal_zstream *);
+extern void
+isal_deflate_icf_finish_hash_hist_base(struct isal_zstream *);
+
+extern void
+isal_deflate_body_rvv(struct isal_zstream *);
+extern void
+isal_deflate_body_base(struct isal_zstream *);
+extern void
+isal_deflate_finish_rvv(struct isal_zstream *);
+extern void
+isal_deflate_finish_base(struct isal_zstream *);
+
+struct isal_huff_histogram;
+extern void
+isal_update_histogram_rvv(uint8_t *, int, struct isal_huff_histogram *);
+extern void
+isal_update_histogram_base(uint8_t *, int, struct isal_huff_histogram *);
+
+struct deflate_icf;
+extern void
+set_long_icf_fg_rvv(uint8_t *, uint64_t, uint64_t, struct deflate_icf *);
+extern void
+set_long_icf_fg_base(uint8_t *, uint64_t, uint64_t, struct deflate_icf *);
+
+/*
+ * isal_deflate_hash_rvv loads overlapping windows with a stride-1 vlse64.v,
+ * i.e. misaligned vector element accesses. Cores without misaligned vector
+ * support (e.g. SpacemiT K1) raise SIGBUS/BUS_ADRALN and the kernel does not
+ * emulate vector misaligned accesses, so that implementation may only run
+ * where the cpu reports working misaligned vector accesses. The dedicated
+ * hwprobe key for that is RISCV_HWPROBE_KEY_MISALIGNED_VECTOR_PERF.
+ * Kernels lacking this key leave value == -1, which must read as "missing"
+ * so we stay on the base path.
+ */
+#if HAVE_SYS_HWPROBE_H || HAVE_ASM_HWPROBE_H
+#ifndef RISCV_HWPROBE_KEY_MISALIGNED_VECTOR_PERF
+#define RISCV_HWPROBE_KEY_MISALIGNED_VECTOR_PERF 10
+#endif
+#ifndef RISCV_HWPROBE_MISALIGNED_VECTOR_UNKNOWN
+#define RISCV_HWPROBE_MISALIGNED_VECTOR_UNKNOWN 0
+#endif
+#ifndef RISCV_HWPROBE_MISALIGNED_VECTOR_SLOW
+#define RISCV_HWPROBE_MISALIGNED_VECTOR_SLOW 2
+#endif
+#ifndef RISCV_HWPROBE_MISALIGNED_VECTOR_FAST
+#define RISCV_HWPROBE_MISALIGNED_VECTOR_FAST 3
+#endif
+#ifndef RISCV_HWPROBE_MISALIGNED_VECTOR_UNSUPPORTED
+#define RISCV_HWPROBE_MISALIGNED_VECTOR_UNSUPPORTED 4
+#endif
+
+static int
+misaligned_vector_ok(void)
+{
+        struct riscv_hwprobe pair = { .key = RISCV_HWPROBE_KEY_MISALIGNED_VECTOR_PERF };
+
+        if (__riscv_hwprobe(&pair, 1, 0, NULL, 0) != 0 || pair.value == -1)
+                return 0;
+        /* SLOW may be kernel-emulated: correct, though not necessarily fast. */
+        return pair.value == RISCV_HWPROBE_MISALIGNED_VECTOR_SLOW ||
+               pair.value == RISCV_HWPROBE_MISALIGNED_VECTOR_FAST;
+}
+#else
+/* No hwprobe headers: cannot prove misaligned vector support, stay on base. */
+static int
+misaligned_vector_ok(void)
+{
+        return 0;
+}
+#endif
+
 DEFINE_INTERFACE_DISPATCHER(isal_adler32)
 {
 #if HAVE_RVV
@@ -49,4 +133,106 @@ DEFINE_INTERFACE_DISPATCHER(isal_adler32)
         } else
 #endif
                 return adler32_base;
+}
+
+DEFINE_INTERFACE_DISPATCHER(isal_deflate_hash_lvl0)
+{
+#if HAVE_RVV
+        if (getauxval(AT_HWCAP) & HWCAP_RV('V') && misaligned_vector_ok())
+                return isal_deflate_hash_rvv;
+#endif
+        return isal_deflate_hash_base;
+}
+DEFINE_INTERFACE_DISPATCHER(isal_deflate_hash_lvl1)
+{
+#if HAVE_RVV
+        if (getauxval(AT_HWCAP) & HWCAP_RV('V') && misaligned_vector_ok())
+                return isal_deflate_hash_rvv;
+#endif
+        return isal_deflate_hash_base;
+}
+DEFINE_INTERFACE_DISPATCHER(isal_deflate_hash_lvl2)
+{
+#if HAVE_RVV
+        if (getauxval(AT_HWCAP) & HWCAP_RV('V') && misaligned_vector_ok())
+                return isal_deflate_hash_rvv;
+#endif
+        return isal_deflate_hash_base;
+}
+DEFINE_INTERFACE_DISPATCHER(isal_deflate_hash_lvl3)
+{
+#if HAVE_RVV
+        if (getauxval(AT_HWCAP) & HWCAP_RV('V') && misaligned_vector_ok())
+                return isal_deflate_hash_rvv;
+#endif
+        return isal_deflate_hash_base;
+}
+
+DEFINE_INTERFACE_DISPATCHER(isal_deflate_icf_body_lvl1)
+{
+#if HAVE_RVV
+        if (getauxval(AT_HWCAP) & HWCAP_RV('V'))
+                return isal_deflate_icf_body_hash_hist_rvv;
+#endif
+        return isal_deflate_icf_body_hash_hist_base;
+}
+DEFINE_INTERFACE_DISPATCHER(isal_deflate_icf_body_lvl2)
+{
+#if HAVE_RVV
+        if (getauxval(AT_HWCAP) & HWCAP_RV('V'))
+                return isal_deflate_icf_body_hash_hist_rvv;
+#endif
+        return isal_deflate_icf_body_hash_hist_base;
+}
+
+DEFINE_INTERFACE_DISPATCHER(isal_deflate_icf_finish_lvl1)
+{
+#if HAVE_RVV
+        if (getauxval(AT_HWCAP) & HWCAP_RV('V'))
+                return isal_deflate_icf_finish_hash_hist_rvv;
+#endif
+        return isal_deflate_icf_finish_hash_hist_base;
+}
+DEFINE_INTERFACE_DISPATCHER(isal_deflate_icf_finish_lvl2)
+{
+#if HAVE_RVV
+        if (getauxval(AT_HWCAP) & HWCAP_RV('V'))
+                return isal_deflate_icf_finish_hash_hist_rvv;
+#endif
+        return isal_deflate_icf_finish_hash_hist_base;
+}
+
+DEFINE_INTERFACE_DISPATCHER(isal_deflate_body)
+{
+#if HAVE_RVV
+        if (getauxval(AT_HWCAP) & HWCAP_RV('V'))
+                return isal_deflate_body_rvv;
+#endif
+        return isal_deflate_body_base;
+}
+DEFINE_INTERFACE_DISPATCHER(isal_deflate_finish)
+{
+#if HAVE_RVV
+        if (getauxval(AT_HWCAP) & HWCAP_RV('V'))
+                return isal_deflate_finish_rvv;
+#endif
+        return isal_deflate_finish_base;
+}
+
+DEFINE_INTERFACE_DISPATCHER(isal_update_histogram)
+{
+#if HAVE_RVV
+        if (getauxval(AT_HWCAP) & HWCAP_RV('V'))
+                return isal_update_histogram_rvv;
+#endif
+        return isal_update_histogram_base;
+}
+
+DEFINE_INTERFACE_DISPATCHER(set_long_icf_fg)
+{
+#if HAVE_RVV
+        if (getauxval(AT_HWCAP) & HWCAP_RV('V'))
+                return set_long_icf_fg_rvv;
+#endif
+        return set_long_icf_fg_base;
 }

--- a/igzip/riscv64/igzip_set_long_icf_fg_rvv.c
+++ b/igzip/riscv64/igzip_set_long_icf_fg_rvv.c
@@ -1,0 +1,62 @@
+#include <stdint.h>
+#include "igzip_lib.h"
+#include "../huffman.h"
+#include "../huff_codes.h"
+#include "../encode_df.h"
+#include "../igzip_level_buf_structs.h"
+#include "unaligned.h"
+
+extern uint32_t
+compare_rvv(const uint8_t *str1, const uint8_t *str2, uint32_t max_length);
+
+/* Replicated verbatim from igzip_icf_body.c (static inline there). */
+static inline void
+write_deflate_icf(struct deflate_icf *icf, uint32_t lit_len, uint32_t lit_dist, uint32_t extra_bits)
+{
+        store_native_u32((uint8_t *) icf,
+                         lit_len | (lit_dist << LIT_LEN_BIT_COUNT) |
+                                 (extra_bits << (LIT_LEN_BIT_COUNT + DIST_LIT_BIT_COUNT)));
+}
+
+void
+set_long_icf_fg_rvv(uint8_t *next_in, uint64_t processed, uint64_t input_size,
+                    struct deflate_icf *match_lookup)
+{
+        uint8_t *end_processed = next_in + processed;
+        uint8_t *end_in = next_in + input_size;
+        uint32_t dist_code, dist_extra, dist, len;
+        uint32_t match_len;
+        uint32_t dist_start[] = { 0x0001, 0x0002, 0x0003, 0x0004, 0x0005, 0x0007, 0x0009, 0x000d,
+                                  0x0011, 0x0019, 0x0021, 0x0031, 0x0041, 0x0061, 0x0081, 0x00c1,
+                                  0x0101, 0x0181, 0x0201, 0x0301, 0x0401, 0x0601, 0x0801, 0x0c01,
+                                  0x1001, 0x1801, 0x2001, 0x3001, 0x4001, 0x6001, 0x0000, 0x0000 };
+
+        if (end_in > end_processed + ISAL_LOOK_AHEAD)
+                end_in = end_processed + ISAL_LOOK_AHEAD;
+
+        while (next_in < end_processed) {
+                dist_code = match_lookup->lit_dist;
+                dist_extra = match_lookup->dist_extra;
+                dist = dist_start[dist_code] + dist_extra;
+                len = match_lookup->lit_len;
+                if (len >= 8 + LEN_OFFSET) {
+                        /* RVV-accelerated longest-common-prefix match (uncapped). */
+                        match_len = compare_rvv((next_in + 8) - dist, next_in + 8,
+                                                (uint32_t) (end_in - (next_in + 8))) +
+                                    LEN_OFFSET + 8;
+
+                        while (match_len > match_lookup->lit_len &&
+                               match_len >= LEN_OFFSET + SHORTEST_MATCH) {
+                                write_deflate_icf(match_lookup,
+                                                  match_len > LEN_MAX ? LEN_MAX : match_len,
+                                                  dist_code, dist_extra);
+                                match_lookup++;
+                                next_in++;
+                                match_len--;
+                        }
+                }
+
+                match_lookup++;
+                next_in++;
+        }
+}

--- a/igzip/riscv64/igzip_update_histogram_rvv.c
+++ b/igzip/riscv64/igzip_update_histogram_rvv.c
@@ -1,0 +1,131 @@
+/**********************************************************************
+  Copyright(c) 2011-2016 Intel Corporation All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+    * Neither the name of Intel Corporation nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**********************************************************************/
+#include <stdint.h>
+#include <string.h>
+#include "igzip_lib.h"
+#include "../huffman.h"
+#include "../huff_codes.h"
+#include "unaligned.h"
+
+extern uint32_t
+compare258_rvv(const uint8_t *str1, const uint8_t *str2, uint32_t max_length);
+
+/* Replicated verbatim from huff_codes.c (static there). */
+static inline uint32_t
+convert_dist_to_dist_sym(uint32_t dist)
+{
+        assert(dist <= 32768 && dist > 0);
+        if (dist <= 32768) {
+                uint32_t msb = dist > 4 ? bsr(dist - 1) - 2 : 0;
+                return (msb * 2) + ((dist - 1) >> msb);
+        } else {
+                return ~0;
+        }
+}
+
+static inline uint32_t
+convert_length_to_len_sym(uint32_t length)
+{
+        assert(length > 2 && length < 259);
+
+        /* Based on tables on page 11 in RFC 1951 */
+        if (length < 11)
+                return 257 + length - 3;
+        else if (length < 19)
+                return 261 + (length - 3) / 2;
+        else if (length < 35)
+                return 265 + (length - 3) / 4;
+        else if (length < 67)
+                return 269 + (length - 3) / 8;
+        else if (length < 131)
+                return 273 + (length - 3) / 16;
+        else if (length < 258)
+                return 277 + (length - 3) / 32;
+        else
+                return 285;
+}
+
+void
+isal_update_histogram_rvv(uint8_t *start_stream, int length, struct isal_huff_histogram *histogram)
+{
+        uint32_t literal = 0, hash;
+        uint16_t seen, *last_seen = histogram->hash_table;
+        uint8_t *current, *end_stream, *next_hash, *end;
+        uint32_t match_length;
+        uint32_t dist;
+        uint64_t *lit_len_histogram = histogram->lit_len_histogram;
+        uint64_t *dist_histogram = histogram->dist_histogram;
+
+        if (length <= 0)
+                return;
+
+        end_stream = start_stream + length;
+        memset(last_seen, 0, sizeof(histogram->hash_table)); /* Initialize last_seen to be 0. */
+        for (current = start_stream; current < end_stream - 3; current++) {
+                literal = load_le_u32(current);
+                hash = compute_hash(literal) & LVL0_HASH_MASK;
+                seen = last_seen[hash];
+                last_seen[hash] = (current - start_stream) & 0xFFFF;
+                dist = (current - start_stream - seen) & 0xFFFF;
+                if (dist - 1 < D - 1) {
+                        assert(start_stream <= current - dist);
+                        /* RVV-accelerated longest-common-prefix match. */
+                        match_length = compare258_rvv(current - dist, current,
+                                                      (uint32_t) (end_stream - current));
+                        if (match_length >= SHORTEST_MATCH) {
+                                next_hash = current;
+#ifdef ISAL_LIMIT_HASH_UPDATE
+                                end = next_hash + 3;
+#else
+                                end = next_hash + match_length;
+#endif
+                                if (end > end_stream - 3)
+                                        end = end_stream - 3;
+                                next_hash++;
+                                for (; next_hash < end; next_hash++) {
+                                        literal = load_le_u32(next_hash);
+                                        hash = compute_hash(literal) & LVL0_HASH_MASK;
+                                        last_seen[hash] = (next_hash - start_stream) & 0xFFFF;
+                                }
+
+                                dist_histogram[convert_dist_to_dist_sym(dist)] += 1;
+                                lit_len_histogram[convert_length_to_len_sym(match_length)] += 1;
+                                current += match_length - 1;
+                                continue;
+                        }
+                }
+                lit_len_histogram[literal & 0xFF] += 1;
+        }
+
+        for (; current < end_stream; current++)
+                lit_len_histogram[*current] += 1;
+
+        lit_len_histogram[256] += 1;
+        return;
+}


### PR DESCRIPTION

The hot functions in the three parts—icf_body, deflate_body, and update_histogram—are centered around compare258. By implementing a reusable vectorized assembly version of compare258 (i.e., compare258_rvv) using RISC-V vector extensions, while keeping the original C control flow in the outer layers, we can improve deflate performance.

This optimization has been validated with igzip_perf on the Spacemit(R) X100 platform:

igzip_perf -f 0 -y 0 -b 1024 silesia.tar (6% performance improvement) 
new：isal_stateful_deflate-> runtime = 4342565 usecs, bandwidth 423 MB in 4.3426 sec = 97.62 MB/s 
old：isal_stateful_deflate-> runtime = 4616307 usecs, bandwidth 423 MB in 4.6163 sec = 91.83 MB/s

igzip_perf -f 0 -y 1 -b 1024 silesia.tar (9% performance improvement) 
new：isal_stateful_deflate-> runtime = 3975344 usecs, bandwidth 423 MB in 3.9753 sec = 106.64 MB/s 
old：isal_stateful_deflate-> runtime = 4322878 usecs, bandwidth 423 MB in 4.3229 sec = 98.06 MB/s

igzip_perf -f 1 -y 0 -b 1024 silesia.tar (10% performance improvement) 
new：isal_stateful_deflate-> runtime = 4233799 usecs, bandwidth 423 MB in 4.2338 sec = 100.13 MB/s 
old：isal_stateful_deflate-> runtime = 4656209 usecs, bandwidth 423 MB in 4.6562 sec = 91.04 MB/s

igzip_perf -f 1 -y 1 -b 1024 silesia.tar (6% performance improvement) 
new：isal_stateful_deflate-> runtime = 5723116 usecs, bandwidth 211 MB in 5.7231 sec = 37.04 MB/s 
old：isal_stateful_deflate-> runtime = 6045445 usecs, bandwidth 211 MB in 6.0454 sec = 35.06 MB/s

All tests successful：
PASS: igzip/igzip_rand_test