### PR TITLE
igzip/aarch64: optimize deflate level 3 performance

### DIFF
--- a/igzip/aarch64/igzip_multibinary_aarch64_dispatcher.c
+++ b/igzip/aarch64/igzip_multibinary_aarch64_dispatcher.c
@@ -56,6 +56,8 @@ extern void
 isal_deflate_icf_finish_hash_hist_base(struct isal_zstream *);
 
 extern void
+icf_body_lazyhash1_fillgreedy_greedy(struct isal_zstream *);
+extern void
 icf_body_hash1_fillgreedy_lazy(struct isal_zstream *);
 
 extern void
@@ -184,10 +186,10 @@ DEFINE_INTERFACE_DISPATCHER(isal_deflate_icf_body_lvl3)
 #if defined(__linux__)
         unsigned long auxval = getauxval(AT_HWCAP);
         if (auxval & HWCAP_CRC32)
-                return icf_body_hash1_fillgreedy_lazy;
+                return icf_body_lazyhash1_fillgreedy_greedy;
 #elif defined(__APPLE__)
         if (sysctlEnabled(SYSCTL_CRC32_KEY))
-                return icf_body_hash1_fillgreedy_lazy;
+                return icf_body_lazyhash1_fillgreedy_greedy;
 #endif
         return icf_body_hash1_fillgreedy_lazy;
 }


### PR DESCRIPTION
The aarch64 platform provides an assembly-optimized implementation of gen_icf_map_h1_aarch64. However, this optimized path was not correctly enabled for deflate compression level 3. After correcting the invocation logic, deflate throughput increased by 11%.

This optimization has been validated with igzip_perf on the ZXIC(R) ZhuFengXin Processor platform：
 ./igzip/igzip_perf -f 3 -y 0 -b 1024 silesia.tar  (11% performance improvement) 
new：
  file info-> name: silesia.tar file_size: 211957760 compress_size: 75671749 ratio: 35.70%
    isal_stateful_deflate->  runtime =    3623708 usecs, bandwidth 423 MB in 3.6237 sec = 116.98 MB/s
old：
  file info-> name: silesia.tar file_size: 211957760 compress_size: 75699582 ratio: 35.71%
    isal_stateful_deflate->  runtime =    4029556 usecs, bandwidth 423 MB in 4.0296 sec = 105.20 MB/s

All tests successful：
PASS: igzip/igzip_rand_test